### PR TITLE
chore: sync docs after admin branch protection enforcement

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -21,7 +21,6 @@ The hosted minimum-slice backend seam is live and the thin Expo mobile seam now 
 - Source of truth repo: `gzug/One-L1fe`
 - Current blockers:
   - mobile auth still uses environment placeholders instead of a real app session source
-  - CI enforcement wording needs to stay aligned with actual GitHub behavior and bypass settings
 - Key confirmed facts:
   - hosted migrations match repo
   - RLS and policies are live
@@ -35,11 +34,10 @@ The hosted minimum-slice backend seam is live and the thin Expo mobile seam now 
 The next best steps are, in order:
 1. wire a real app auth session into `apps/mobile/minimumSliceScreenController.ts` and validate one authenticated Expo submission against the hosted endpoint,
 2. decide whether the next thin app seam is a dedicated hook extraction or a second screen around the same controller,
-3. tighten CI wording and behavior so repo truth matches actual GitHub enforcement and bypass rules,
-4. activate `supabase db lint` as the next CI check,
-5. add boot/reset CI validation (`supabase start` + `supabase db reset`) after lint is stable,
-6. add drift detection CI only after boot/reset is stable,
-7. merge or close PR #1 cleanly.
+3. activate `supabase db lint` as the next CI check,
+4. add boot/reset CI validation (`supabase start` + `supabase db reset`) after lint is stable,
+5. add drift detection CI only after boot/reset is stable,
+6. merge or close PR #1 cleanly.
 
 ## Startup rule
 

--- a/checkpoint.yaml
+++ b/checkpoint.yaml
@@ -9,7 +9,6 @@ next_best_steps:
   - choose the next thin mobile seam after the first hosted path is confirmed
 active_blockers:
   - mobile auth still uses environment placeholders instead of a real app session source
-  - CI wording and GitHub bypass behavior need to stay aligned with actual enforcement
 startup_truth:
   - CHECKPOINT.md
   - README.md only for broad orientation

--- a/docs/planning/github-hardening-checklist.md
+++ b/docs/planning/github-hardening-checklist.md
@@ -18,11 +18,9 @@ Verified on GitHub as of 2026-04-13:
 - branch protection on `main` exists
 - force pushes to `main` are blocked
 - required check `validate` is configured
+- admins are also subject to branch protection
 - `SUPABASE_ACCESS_TOKEN` exists
 - `SUPABASE_PROJECT_REF` exists
-
-Important caveat:
-- bypass paths still matter in practice, so repo wording should not overclaim stricter enforcement than GitHub is actually applying
 
 ## Recommended now
 


### PR DESCRIPTION
## Summary
- remove outdated CI bypass blocker wording from CHECKPOINT.md
- align checkpoint.yaml with live branch protection state
- update GitHub hardening checklist after enabling admin enforcement

## Why
Branch protection now applies to admins as well, so the repo truth should match the live GitHub configuration.
