### PR TITLE
docs(mobile): align env example with real auth seam

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,4 +1,4 @@
-EXPO_PUBLIC_ONE_L1FE_ACCESS_TOKEN=replace-with-a-real-access-token
-EXPO_PUBLIC_ONE_L1FE_PROFILE_ID=replace-with-a-real-user-id
 EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL=https://lbqgjourpsodqglputkj.supabase.co
+EXPO_PUBLIC_ONE_L1FE_SUPABASE_ANON_KEY=replace-with-a-real-supabase-anon-key
+# Optional: override the default hosted function path
 EXPO_PUBLIC_ONE_L1FE_FUNCTION_PATH=save-minimum-slice-interpretation


### PR DESCRIPTION
## Verdict
Keep the mobile env example aligned with the now-merged real Supabase auth seam.

## Change
- remove old placeholder auth vars (`EXPO_PUBLIC_ONE_L1FE_ACCESS_TOKEN`, `EXPO_PUBLIC_ONE_L1FE_PROFILE_ID`)
- add `EXPO_PUBLIC_ONE_L1FE_SUPABASE_ANON_KEY`
- keep the optional function-path override documented

## Why
The current `apps/mobile/.env.example` still points to the pre-login placeholder flow and will mislead the next real Expo submit.
