### PR TITLE
chore: fix .env.example — remove stale vars, add ANON_KEY

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,4 +1,3 @@
-EXPO_PUBLIC_ONE_L1FE_ACCESS_TOKEN=replace-with-a-real-access-token
-EXPO_PUBLIC_ONE_L1FE_PROFILE_ID=replace-with-a-real-user-id
 EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL=https://lbqgjourpsodqglputkj.supabase.co
+EXPO_PUBLIC_ONE_L1FE_SUPABASE_ANON_KEY=replace-with-your-anon-key
 EXPO_PUBLIC_ONE_L1FE_FUNCTION_PATH=save-minimum-slice-interpretation


### PR DESCRIPTION
## Summary
Fix `.env.example` to match the current auth implementation.

- Removed `EXPO_PUBLIC_ONE_L1FE_ACCESS_TOKEN` — no longer used (replaced by Supabase session)
- Removed `EXPO_PUBLIC_ONE_L1FE_PROFILE_ID` — no longer used (profileId now comes from auth session)
- Added `EXPO_PUBLIC_ONE_L1FE_SUPABASE_ANON_KEY` — required by `mobileSupabaseAuth.ts`
- Kept `EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL` and `EXPO_PUBLIC_ONE_L1FE_FUNCTION_PATH`

## Scope
- [x] repo hygiene / tooling

## Checks
- [x] no logic changed, only example env file
- [x] docs updated (this is the doc)