### PR TITLE
fix(mobile): use dot notation for Expo env vars in mobileSupabaseAuth.ts

### DIFF
--- a/apps/mobile/mobileSupabaseAuth.ts
+++ b/apps/mobile/mobileSupabaseAuth.ts
@@ -9,8 +9,8 @@ let _client: SupabaseClient | undefined;
 export function getMobileSupabaseClient(): SupabaseClient {
   if (_client !== undefined) return _client;
 
-  const url = process.env['EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL'];
-  const anonKey = process.env['EXPO_PUBLIC_ONE_L1FE_SUPABASE_ANON_KEY'];
+    const url = process.env.EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL;
+    const anonKey = process.env.EXPO_PUBLIC_ONE_L1FE_SUPABASE_ANON_KEY;
 
   if (!url || !anonKey) {
     throw new Error(


### PR DESCRIPTION
## Summary
Fix Expo Metro Bundler env var access in `mobileSupabaseAuth.ts`.

Expo statically replaces `process.env.VAR_NAME` at build time, but NOT `process.env['VAR_NAME']` (bracket notation). This fix ensures the Supabase URL and anon key are correctly injected by the bundler.

- Before: `process.env['EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL']` — broken in Expo bundle
- After: `process.env.EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL` — correctly resolved

## Scope
- [x] repo hygiene / tooling

## Checks
- [x] no logic changed, only env access syntax
- [x] typecheck still passes (dot notation is valid TS)