### PR TITLE
feat(mobile): extract MinimumSliceScreen.tsx from App.tsx

### DIFF
--- a/apps/mobile/MinimumSliceScreen.tsx
+++ b/apps/mobile/MinimumSliceScreen.tsx
@@ -1,0 +1,247 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { MinimumSliceScreenModel } from './minimumSliceScreenModel.ts';
+import { MinimumSliceScreenController } from './minimumSliceScreenController.ts';
+
+const FIELD_ORDER = [
+  { key: 'panelId', label: 'Panel ID', keyboardType: 'default' },
+  { key: 'collectedAt', label: 'Collected at (ISO)', keyboardType: 'default' },
+  { key: 'apob', label: 'ApoB', keyboardType: 'numeric' },
+  { key: 'ldl', label: 'LDL-C', keyboardType: 'numeric' },
+  { key: 'hba1c', label: 'HbA1c', keyboardType: 'numeric' },
+  { key: 'glucose', label: 'Glucose', keyboardType: 'numeric' },
+  { key: 'lpa', label: 'Lp(a)', keyboardType: 'numeric' },
+  { key: 'crp', label: 'CRP', keyboardType: 'numeric' },
+  { key: 'source', label: 'Source', keyboardType: 'default' },
+] as const;
+
+type FieldKey = (typeof FIELD_ORDER)[number]['key'];
+
+function renderTopDrivers(state: MinimumSliceScreenModel): string {
+  const topDrivers = state.submissionSummary.lastResultSummary?.topDrivers;
+  return topDrivers !== undefined && topDrivers.length > 0
+    ? topDrivers.join(', ')
+    : 'none';
+}
+
+interface MinimumSliceScreenProps {
+  controller: MinimumSliceScreenController;
+}
+
+export default function MinimumSliceScreen({
+  controller,
+}: MinimumSliceScreenProps): React.JSX.Element {
+  const [screenState, setScreenState] = useState<MinimumSliceScreenModel>(
+    () => controller.reset(),
+  );
+  const [localError, setLocalError] = useState<string | undefined>();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const helperText = useMemo(() => {
+    return [
+      `Status: ${screenState.submissionSummary.status}`,
+      `Coverage: ${screenState.submissionSummary.lastResultSummary?.coverageState ?? 'n/a'}`,
+      `Interpretation run: ${screenState.submissionSummary.lastResultSummary?.interpretationRunId ?? 'n/a'}`,
+      `Entries: ${screenState.submissionSummary.lastResultSummary?.interpretedEntryCount ?? 'n/a'}`,
+      `Recommendations: ${screenState.submissionSummary.lastResultSummary?.recommendationCount ?? 'n/a'}`,
+      `Top drivers: ${renderTopDrivers(screenState)}`,
+    ].join('\n');
+  }, [screenState]);
+
+  const handleSubmit = useCallback(async (): Promise<void> => {
+    setIsSubmitting(true);
+    setLocalError(undefined);
+    try {
+      const nextState = await controller.submit();
+      setScreenState(nextState);
+    } catch (error) {
+      setLocalError(
+        error instanceof Error ? error.message : 'Unknown submission error',
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [controller]);
+
+  const handleReset = useCallback((): void => {
+    setLocalError(undefined);
+    setScreenState(controller.reset());
+  }, [controller]);
+
+  const handleChange = useCallback(
+    (field: FieldKey, value: string): void => {
+      const nextState = controller.patchDraft({ [field]: value });
+      setScreenState(nextState);
+    },
+    [controller],
+  );
+
+  return (
+    <ScrollView
+      style={styles.scrollView}
+      contentContainerStyle={styles.container}
+    >
+      <View style={styles.header}>
+        <Text style={styles.eyebrow}>One L1fe</Text>
+        <Text style={styles.title}>Minimum-slice</Text>
+        <Text style={styles.subtitle}>
+          Thin Expo screen, shared domain contract, hosted Supabase function.
+        </Text>
+      </View>
+
+      <View style={styles.card}>
+        {FIELD_ORDER.map((field) => (
+          <View key={field.key} style={styles.fieldGroup}>
+            <Text style={styles.label}>{field.label}</Text>
+            <TextInput
+              keyboardType={field.keyboardType as any}
+              onChangeText={(value) => handleChange(field.key, value)}
+              style={styles.input}
+              value={screenState.draft[field.key]}
+            />
+          </View>
+        ))}
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>Submission summary</Text>
+        <Text style={styles.summary}>{helperText}</Text>
+        {screenState.submissionSummary.lastError !== undefined ? (
+          <Text style={styles.errorText}>
+            {screenState.submissionSummary.lastError}
+          </Text>
+        ) : null}
+        {localError !== undefined ? (
+          <Text style={styles.errorText}>{localError}</Text>
+        ) : null}
+      </View>
+
+      <View style={styles.actions}>
+        <Pressable
+          onPress={handleSubmit}
+          style={styles.primaryButton}
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? (
+            <ActivityIndicator color="#ffffff" />
+          ) : (
+            <Text style={styles.primaryButtonText}>Submit</Text>
+          )}
+        </Pressable>
+        <Pressable onPress={handleReset} style={styles.secondaryButton}>
+          <Text style={styles.secondaryButtonText}>Reset demo draft</Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollView: {
+    flex: 1,
+    backgroundColor: '#f4f7fb',
+  },
+  container: {
+    padding: 20,
+    gap: 16,
+  },
+  header: {
+    gap: 6,
+    marginBottom: 4,
+  },
+  eyebrow: {
+    color: '#4263eb',
+    fontSize: 13,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: '#152033',
+    fontSize: 28,
+    fontWeight: '700',
+  },
+  subtitle: {
+    color: '#52607a',
+    fontSize: 15,
+    lineHeight: 21,
+  },
+  card: {
+    backgroundColor: '#ffffff',
+    borderColor: '#d9e2f2',
+    borderRadius: 16,
+    borderWidth: 1,
+    gap: 12,
+    padding: 16,
+  },
+  fieldGroup: {
+    gap: 6,
+  },
+  label: {
+    color: '#24324a',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  input: {
+    backgroundColor: '#f8fafc',
+    borderColor: '#c8d3e1',
+    borderRadius: 10,
+    borderWidth: 1,
+    color: '#152033',
+    fontSize: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  sectionTitle: {
+    color: '#152033',
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  summary: {
+    color: '#24324a',
+    fontSize: 14,
+    lineHeight: 21,
+  },
+  errorText: {
+    color: '#b42318',
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  actions: {
+    gap: 12,
+    marginBottom: 32,
+  },
+  primaryButton: {
+    alignItems: 'center',
+    backgroundColor: '#4263eb',
+    borderRadius: 12,
+    minHeight: 52,
+    justifyContent: 'center',
+  },
+  primaryButtonText: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  secondaryButton: {
+    alignItems: 'center',
+    backgroundColor: '#ffffff',
+    borderColor: '#c8d3e1',
+    borderRadius: 12,
+    borderWidth: 1,
+    minHeight: 52,
+    justifyContent: 'center',
+  },
+  secondaryButtonText: {
+    color: '#24324a',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});


### PR DESCRIPTION
## Summary
Extracts `MinimumSliceScreen.tsx` as a standalone component from `App.tsx`.

- Form UI, field mapping, submit/reset/change handlers, and styles moved into `MinimumSliceScreen.tsx`
- Component receives `controller` as a prop — no direct Supabase/env knowledge
- `handleSubmit` and `handleReset` are now `useCallback`-wrapped for stability
- `App.tsx` stays as a pure auth-gate shell (loading → signed-out → signed-in)
- Follows the same pattern as `LoginScreen.tsx`
- Opens the path to a second screen without bloating `App.tsx`

## Scope
- [x] product logic (mobile UI structure)

## Checks
- [x] `MinimumSliceScreenController` type imported — controller is prop-injected, not constructed inside component
- [x] All styles preserved from App.tsx, renamed `container` → `scrollView` + `container` split
- [x] No auth logic, no env vars in this component

## Risk review
- affected areas: `apps/mobile/` only
- known limits: App.tsx still contains duplicated form logic until next PR updates it to use this component
- follow-up needed: update App.tsx to import and use MinimumSliceScreen