### PR TITLE
fix(schema): wearables hardening — 5 structural fixes before mobile sync build

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -12,7 +12,7 @@ scope: repo
 
 ## Verdict
 
-Mobile auth blocker resolved, backend hardening migration landed on `main`, and Supabase validation now includes linked-project lint plus local replay. The main remaining product blocker is still the first real authenticated Expo submit against the hosted edge function.
+Mobile auth scaffolding is now in a cleaner shape, backend hardening is already on `main`, and the main remaining product blocker is unchanged: the first real authenticated Expo submit against the hosted edge function still has not been verified live.
 
 ## Current state
 
@@ -27,28 +27,29 @@ Mobile auth blocker resolved, backend hardening migration landed on `main`, and 
   - `save-minimum-slice-interpretation` is deployed with JWT enforcement
   - one authenticated hosted smoke call returned HTTP 200 with writes succeeding end to end
   - backend hardening migration `20260413093000_phase0_backend_hardening.sql` is now on `main`
-  -   - PR #1 (phase0 backend hardening) merged to `main` — 2026-04-13
+  - PR #1 (phase0 backend hardening) merged to `main` on 2026-04-13
   - Supabase CI now runs linked-project lint plus local `supabase start` and `supabase db reset`
   - the repo now includes `memory/`, `docs/ops/`, a data-handling policy, and lightweight metadata files
-  - `mobileSupabaseAuth.ts` added: thin Supabase client adapter using `auth.getSession()`
-  - `LoginScreen.tsx` added: minimal email/password UI, delegates to Supabase client
-  - `App.tsx`: auth state machine (`loading -> signed-out -> signed-in`), listens to `onAuthStateChange`
-  - placeholder env vars (`EXPO_PUBLIC_ONE_L1FE_ACCESS_TOKEN`, `EXPO_PUBLIC_ONE_L1FE_PROFILE_ID`) removed
-  - `apps/mobile/.env.example` now matches the real auth seam (`SUPABASE_URL` + `SUPABASE_ANON_KEY`)
-  -   - `mobileSupabaseAuth.ts` and `App.tsx`: Expo env dot-notation fix applied (PR #14, #15) — `readEnv` helper removed, `process.env.VAR_NAME` used directly
-      -   - Supabase test user created: `test@one-l1fe.dev` (UID: `3aa48a6f-0f7b-47d3-9875-7353064dd359`) — ready for first Expo smoke submit
-          -   - `useAuthSession.ts` added: thin React hook wrapping Supabase auth state (`loading -> signed-out -> signed-in`), reusable across screens — PR #17 merged 2026-04-13
-    - `App.tsx` refactored to consume `useAuthSession`; auth `useState`/`useEffect` removed from component body
-    -     - `MinimumSliceScreen.tsx` extracted as standalone component — form UI, handlers, styles — PR #19 merged 2026-04-13
-    -  `App.tsx` reduced from ~200 to 55 lines — pure auth-gate shell consuming `MinimumSliceScreen` — PR #20 merged 2026-04-13
+  - `mobileSupabaseAuth.ts` is the thin Supabase client adapter using `auth.getSession()`
+  - `LoginScreen.tsx` is the minimal email/password UI and delegates to the Supabase client
+  - placeholder env vars (`EXPO_PUBLIC_ONE_L1FE_ACCESS_TOKEN`, `EXPO_PUBLIC_ONE_L1FE_PROFILE_ID`) were removed
+  - `apps/mobile/.env.example` now matches the real auth seam (`EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL` + `EXPO_PUBLIC_ONE_L1FE_SUPABASE_ANON_KEY`)
+  - Expo env access was normalized to direct `process.env.VAR_NAME` dot notation, removing the earlier `readEnv` helper (PR #14, #15)
+  - Supabase test user exists for smoke testing: `test@one-l1fe.dev` (UID `3aa48a6f-0f7b-47d3-9875-7353064dd359`)
+  - `useAuthSession.ts` now owns the thin React auth-state wrapper (`loading -> signed-out -> signed-in`) and was merged in PR #17 on 2026-04-13
+  - `MinimumSliceScreen.tsx` is now the standalone minimum-slice form component and was merged in PR #19 on 2026-04-13
+  - `App.tsx` is now a ~55-line pure auth-gate shell consuming `useAuthSession`, `LoginScreen.tsx`, and `MinimumSliceScreen.tsx`, merged in PR #20 on 2026-04-13
+  - missing mobile Supabase env no longer hard-crashes the auth seam; the login surface stays visible with a clear config error
+  - the signed-in mobile shell now includes a thin session bar with user identity and explicit sign-out, making signed-out transition testing a first-class path
 - Deployment note: domain files are vendored into `_lib/domain` at deploy time via `scripts/prepare-supabase-function-domain.sh`, while source of truth stays in `packages/domain/`
 
 ## Current next step
 
 The next best steps are, in order:
 1. **Run first live authenticated Expo submit**: set `EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL` and `EXPO_PUBLIC_ONE_L1FE_SUPABASE_ANON_KEY` in `.env`, start the app, sign in with a real user, submit the minimum-slice form, verify HTTP 200 plus DB write under the correct `profileId`,
-2. smoke-test the main auth failure modes once in Expo: wrong credentials, missing env, signed-out launch, hosted function error,
-3. decide whether the next thin app seam is a dedicated hook extraction (`useAuthSession`) or a second screen around the same controller,
+2. smoke-test the remaining main auth failure modes once in Expo: wrong credentials and hosted function error,
+3. verify the explicit sign-out path once in Expo and confirm the app returns cleanly to Login without stale signed-in access,
+4. only then choose the next thin app seam, likely a second signed-in screen around the same controller surface,
 4. add schema drift detection CI only after the current lint plus replay path has stayed stable across a couple of clean cycles.
 
 ## Startup rule

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -32,8 +32,9 @@ Important: this file stores project memory, not personal health records. Do not 
 - Keep the Priority Score framed as a bounded prioritization aid, not a clinical risk score.
 - Keep shared domain imports cross-runtime safe when the same files must run under both Node-based tests and Supabase Edge Functions.
 - For the first real mobile app seam, use Expo scaffolding first and avoid `expo-router` until there is a concrete navigation need.
-- The Expo scaffold under `apps/mobile/` uses a real Supabase auth session (`mobileSupabaseAuth.ts` via `auth.getSession()`). Environment placeholders for auth have been removed. Next step: first real authenticated Expo
-- - `MinimumSliceScreen.tsx` extracted as a standalone component (form UI, handlers, styles). `App.tsx` is now a 55-line pure auth-gate shell (loading → signed-out → signed-in). Mobile component architecture: `App.tsx` → `LoginScreen.tsx` | `MinimumSliceScreen.tsx`. Controller is wired once in `App.tsx` and prop-injected.
+- The Expo scaffold under `apps/mobile/` uses a real Supabase auth session through `mobileSupabaseAuth.ts` (`auth.getSession()`), with real Expo env keys for Supabase URL and anon key instead of auth placeholders.
+- Keep the mobile auth/session architecture thin and explicit: `useAuthSession.ts` owns auth-state subscription, `LoginScreen.tsx` owns sign-in UI, `MinimumSliceScreen.tsx` owns the signed-in minimum-slice form, and `App.tsx` stays a small auth-gate shell that wires those pieces together.
+- For wearables, keep daily summaries explicit about source scope (`single_source` vs `merged`) and timezone semantics, and keep context notes minimally structured with tags instead of free text only.
 
 ## Durable repo operations posture
 

--- a/README.md
+++ b/README.md
@@ -128,12 +128,15 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the operating rules.
 - [docs/architecture/v1-implementation-rule-inventory.md](./docs/architecture/v1-implementation-rule-inventory.md)
 - [docs/architecture/v1-decision-tables.md](./docs/architecture/v1-decision-tables.md)
 - [docs/architecture/v1-backend-interpretation-contract.md](./docs/architecture/v1-backend-interpretation-contract.md)
+- [docs/architecture/wearables-and-context-schema-draft.md](./docs/architecture/wearables-and-context-schema-draft.md)
+- [docs/architecture/wearable-metric-keys-v1.md](./docs/architecture/wearable-metric-keys-v1.md)
 
 ### Planning and roadmap
 - [docs/planning/V1-backlog.md](./docs/planning/V1-backlog.md)
 - [docs/planning/V1-minimum-slice.md](./docs/planning/V1-minimum-slice.md)
 - [docs/planning/github-hardening-checklist.md](./docs/planning/github-hardening-checklist.md)
 - [docs/planning/mobile-minimum-slice-first-seam.md](./docs/planning/mobile-minimum-slice-first-seam.md)
+- [docs/planning/wearables-hard-facts-and-automation.md](./docs/planning/wearables-hard-facts-and-automation.md)
 - [docs/archive/roadmap/phase-0.md](./docs/archive/roadmap/phase-0.md) (historical)
 - [docs/roadmap/v1-checkpoint-and-next-agent-brief.md](./docs/roadmap/v1-checkpoint-and-next-agent-brief.md)
 

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,6 +1,6 @@
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
-import { SafeAreaView, StyleSheet } from 'react-native';
+import { SafeAreaView, StyleSheet, View } from 'react-native';
 import { createMinimumSliceScreenController } from './minimumSliceScreenController.ts';
 import {
   getOneL1feSupabaseUrl,
@@ -9,6 +9,7 @@ import {
 import { createMobileSupabaseAuthSessionProvider } from './mobileSupabaseAuth.ts';
 import LoginScreen from './LoginScreen.tsx';
 import MinimumSliceScreen from './MinimumSliceScreen.tsx';
+import SessionBar from './SessionBar.tsx';
 import { useAuthSession } from './useAuthSession.ts';
 
 const controller = createMinimumSliceScreenController({
@@ -20,7 +21,7 @@ const controller = createMinimumSliceScreenController({
 });
 
 export default function App(): React.JSX.Element {
-  const { authState } = useAuthSession();
+  const { authState, error, user, signOut } = useAuthSession();
 
   // onSignedIn is kept for LoginScreen prop contract; auth state managed by useAuthSession
   const handleSignedIn = React.useCallback(() => {}, []);
@@ -31,14 +32,19 @@ export default function App(): React.JSX.Element {
     );
   }
 
-  if (authState === 'signed-out') {
-    return <LoginScreen onSignedIn={handleSignedIn} />;
+  if (authState === 'signed-out' || authState === 'config-error') {
+    return <LoginScreen onSignedIn={handleSignedIn} initialError={error} />;
   }
 
   return (
     <SafeAreaView style={styles.safeArea}>
       <StatusBar style="auto" />
-      <MinimumSliceScreen controller={controller} />
+      <View style={styles.appShell}>
+        {user !== undefined ? (
+          <SessionBar email={user.email} userId={user.id} onSignOut={signOut} />
+        ) : null}
+        <MinimumSliceScreen controller={controller} />
+      </View>
     </SafeAreaView>
   );
 }
@@ -52,5 +58,8 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  appShell: {
+    flex: 1,
   },
 });

--- a/apps/mobile/LoginScreen.tsx
+++ b/apps/mobile/LoginScreen.tsx
@@ -14,13 +14,21 @@ import { getMobileSupabaseClient } from './mobileSupabaseAuth.ts';
 
 interface LoginScreenProps {
   onSignedIn: () => void;
+  initialError?: string;
 }
 
-export default function LoginScreen({ onSignedIn }: LoginScreenProps): React.JSX.Element {
+export default function LoginScreen({
+  onSignedIn,
+  initialError,
+}: LoginScreenProps): React.JSX.Element {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | undefined>();
+  const [error, setError] = useState<string | undefined>(initialError);
+
+  React.useEffect(() => {
+    setError(initialError);
+  }, [initialError]);
 
   async function handleSignIn(): Promise<void> {
     if (email.trim().length === 0 || password.length === 0) {

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -47,18 +47,22 @@ Then open in iOS Simulator, Android Emulator, or Expo Go.
 Run these once before calling the seam proven:
 
 1. Wrong password -> Login screen shows an error, no crash.
-2. Missing env vars -> app fails fast with a clear config error.
+2. Missing env vars -> Login screen stays visible and shows a clear config error instead of crashing.
 3. Signed-out launch -> Login screen is shown instead of the form.
-4. Hosted function error -> submission summary shows an error instead of hanging silently.
+4. Sign out from the signed-in screen -> app returns cleanly to Login without stale form access.
+5. Hosted function error -> submission summary shows an error instead of hanging silently.
 
 ## Auth flow
 
 ```
 App starts
   +-- getMobileSupabaseClient().auth.getSession()
-       +-- session exists  -> show MinimumSlice form screen
+       +-- session exists  -> show SessionBar + MinimumSlice form screen
        +-- no session      -> show LoginScreen
-            +-- signInWithPassword() success -> show form screen
+            +-- signInWithPassword() success -> show signed-in screen
+
+Signed-in screen
+  +-- SessionBar -> signOut() -> return to LoginScreen
 
 Form screen: Submit button
   +-- controller.submit()
@@ -71,8 +75,9 @@ Form screen: Submit button
 
 | File | Role |
 |---|---|
-| `App.tsx` | Root component, auth state machine, form screen |
+| `App.tsx` | Root component, auth state machine, signed-in shell |
 | `LoginScreen.tsx` | Email/password sign-in UI |
+| `SessionBar.tsx` | Signed-in session identity + sign-out action |
 | `mobileSupabaseAuth.ts` | Supabase client singleton + `MinimumSliceAuthSessionProvider` adapter |
 | `minimumSliceScreenController.ts` | Screen controller (auth-provider-agnostic) |
 | `minimumSliceScreenModel.ts` | Screen model, submit logic |

--- a/apps/mobile/SessionBar.tsx
+++ b/apps/mobile/SessionBar.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+
+interface SessionBarProps {
+  email?: string;
+  userId: string;
+  onSignOut: () => Promise<void>;
+}
+
+function formatIdentity(email: string | undefined, userId: string): string {
+  if (email !== undefined && email.length > 0) {
+    return email;
+  }
+
+  return `user ${userId.slice(0, 8)}`;
+}
+
+export default function SessionBar({
+  email,
+  userId,
+  onSignOut,
+}: SessionBarProps): React.JSX.Element {
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  async function handleSignOut(): Promise<void> {
+    setIsSigningOut(true);
+    setError(undefined);
+
+    try {
+      await onSignOut();
+    } catch (signOutError) {
+      setError(
+        signOutError instanceof Error ? signOutError.message : 'Sign out failed.',
+      );
+    } finally {
+      setIsSigningOut(false);
+    }
+  }
+
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.row}>
+        <View style={styles.identityBlock}>
+          <Text style={styles.label}>Signed in</Text>
+          <Text style={styles.identity}>{formatIdentity(email, userId)}</Text>
+        </View>
+
+        <Pressable
+          disabled={isSigningOut}
+          onPress={handleSignOut}
+          style={[styles.button, isSigningOut && styles.buttonDisabled]}
+        >
+          {isSigningOut ? (
+            <ActivityIndicator color="#24324a" size="small" />
+          ) : (
+            <Text style={styles.buttonText}>Sign out</Text>
+          )}
+        </Pressable>
+      </View>
+
+      {error !== undefined ? <Text style={styles.error}>{error}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    backgroundColor: '#ffffff',
+    borderBottomColor: '#d9e2f2',
+    borderBottomWidth: 1,
+    gap: 8,
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+  },
+  row: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 12,
+    justifyContent: 'space-between',
+  },
+  identityBlock: {
+    flex: 1,
+    gap: 2,
+  },
+  label: {
+    color: '#52607a',
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+  },
+  identity: {
+    color: '#152033',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  button: {
+    alignItems: 'center',
+    backgroundColor: '#eef2ff',
+    borderColor: '#c8d3e1',
+    borderRadius: 10,
+    borderWidth: 1,
+    justifyContent: 'center',
+    minHeight: 40,
+    minWidth: 92,
+    paddingHorizontal: 14,
+  },
+  buttonDisabled: {
+    opacity: 0.7,
+  },
+  buttonText: {
+    color: '#24324a',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  error: {
+    color: '#b42318',
+    fontSize: 13,
+    lineHeight: 18,
+  },
+});

--- a/apps/mobile/useAuthSession.ts
+++ b/apps/mobile/useAuthSession.ts
@@ -1,10 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { getMobileSupabaseClient } from './mobileSupabaseAuth.ts';
 
-export type AuthState = 'loading' | 'signed-out' | 'signed-in';
+export type AuthState = 'loading' | 'signed-out' | 'signed-in' | 'config-error';
+
+export interface AuthUserSummary {
+  id: string;
+  email?: string;
+}
 
 export interface UseAuthSessionResult {
   authState: AuthState;
+  error?: string;
+  user?: AuthUserSummary;
+  signOut: () => Promise<void>;
 }
 
 /**
@@ -14,24 +22,90 @@ export interface UseAuthSessionResult {
  *
  * Keeps App.tsx and future screens free of direct Supabase client wiring.
  */
+type AuthSubscription = {
+  unsubscribe: () => void;
+};
+
 export function useAuthSession(): UseAuthSessionResult {
   const [authState, setAuthState] = useState<AuthState>('loading');
+  const [error, setError] = useState<string | undefined>();
+  const [user, setUser] = useState<AuthUserSummary | undefined>();
 
   useEffect(() => {
-    const client = getMobileSupabaseClient();
+    let authSubscription: AuthSubscription | undefined;
 
-    client.auth.getSession().then(({ data }) => {
-      setAuthState(data.session !== null ? 'signed-in' : 'signed-out');
-    });
+    try {
+      const client = getMobileSupabaseClient();
 
-    const { data: listener } = client.auth.onAuthStateChange((_event, session) => {
-      setAuthState(session !== null ? 'signed-in' : 'signed-out');
-    });
+      client.auth
+        .getSession()
+        .then(({ data, error: sessionError }) => {
+          if (sessionError !== null) {
+            setUser(undefined);
+            setError(`Supabase auth error: ${sessionError.message}`);
+            setAuthState('config-error');
+            return;
+          }
+
+          setUser(
+            data.session !== null
+              ? {
+                  id: data.session.user.id,
+                  email: data.session.user.email,
+                }
+              : undefined,
+          );
+          setAuthState(data.session !== null ? 'signed-in' : 'signed-out');
+        })
+        .catch((sessionError: unknown) => {
+          setUser(undefined);
+          setError(
+            sessionError instanceof Error
+              ? sessionError.message
+              : 'Failed to resolve auth session.',
+          );
+          setAuthState('config-error');
+        });
+
+      const authStateChangeListener = client.auth.onAuthStateChange(
+        (_event, session) => {
+          setError(undefined);
+          setUser(
+            session !== null
+              ? {
+                  id: session.user.id,
+                  email: session.user.email,
+                }
+              : undefined,
+          );
+          setAuthState(session !== null ? 'signed-in' : 'signed-out');
+        },
+      );
+
+      authSubscription = authStateChangeListener.data.subscription;
+    } catch (clientError) {
+      setUser(undefined);
+      setError(
+        clientError instanceof Error
+          ? clientError.message
+          : 'Supabase client configuration is invalid.',
+      );
+      setAuthState('config-error');
+    }
 
     return () => {
-      listener.subscription.unsubscribe();
+      authSubscription?.unsubscribe();
     };
   }, []);
 
-  return { authState };
+  const signOut = useCallback(async (): Promise<void> => {
+    const client = getMobileSupabaseClient();
+    const { error: signOutError } = await client.auth.signOut();
+
+    if (signOutError !== null) {
+      throw new Error(`Supabase auth error: ${signOutError.message}`);
+    }
+  }, []);
+
+  return { authState, error, user, signOut };
 }

--- a/docs/architecture/supabase-schema.md
+++ b/docs/architecture/supabase-schema.md
@@ -105,6 +105,12 @@ Not included yet:
 
 That is deliberate. The schema is trying to be a stable Phase 0 base, not an overbuilt health platform.
 
+A separate wearables and context expansion lane is now drafted in:
+- `docs/architecture/wearables-and-context-schema-draft.md`
+- `docs/architecture/wearable-metric-keys-v1.md`
+
+That next lane should stay separate from the lab schema rather than stretching `lab_results` into a generic health-events table.
+
 ## Current phase update
 
 A second migration now extends the baseline with:

--- a/docs/architecture/wearable-metric-keys-v1.md
+++ b/docs/architecture/wearable-metric-keys-v1.md
@@ -1,0 +1,164 @@
+---
+status: current
+canonical_for: initial wearable metric taxonomy
+owner: repo
+last_verified: 2026-04-13
+supersedes: []
+superseded_by: null
+scope: architecture
+---
+
+# Wearable metric keys V1
+
+## Verdict
+
+The first wearable metric set should stay small, stable, and biased toward metrics that are:
+- commonly exposed by Apple Health and Health Connect,
+- understandable without vendor-specific black-box logic,
+- useful for dashboards and later context-aware interpretation.
+
+## First V1 subset
+
+These are the recommended first keys to support end to end.
+
+### Sleep
+- `sleep_session`
+- `sleep_duration`
+- `awake_duration`
+
+### Activity
+- `steps_total`
+- `active_minutes`
+- `workout_session`
+
+### Cardiovascular / recovery
+- `heart_rate`
+- `resting_heart_rate`
+- `hrv`
+
+## Second wave, only if platform support is clean
+- `respiratory_rate`
+- `spo2`
+- `temperature_deviation`
+- `distance_total`
+- `active_energy_burned`
+
+## Explicitly not first-class rule inputs in V1
+- `sleep_stage`
+- `readiness_score`
+- `stress_score`
+- `body_battery`
+- `recovery_score`
+- `vo2max_estimate`
+
+These may still be stored later, but should be flagged as vendor-derived or vendor-black-box.
+
+## Key definitions
+
+| key | display name | domain | value type | default unit | aggregation hint | evidence class | confidence |
+|---|---|---|---|---|---|---|---|
+| `sleep_session` | Sleep session | sleep | json |  | session | device_observed | medium |
+| `sleep_duration` | Sleep duration | sleep | numeric | min | session | device_observed | medium |
+| `awake_duration` | Awake duration during sleep | sleep | numeric | min | session | vendor_derived | low |
+| `steps_total` | Steps total | activity | numeric | count | day | device_observed | high |
+| `active_minutes` | Active minutes | activity | numeric | min | day | product_derived | medium |
+| `workout_session` | Workout session | activity | json |  | session | device_observed | medium |
+| `heart_rate` | Heart rate | cardiovascular | numeric | bpm | sample | device_observed | medium |
+| `resting_heart_rate` | Resting heart rate | cardiovascular | numeric | bpm | day | vendor_derived | medium |
+| `hrv` | Heart rate variability | recovery | numeric | ms | sample | device_observed | variable |
+| `respiratory_rate` | Respiratory rate | respiration | numeric | breaths/min | sample | vendor_derived | variable |
+| `spo2` | Blood oxygen saturation | recovery | numeric | % | sample | vendor_derived | variable |
+| `temperature_deviation` | Temperature deviation | recovery | numeric | delta_c | day | vendor_derived | variable |
+| `distance_total` | Distance total | activity | numeric | m | day | device_observed | high |
+| `active_energy_burned` | Active energy burned | activity | numeric | kcal | day | vendor_derived | low |
+
+## Modeling notes
+
+### `sleep_session`
+Use as a session-shaped row with:
+- `observed_at` = sleep start
+- `observation_end_at` = sleep end
+- `value_json` for source-specific details when useful
+
+### `workout_session`
+Use as a session-shaped row with:
+- `observed_at` = workout start
+- `observation_end_at` = workout end
+- `value_text` = workout type if available
+- `value_json` = source-specific workout metadata
+
+### `steps_total`
+Prefer daily totals first.
+Do not overfit to intraday sample granularity in V1 unless a concrete product use case appears.
+
+### `active_minutes`
+Treat carefully because platform semantics vary.
+Use only as a convenient trend signal, not as an exact physiological quantity.
+Treat it as product-derived normalization over platform-specific activity concepts, not as a strict raw-equivalent metric.
+
+### `resting_heart_rate`
+Usually safe as a product trend input.
+Still keep source provenance because vendor calculation methods differ.
+
+### `hrv`
+Do not assume one universal HRV method.
+Apple Health commonly exposes SDNN, while Health Connect commonly exposes RMSSD.
+Store the method explicitly in source metadata and do not compare cross-platform HRV as if it were the same signal.
+
+## Recommended source mapping posture
+
+### Apple Health / HealthKit
+Likely first mappings:
+- `sleep_session` / `sleep_duration` from `HKCategoryTypeIdentifierSleepAnalysis`
+- `steps_total` from `HKQuantityTypeIdentifierStepCount`
+- `heart_rate` from `HKQuantityTypeIdentifierHeartRate`
+- `resting_heart_rate` from `HKQuantityTypeIdentifierRestingHeartRate`
+- `hrv` from `HKQuantityTypeIdentifierHeartRateVariabilitySDNN`
+- `workout_session` from `HKWorkoutType`
+
+Prefer platform-store ingestion over direct vendor APIs in V1.
+
+### Android Health Connect
+Likely first mappings:
+- `sleep_session` / `sleep_duration` from `SleepSessionRecord`
+- `steps_total` from `StepsRecord`
+- `heart_rate` from `HeartRateRecord`
+- `resting_heart_rate` from `RestingHeartRateRecord`
+- `hrv` from `HeartRateVariabilityRmssdRecord`
+- `workout_session` from `ExerciseSessionRecord`
+
+Accept that some Android device ecosystems will expose less consistent HRV and sleep data.
+
+## Summary-key examples for `wearable_daily_summaries`
+
+Daily summaries should declare whether they are source-specific or merged across sources.
+If merged, the precedence and timezone rule must be explicit in the computation contract.
+
+Daily summaries that are good first candidates:
+- `steps_total`
+- `sleep_duration_total`
+- `resting_heart_rate_daily`
+- `hrv_overnight_avg`
+- `active_minutes_total`
+- `workout_minutes_total`
+
+Rolling summaries that are good later candidates:
+- `steps_avg_7d`
+- `sleep_duration_avg_7d`
+- `resting_heart_rate_avg_7d`
+- `hrv_overnight_avg_7d`
+- `activity_consistency_7d`
+- `sleep_regularity_7d`
+
+## Research prompts
+
+If platform-specific research is needed, use prompts like:
+
+### Apple Health prompt
+"Map the following canonical health app metrics to Apple Health / HealthKit record or sample types: sleep_session, sleep_duration, awake_duration, steps_total, active_minutes, workout_session, heart_rate, resting_heart_rate, hrv, respiratory_rate, spo2, temperature_deviation. For each, state likely HealthKit type name, whether it is raw vs derived, common caveats, and whether it is practical for a first iPhone import. Call out HRV method differences explicitly."
+
+### Health Connect prompt
+"Map the following canonical health app metrics to Android Health Connect record types: sleep_session, sleep_duration, awake_duration, steps_total, active_minutes, workout_session, heart_rate, resting_heart_rate, hrv, respiratory_rate, spo2, temperature_deviation. For each, state likely record type, platform availability caveats, and whether it is practical for a first Android import. Call out HRV method differences explicitly."
+
+### Cross-platform product prompt
+"Given a private health app with labs as the primary hard-data lane, which smartwatch-derived metrics are strong enough for dashboard and trend use in V1, which are acceptable as contextual signals only, and which should be excluded because they rely too heavily on opaque vendor algorithms? Focus on Apple Health and Health Connect compatible data."

--- a/docs/architecture/wearable-metric-keys-v1.md
+++ b/docs/architecture/wearable-metric-keys-v1.md
@@ -2,7 +2,7 @@
 status: current
 canonical_for: initial wearable metric taxonomy
 owner: repo
-last_verified: 2026-04-13
+last_verified: 2026-04-14
 supersedes: []
 superseded_by: null
 scope: architecture
@@ -71,6 +71,11 @@ These may still be stored later, but should be flagged as vendor-derived or vend
 | `temperature_deviation` | Temperature deviation | recovery | numeric | delta_c | day | vendor_derived | variable |
 | `distance_total` | Distance total | activity | numeric | m | day | device_observed | high |
 | `active_energy_burned` | Active energy burned | activity | numeric | kcal | day | vendor_derived | low |
+
+> **Taxonomy note:** The canonical `evidence_class` values are defined in the `evidence_class` SQL enum.
+> Single source of truth: `supabase/migrations/20260413214000_phase0_wearables_context.sql`.
+> Valid values: `device_observed | vendor_derived | vendor_black_box | self_report | product_derived`.
+> `product_compatible` is NOT a valid value — use `product_derived`.
 
 ## Modeling notes
 

--- a/docs/architecture/wearables-and-context-schema-draft.md
+++ b/docs/architecture/wearables-and-context-schema-draft.md
@@ -1,0 +1,447 @@
+---
+status: current
+canonical_for: wearables, self-report, and context schema direction
+owner: repo
+last_verified: 2026-04-13
+supersedes: []
+superseded_by: null
+scope: architecture
+---
+
+# Wearables and context schema draft
+
+## Verdict
+
+The next health-data layer after labs should be split into four distinct storage classes:
+1. device and platform sources,
+2. raw wearable observations,
+3. app-facing summaries,
+4. self-report and context.
+
+Do not fold smartwatch data into the lab schema.
+Do not mix subjective check-ins with raw device observations.
+Do not treat opaque vendor scores as first-class clinical truth.
+
+## Why this shape is the right one
+
+The old Notion workspace already implied four different kinds of information:
+- stable profile baselines,
+- weekly self-report pillars,
+- contextual notes,
+- and measurable activity and sleep-related facts.
+
+The current backend, by contrast, is optimized for labs and interpretation runs.
+That is correct for V1, but it leaves a clear expansion lane for wearables.
+
+The clean bridge is not one giant generic health-events table.
+It is a small set of tables with explicit evidence class and provenance.
+
+## Data classes
+
+### 1. Lab facts
+Examples:
+- ApoB
+- LDL-C
+- HbA1c
+- glucose
+
+Storage posture:
+- keep in the existing lab tables.
+
+### 2. Device-observed wearable signals
+Examples:
+- steps
+- heart rate
+- HRV with explicit method metadata
+- resting heart rate
+- sleep session timing
+- workout sessions
+
+Storage posture:
+- raw observation tables with explicit source and confidence.
+
+### 3. Product-derived summaries
+Examples:
+- daily steps total
+- 7-day HRV average
+- sleep regularity
+- workout consistency
+
+Storage posture:
+- separate derived summary tables with computation versioning.
+
+### 4. Self-report and context
+Examples:
+- weekly sleep rating
+- stress this week
+- travel
+- illness
+- unusual training load
+- sleep disruption reason
+
+Storage posture:
+- separate self-report and context tables.
+
+## Recommended tables
+
+## `wearable_sources`
+
+Purpose:
+- track which platform or device produced wearable data for a profile.
+
+Examples:
+- Apple Health
+- Health Connect
+- Garmin direct import later
+- Oura direct import later
+
+Suggested columns:
+- `id uuid primary key default gen_random_uuid()`
+- `profile_id uuid not null references public.profiles(id) on delete cascade`
+- `source_kind text not null check (source_kind in ('apple_health', 'health_connect', 'vendor_api', 'manual_import'))`
+- `vendor_name text not null`
+- `source_app_name text`
+- `source_app_id text`
+- `device_label text`
+- `device_hardware_id text`
+- `app_install_id text`
+- `is_active boolean not null default true`
+- `last_synced_at timestamptz`
+- `created_at timestamptz not null default now()`
+- `updated_at timestamptz not null default now()`
+
+Notes:
+- `vendor_name` can be `apple`, `garmin`, `oura`, `whoop`, `fitbit`, `google`, etc.
+- keep multiple active sources possible, but do not assume they are interchangeable.
+
+## `wearable_sync_runs`
+
+Purpose:
+- audit ingestion attempts from mobile or later vendor integrations.
+
+Suggested columns:
+- `id uuid primary key default gen_random_uuid()`
+- `profile_id uuid not null references public.profiles(id) on delete cascade`
+- `wearable_source_id uuid not null references public.wearable_sources(id) on delete cascade`
+- `sync_mode text not null check (sync_mode in ('manual', 'app_launch', 'foreground_refresh', 'background', 'backfill'))`
+- `started_at timestamptz not null`
+- `completed_at timestamptz`
+- `status text not null check (status in ('running', 'success', 'partial', 'failed'))`
+- `records_seen integer not null default 0`
+- `records_inserted integer not null default 0`
+- `records_updated integer not null default 0`
+- `error_summary text`
+- `source_cursor text`
+- `created_at timestamptz not null default now()`
+
+Notes:
+- useful for debugging permissions, duplicates, partial syncs, and device/API instability.
+
+## `wearable_metric_definitions`
+
+Purpose:
+- canonical registry for wearable metric keys, units, and confidence posture.
+
+Suggested columns:
+- `key text primary key`
+- `display_name text not null`
+- `domain text not null check (domain in ('sleep', 'activity', 'cardiovascular', 'recovery', 'body', 'respiration', 'other'))`
+- `value_type text not null check (value_type in ('numeric', 'boolean', 'enum', 'json'))`
+- `default_unit text`
+- `aggregation_hint text check (aggregation_hint in ('sample', 'session', 'day', 'week'))`
+- `evidence_class text not null check (evidence_class in ('device_observed', 'vendor_derived', 'vendor_black_box', 'self_report', 'product_derived'))`
+- `confidence_class text not null check (confidence_class in ('high', 'medium', 'low', 'variable'))`
+- `is_v1_enabled boolean not null default true`
+- `notes text`
+
+Notes:
+- this is the wearable equivalent of `biomarker_definitions`, but should stay explicitly weaker in evidence semantics.
+
+## `wearable_observations`
+
+Purpose:
+- store raw or near-raw time-series observations from platform health stores or vendor imports.
+
+Suggested columns:
+- `id uuid primary key default gen_random_uuid()`
+- `profile_id uuid not null references public.profiles(id) on delete cascade`
+- `wearable_source_id uuid not null references public.wearable_sources(id) on delete cascade`
+- `metric_key text not null references public.wearable_metric_definitions(key)`
+- `source_record_id text not null`
+- `raw_type text`
+- `aggregation_level text not null check (aggregation_level in ('sample', 'session', 'day'))`
+- `observed_at timestamptz not null`
+- `observation_end_at timestamptz`
+- `source_timezone text`
+- `value_numeric numeric(12,4)`
+- `value_text text`
+- `value_json jsonb`
+- `unit text`
+- `measurement_method text`
+- `source_confidence text not null check (source_confidence in ('high', 'medium', 'low', 'unknown')) default 'unknown'`
+- `vendor_signal_class text not null check (vendor_signal_class in ('raw_observed', 'vendor_derived', 'vendor_black_box')) default 'raw_observed'`
+- `is_deleted_at_source boolean not null default false`
+- `recorded_at_source timestamptz`
+- `source_payload jsonb not null default '{}'::jsonb`
+- `created_at timestamptz not null default now()`
+- `updated_at timestamptz not null default now()`
+- `unique (wearable_source_id, metric_key, source_record_id)`
+
+Notes:
+- one table is acceptable here because provenance, metric definition, and aggregation level make the row interpretable.
+- do not force every metric into numeric-only shape.
+- prefer raw source timestamps over import timestamps when available.
+- keep `raw_type`, `source_timezone`, and `measurement_method` explicit for tricky signals like sleep sessions and HRV.
+
+## `wearable_daily_summaries`
+
+Purpose:
+- store stable app-facing daily rollups and trend inputs.
+
+Suggested columns:
+- `id uuid primary key default gen_random_uuid()`
+- `profile_id uuid not null references public.profiles(id) on delete cascade`
+- `summary_source_scope text not null check (summary_source_scope in ('single_source', 'merged'))`
+- `wearable_source_id uuid references public.wearable_sources(id) on delete cascade`
+- `summary_date date not null`
+- `summary_timezone text not null`
+- `summary_key text not null`
+- `value_numeric numeric(12,4)`
+- `value_text text`
+- `unit text`
+- `computation_version text not null`
+- `derived_from jsonb not null default '[]'::jsonb`
+- `quality_flag text not null check (quality_flag in ('good', 'partial', 'uncertain', 'insufficient')) default 'good'`
+- `created_at timestamptz not null default now()`
+- `updated_at timestamptz not null default now()`
+- partial unique index for source-specific summaries: `unique (profile_id, wearable_source_id, summary_date, summary_key, computation_version)` when `summary_source_scope = 'single_source'`
+- partial unique index for merged summaries: `unique (profile_id, summary_date, summary_key, computation_version)` when `summary_source_scope = 'merged'`
+
+Examples:
+- `steps_total`
+- `sleep_duration_total`
+- `sleep_midpoint`
+- `resting_hr_daily`
+- `hrv_overnight_avg`
+- `workout_minutes_total`
+- `activity_consistency_7d`
+
+Notes:
+- keep these derived summaries auditable and versioned.
+- do not assume one permanent formula forever.
+- do not allow silent writer-wins collisions between Apple Health and Health Connect.
+- `summary_timezone` must encode which local day the summary belongs to. Do not leave day-boundary semantics implicit.
+- use `single_source` first if merge logic is not yet trustworthy; add `merged` only once source precedence is explicit.
+
+## `weekly_checkins`
+
+Purpose:
+- preserve the old weekly self-report layer in a first-class, queryable form.
+
+Suggested columns:
+- `id uuid primary key default gen_random_uuid()`
+- `profile_id uuid not null references public.profiles(id) on delete cascade`
+- `week_date date not null`
+- `exercise_score smallint check (exercise_score between 0 and 10)`
+- `sleep_score smallint check (sleep_score between 0 and 10)`
+- `nutrition_score smallint check (nutrition_score between 0 and 10)`
+- `emotional_health_score smallint check (emotional_health_score between 0 and 10)`
+- `bottleneck text`
+- `biggest_risk text`
+- `intended_action text`
+- `summary text`
+- `created_at timestamptz not null default now()`
+- `updated_at timestamptz not null default now()`
+- `unique (profile_id, week_date)`
+
+Notes:
+- anchored semantics should follow `weekly-self-report-anchors-v1.md`.
+- this table is intentionally self-report, not wearable import.
+
+## `context_notes`
+
+Purpose:
+- store interpretation-relevant explanatory context that should not be faked as measurements.
+
+Suggested columns:
+- `id uuid primary key default gen_random_uuid()`
+- `profile_id uuid not null references public.profiles(id) on delete cascade`
+- `context_type text not null check (context_type in ('work_stress', 'sleep_disruption', 'illness', 'travel', 'training_load', 'nutrition_disruption', 'medication_change', 'supplement_change', 'other'))`
+- `started_at timestamptz`
+- `ended_at timestamptz`
+- `summary text not null`
+- `details text`
+- `tags jsonb not null default '[]'::jsonb`
+- `relevance_level text not null check (relevance_level in ('low', 'medium', 'high')) default 'medium'`
+- `created_at timestamptz not null default now()`
+- `updated_at timestamptz not null default now()`
+
+Notes:
+- this is the right place for jet lag, infection week, bad sleep due to travel, and unusual workload.
+- keep it simple and queryable.
+- do not make free text the only machine-usable structure. Keep lightweight tags for later rules, filtering, and UI chips.
+
+## `profile_baselines`
+
+Purpose:
+- keep stable or slowly changing baseline context out of raw observation tables.
+
+Suggested columns:
+- `profile_id uuid primary key references public.profiles(id) on delete cascade`
+- `exercise_baseline text`
+- `sleep_baseline text`
+- `nutrition_baseline text`
+- `emotional_baseline text`
+- `health_goal text`
+- `priority_horizon text`
+- `constraints_json jsonb not null default '[]'::jsonb`
+- `family_history_summary text`
+- `updated_at timestamptz not null default now()`
+
+Notes:
+- this can be a separate table or absorbed into `profiles` later.
+- separating it keeps `profiles` lean if the base product profile stays minimal.
+- keep this table for narrative and preference-like baselines, not drifting physiologic baselines that need history.
+
+## What smartwatch data should map where
+
+### Sleep-related
+Use `wearable_observations` for:
+- sleep session start and end
+- sleep duration
+- awake time
+- HRV sample or overnight HRV aggregate with method metadata
+- overnight heart rate
+- respiratory rate if available
+- SpO2 if available
+- temperature deviation if available
+
+Use `wearable_daily_summaries` for:
+- total sleep duration per day
+- sleep regularity metrics
+- overnight resting heart rate summary
+- rolling sleep trend metrics
+
+Use `weekly_checkins` and `context_notes` for:
+- "sleep felt poor this week"
+- "travel disrupted sleep"
+- "new baby / stress / late workload"
+
+### Activity-related
+Use `wearable_observations` for:
+- steps sample or total
+- workout session
+- heart-rate trace during workout
+- active minutes
+- distance
+- cadence or pace when useful
+
+Use `wearable_daily_summaries` for:
+- daily steps total
+- workout minutes total
+- weekly activity consistency
+- training load proxy
+
+Use `context_notes` for:
+- unusual training block
+- injury-limited week
+- travel week with low movement
+
+## What should not become hard engine truth early
+
+Avoid early rule dependence on:
+- vendor readiness scores
+- body battery style scores
+- stress scores from closed algorithms
+- sleep stage percentages from consumer devices
+- opaque recovery scores
+
+If ingested at all, store them with:
+- original vendor label,
+- low or variable confidence,
+- explicit `vendor_black_box` classification.
+
+## Recommended first V1 metric keys
+
+Best first candidates:
+- `steps_total`
+- `active_minutes`
+- `workout_session`
+- `heart_rate`
+- `resting_heart_rate`
+- `hrv`
+- `sleep_session`
+- `sleep_duration`
+- `awake_duration`
+- `respiratory_rate`
+- `spo2`
+- `temperature_deviation`
+
+Not all need to be supported on day one.
+The best first cut is:
+- steps
+- workouts
+- heart rate
+- resting heart rate
+- HRV with stored method metadata
+- sleep session timing
+- sleep duration
+
+## RLS posture
+
+All user-owned rows should follow the same rule as the current health tables:
+- ownership anchored by `profile_id = auth.uid()`
+- strict row-level security on every user data table
+- no shared wearable tables without explicit future sharing design
+
+## Recommended indexes
+
+At minimum:
+- `wearable_observations (profile_id, metric_key, observed_at desc)`
+- `wearable_observations (wearable_source_id, source_record_id)` unique already implied by constraint
+- `wearable_daily_summaries (profile_id, summary_date desc, summary_key)`
+- `weekly_checkins (profile_id, week_date desc)`
+- `context_notes (profile_id, started_at desc)`
+- `wearable_sync_runs (profile_id, started_at desc)`
+
+## Suggested build order
+
+1. add `wearable_metric_definitions`
+2. add `wearable_sources`
+3. add `wearable_sync_runs`
+4. add `wearable_observations`
+5. add `wearable_daily_summaries`
+6. add `weekly_checkins`
+7. add `context_notes`
+8. only then add import logic in mobile app
+
+## Confidence and uncertainty
+
+Known:
+- the old system shape clearly needs weekly and context layers in addition to labs
+- smartwatch and phone-platform data can realistically automate part of this
+- labs and wearables are different evidence classes and should stay separate
+
+Inferred:
+- Apple Health and Health Connect are the right first ingestion path
+- a normalized raw observation table plus daily summaries is the best first schema split
+
+Still uncertain:
+- exact metric key taxonomy beyond the first small subset
+- whether `profile_baselines` should be separate from `profiles`
+- which wearable metrics deserve rule-level use in V1 versus dashboard-only use
+- how aggressively Apple SDNN and Android RMSSD should be normalized versus kept as method-tagged HRV variants
+
+Resolved for this draft:
+- daily summaries must declare whether they are `single_source` or `merged`
+- daily summaries must carry explicit timezone semantics
+- context notes need lightweight structured tags in addition to free text
+- `profile_baselines` is scoped to narrative or preference-like baseline context, not longitudinal physiologic baselines
+
+## Recommended next action
+
+The next concrete step after this doc should be:
+1. define canonical wearable metric keys in code and docs,
+2. choose the first Apple Health / Health Connect metric subset,
+3. write the first Supabase migration for the wearable tables,
+4. build mobile sync only for that narrow subset.

--- a/docs/planning/wearables-hard-facts-and-automation.md
+++ b/docs/planning/wearables-hard-facts-and-automation.md
@@ -1,0 +1,354 @@
+---
+status: current
+canonical_for: wearables scope and ingestion posture
+owner: repo
+last_verified: 2026-04-13
+supersedes: []
+superseded_by: null
+scope: planning
+---
+
+# Wearables hard facts and automation
+
+## Verdict
+
+Wearables should be added as a separate raw-data stream, not folded into the lab schema and not treated as equally trustworthy across all metrics.
+
+The realistic near-term posture is:
+1. keep labs as the first hard clinical data path,
+2. add a bounded wearables layer for high-confidence activity and sleep signals,
+3. store provenance and confidence explicitly,
+4. avoid pretending consumer-watch outputs are medical-grade when they are not.
+
+## Why this matters
+
+The old Notion-shaped workspace clearly included non-lab context such as:
+- exercise baseline,
+- sleep baseline,
+- weekly check-ins,
+- context notes like unusual training load or sleep disruption.
+
+That means wearables are not outside the product shape.
+They are part of the intended whole-system picture.
+But they are a different data class from labs and should be modeled that way.
+
+## Recommended data classes
+
+### 1. Hard fact, device-measured, high confidence
+These are the strongest smartwatch-derived candidates.
+
+Examples:
+- steps
+- distance walked or run
+- active minutes / exercise minutes
+- workout sessions with start and end time
+- heart rate samples
+- resting heart rate
+- sleep start and end times
+- total sleep duration
+- awake episodes during sleep when provided by source platform
+- HRV when captured consistently by the source platform
+- blood oxygen samples if available, but with device/source caveat
+- skin temperature deviation if exposed by platform
+- calories burned as recorded output, but usually lower-confidence analytically than the raw movement/time signals
+
+Recommended posture:
+- store as observed measurements,
+- keep source platform and device provenance,
+- do not over-interpret them clinically by default.
+
+### 2. Derived but still fairly factual summaries
+These are aggregations over raw device measurements.
+
+Examples:
+- daily step total
+- daily sleep duration
+- sleep efficiency estimate
+- weekly training load proxy
+- 7-day resting heart rate average
+- 7-day HRV average
+- activity consistency score
+- sleep regularity score
+
+Recommended posture:
+- compute from raw data where possible,
+- keep aggregation method versioned,
+- make clear that these are product summaries, not vendor truth.
+
+### 3. Soft fact or context-supported data
+These are still useful, but need careful labeling.
+
+Examples:
+- perceived stress
+- readiness
+- recovery score
+- energy level
+- mood
+- sleep quality self-rating
+- illness flags
+- jet lag / travel disruption
+- soreness
+- unusual workload
+
+Recommended posture:
+- store separately from raw device measurements,
+- label as self-report or product-derived context,
+- do not mix them with device observations as if they were the same evidence class.
+
+### 4. Low-confidence or vendor-black-box signals
+These can still be useful operationally, but should not become hard engine truth too early.
+
+Examples:
+- vendor readiness score
+- vendor body battery / recovery score
+- stress score from closed algorithms
+- sleep stage percentages from consumer devices
+- estimated VO2 max from opaque vendor pipelines
+- irregular rhythm alerts unless carefully handled
+
+Recommended posture:
+- ingest only if there is a strong user value case,
+- keep raw vendor label and source intact,
+- do not build core recommendation logic on top of them early.
+
+## What likely falls under sleep and activity
+
+### Sleep
+Potential measurable fields:
+- sleep session start
+- sleep session end
+- total sleep duration
+- time in bed
+- awake duration
+- sleep interruptions count
+- resting heart rate during sleep
+- overnight HRV summary
+- overnight respiratory rate if available
+- overnight SpO2 if available
+- skin temperature deviation if available
+
+Good near-term hard facts:
+- start/end,
+- duration,
+- consistency/regularity,
+- overnight resting HR and HRV trends.
+
+Use more cautiously:
+- sleep stages,
+- readiness/recovery outputs,
+- generalized sleep quality scores from vendor black boxes.
+
+### Activity and training
+Potential measurable fields:
+- steps
+- distance
+- floors climbed
+- active energy
+- total energy
+- active minutes
+- workout type
+- workout duration
+- workout heart-rate trace
+- pace / speed where available
+- cadence where available
+- elevation gain where available
+- zone minutes if computed by us or source platform
+
+Good near-term hard facts:
+- step totals,
+- active minutes,
+- workout sessions,
+- heart-rate traces,
+- weekly volume and consistency.
+
+Use more cautiously:
+- calories,
+- training readiness,
+- proprietary training load or strain scores.
+
+### Recovery / physiology
+Potential measurable fields:
+- resting heart rate
+- HRV
+- respiratory rate
+- skin temperature deviation
+- SpO2
+- weight if synced from another device
+
+Good near-term hard facts:
+- resting HR trend,
+- HRV trend if same source/device,
+- temperature deviation trend when source is stable.
+
+Use more cautiously:
+- single-point conclusions,
+- cross-device comparisons without normalization.
+
+## Realistic automation answer
+
+Yes, automation is realistic.
+But the right answer is usually not "watch directly to our database" as the first move.
+
+The practical path is:
+1. watch -> Apple Health / HealthKit or Google Health Connect,
+2. mobile app reads permitted records,
+3. app normalizes them into a stable internal schema,
+4. app sends them to Supabase,
+5. backend stores raw observations and optional aggregates separately.
+
+## Recommended ingestion architecture
+
+```text
+Smartwatch / wearable
+  -> platform health store (Apple Health / Health Connect)
+  -> One L1fe mobile sync layer
+  -> Supabase raw wearable tables
+  -> aggregation / interpretation layer
+  -> app review surfaces
+```
+
+## Why this is the right first architecture
+
+Because direct vendor integrations are usually messier than they look:
+- each vendor has different APIs and limits,
+- some do not expose all raw data cleanly,
+- platform health stores already unify a lot,
+- user permissions are easier to manage on-device,
+- and the mobile app is the natural place to request consent and run local sync.
+
+## What is realistic in practice
+
+### Very realistic in a first implementation
+- Apple Health import on iPhone for sleep, steps, heart rate, resting heart rate, HRV, workouts
+- Android Health Connect import for similar categories where available
+- periodic foreground sync when app opens
+- manual "sync now" action
+- daily rollups and trend views in backend
+
+### Realistic but more work
+- background sync
+- conflict handling across multiple devices
+- deduplication across vendor and platform records
+- fine-grained provenance per sample
+- raw sample plus aggregate dual-write model
+
+### Possible but should not be first
+- direct Garmin, Oura, Whoop, Fitbit vendor integrations
+- full historical backfills from multiple ecosystems at once
+- recommendation engine logic heavily dependent on opaque vendor scores
+
+## Recommended schema direction
+
+Do not squeeze wearables into `lab_results` or `lab_result_entries`.
+
+Instead add a separate layer such as:
+- `wearable_sources`
+- `wearable_observations`
+- `wearable_daily_summaries`
+- `weekly_checkins` or `self_report_entries`
+- `context_notes`
+
+Suggested shape:
+
+### `wearable_observations`
+Purpose:
+- raw or near-raw time-series observations from device/platform feeds.
+
+Likely fields:
+- id
+- profile_id
+- source_platform (`apple_health`, `health_connect`, `garmin`, `oura`, etc.)
+- source_device_id or source_device_label
+- metric_key (`steps`, `heart_rate`, `hrv_rmssd`, `sleep_duration`, etc.)
+- value_numeric
+- unit
+- observed_at
+- observation_end_at nullable
+- aggregation_level (`sample`, `session`, `day`)
+- source_record_id
+- source_payload_ref or raw payload hash if needed
+- confidence_class
+- created_at
+
+### `wearable_daily_summaries`
+Purpose:
+- stable app-facing daily rollups.
+
+Likely fields:
+- id
+- profile_id
+- date
+- summary_key (`steps_total`, `sleep_duration_total`, `resting_hr_daily`, etc.)
+- value_numeric
+- unit
+- computation_version
+- source_mix_summary
+- created_at
+
+### `weekly_checkins`
+Purpose:
+- keep the subjective and intentional layer separate.
+
+Likely fields:
+- id
+- profile_id
+- week_date
+- exercise_self_rating
+- sleep_self_rating
+- nutrition_self_rating
+- emotional_health_self_rating
+- bottleneck
+- biggest_risk
+- intended_action
+- summary
+
+### `context_notes`
+Purpose:
+- keep non-measurement explanations queryable.
+
+Likely fields:
+- id
+- profile_id
+- context_type
+- started_at nullable
+- ended_at nullable
+- summary
+- details
+- relevance_level
+
+## Product recommendation
+
+Near term:
+- keep labs as the first hard interpretation engine,
+- add wearables as a second raw-data lane,
+- use wearables first for dashboards, trends, and context,
+- only then selectively promote a few wearable signals into rule logic.
+
+Best first wearable candidates for rule-level use later:
+- 7-day resting heart rate trend,
+- 7-day HRV trend from same source,
+- sleep duration trend,
+- activity consistency,
+- recent workout load context.
+
+## Main risk
+
+The main mistake would be treating all wearable outputs as equally objective.
+They are not.
+
+The model should distinguish:
+- lab-measured biomarker facts,
+- device-observed behavioral and physiological signals,
+- self-reported context,
+- vendor-black-box scores.
+
+That separation will matter a lot for trust and future interpretation quality.
+
+## Recommended next step
+
+If wearables become active scope soon, the next concrete design step should be:
+1. define canonical wearable metric keys,
+2. define confidence classes and provenance rules,
+3. add a minimal raw observation schema,
+4. support Apple Health / Health Connect first,
+5. keep vendor-direct integrations out of V1.

--- a/memory/2026-04-13.md
+++ b/memory/2026-04-13.md
@@ -2,18 +2,18 @@
 
 ## Session notes
 
-- The backend minimum-slice seam remains green based on current root checks and prior hosted confirmation recorded in `CHECKPOINT.md`.
-- The first real Expo scaffold now exists under `apps/mobile/` and stays intentionally router-free.
-- The Expo seam still uses environment placeholders for auth and needs one real app session source plus one authenticated hosted submission test.
-- Repo improvement work identified a second track beyond product implementation: truth lifecycle, drift control, short-term memory, and explicit OpenClaw operations guidance.
+- Session closeout synced after the mobile auth cleanup landed on `main`.
+- Backend minimum-slice seam is still considered green from the hosted checks already captured in `CHECKPOINT.md`.
+- Mobile auth architecture is now cleaner: `useAuthSession.ts` owns auth state, `LoginScreen.tsx` owns sign-in, `MinimumSliceScreen.tsx` owns the signed-in form, and `App.tsx` is a small auth-gate shell.
+- Expo auth placeholders are gone. `.env.example` now points at the real Supabase URL and anon-key seam.
+- The remaining product blocker is unchanged: the first real authenticated Expo submit against the hosted function still needs to be run and verified end to end.
 
 ## Open questions
 
-- What should be the canonical home for health-boundary detail versus short operational guardrails?
-- Which high-value docs should get status metadata first?
-- Should the first machine-readable artifact be `checkpoint.yaml` or a narrower policy index?
+- Does the first live Expo smoke submit succeed with the existing hosted setup and test user?
+- Which signed-in screen or flow should come immediately after the minimum-slice seam is proven live?
 
 ## Likely promotions
 
-- Promote only durable repo operating rules to `MEMORY.md`.
-- Promote only the active implementation seam and blockers to `CHECKPOINT.md`.
+- Promote only stable architecture rules and operating posture to `MEMORY.md`.
+- Keep live blockers, current seam status, and immediate next actions in `CHECKPOINT.md`.

--- a/src/lib/wearables/index.ts
+++ b/src/lib/wearables/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Wearables module — public exports
+ *
+ * Import from here, not from individual files, to keep the module boundary clean.
+ */
+
+export * from './metricRegistry';
+export * from './syncContract';

--- a/src/lib/wearables/metricRegistry.ts
+++ b/src/lib/wearables/metricRegistry.ts
@@ -1,0 +1,273 @@
+/**
+ * Wearable Metric Registry — V1
+ *
+ * Canonical TypeScript mirror of wearable_metric_definitions.
+ * Single source of truth for metric keys used in mobile sync, edge functions,
+ * and UI. Must stay in sync with:
+ *   - docs/architecture/wearable-metric-keys-v1.md
+ *   - supabase/migrations/20260413214000_phase0_wearables_context.sql
+ */
+
+// ---------------------------------------------------------------------------
+// Core types
+// ---------------------------------------------------------------------------
+
+export type WearableMetricKey =
+  // Sleep
+  | 'sleep_session'
+  | 'sleep_duration'
+  | 'awake_duration'
+  // Activity
+  | 'steps_total'
+  | 'active_minutes'
+  | 'workout_session'
+  // Cardiovascular / recovery
+  | 'heart_rate'
+  | 'resting_heart_rate'
+  | 'hrv'
+  // Second wave — not enabled by default in V1
+  | 'respiratory_rate'
+  | 'spo2'
+  | 'temperature_deviation'
+  | 'distance_total'
+  | 'active_energy_burned';
+
+export type MetricDomain =
+  | 'sleep'
+  | 'activity'
+  | 'cardiovascular'
+  | 'recovery'
+  | 'respiration'
+  | 'body'
+  | 'other';
+
+export type MetricValueType = 'numeric' | 'boolean' | 'enum' | 'json';
+
+export type AggregationHint = 'sample' | 'session' | 'day' | 'week';
+
+export type EvidenceClass =
+  | 'device_observed'
+  | 'vendor_derived'
+  | 'vendor_black_box'
+  | 'self_report'
+  | 'product_derived';
+
+export type ConfidenceClass = 'high' | 'medium' | 'low' | 'variable';
+
+export interface WearableMetricDefinition {
+  key: WearableMetricKey;
+  displayName: string;
+  domain: MetricDomain;
+  valueType: MetricValueType;
+  defaultUnit: string | null;
+  aggregationHint: AggregationHint;
+  evidenceClass: EvidenceClass;
+  confidenceClass: ConfidenceClass;
+  /** Whether this metric is included in the V1 import set. */
+  isV1Enabled: boolean;
+  notes?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+export const WEARABLE_METRIC_REGISTRY: Record<WearableMetricKey, WearableMetricDefinition> = {
+  // --- Sleep ---
+  sleep_session: {
+    key: 'sleep_session',
+    displayName: 'Sleep session',
+    domain: 'sleep',
+    valueType: 'json',
+    defaultUnit: null,
+    aggregationHint: 'session',
+    evidenceClass: 'device_observed',
+    confidenceClass: 'medium',
+    isV1Enabled: true,
+    notes: 'Session row: observed_at = sleep start, observation_end_at = sleep end.',
+  },
+  sleep_duration: {
+    key: 'sleep_duration',
+    displayName: 'Sleep duration',
+    domain: 'sleep',
+    valueType: 'numeric',
+    defaultUnit: 'min',
+    aggregationHint: 'session',
+    evidenceClass: 'device_observed',
+    confidenceClass: 'medium',
+    isV1Enabled: true,
+  },
+  awake_duration: {
+    key: 'awake_duration',
+    displayName: 'Awake duration during sleep',
+    domain: 'sleep',
+    valueType: 'numeric',
+    defaultUnit: 'min',
+    aggregationHint: 'session',
+    evidenceClass: 'vendor_derived',
+    confidenceClass: 'low',
+    isV1Enabled: true,
+  },
+
+  // --- Activity ---
+  steps_total: {
+    key: 'steps_total',
+    displayName: 'Steps total',
+    domain: 'activity',
+    valueType: 'numeric',
+    defaultUnit: 'count',
+    aggregationHint: 'day',
+    evidenceClass: 'device_observed',
+    confidenceClass: 'high',
+    isV1Enabled: true,
+    notes: 'Prefer daily totals. Do not overfit to intraday granularity in V1.',
+  },
+  active_minutes: {
+    key: 'active_minutes',
+    displayName: 'Active minutes',
+    domain: 'activity',
+    valueType: 'numeric',
+    defaultUnit: 'min',
+    aggregationHint: 'day',
+    evidenceClass: 'product_derived',
+    confidenceClass: 'medium',
+    isV1Enabled: true,
+    notes:
+      'Platform semantics vary. Use as trend signal only, not exact physiological quantity.',
+  },
+  workout_session: {
+    key: 'workout_session',
+    displayName: 'Workout session',
+    domain: 'activity',
+    valueType: 'json',
+    defaultUnit: null,
+    aggregationHint: 'session',
+    evidenceClass: 'device_observed',
+    confidenceClass: 'medium',
+    isV1Enabled: true,
+    notes:
+      'Session row: observed_at = start, observation_end_at = end, value_text = workout type.',
+  },
+
+  // --- Cardiovascular / recovery ---
+  heart_rate: {
+    key: 'heart_rate',
+    displayName: 'Heart rate',
+    domain: 'cardiovascular',
+    valueType: 'numeric',
+    defaultUnit: 'bpm',
+    aggregationHint: 'sample',
+    evidenceClass: 'device_observed',
+    confidenceClass: 'medium',
+    isV1Enabled: true,
+  },
+  resting_heart_rate: {
+    key: 'resting_heart_rate',
+    displayName: 'Resting heart rate',
+    domain: 'cardiovascular',
+    valueType: 'numeric',
+    defaultUnit: 'bpm',
+    aggregationHint: 'day',
+    evidenceClass: 'vendor_derived',
+    confidenceClass: 'medium',
+    isV1Enabled: true,
+    notes: 'Keep source provenance — vendor calculation methods differ.',
+  },
+  hrv: {
+    key: 'hrv',
+    displayName: 'Heart rate variability',
+    domain: 'recovery',
+    valueType: 'numeric',
+    defaultUnit: 'ms',
+    aggregationHint: 'sample',
+    evidenceClass: 'device_observed',
+    confidenceClass: 'variable',
+    isV1Enabled: true,
+    notes:
+      'CRITICAL: Apple Health = SDNN (HKQuantityTypeIdentifierHeartRateVariabilitySDNN). ' +
+      'Health Connect = RMSSD (HeartRateVariabilityRmssdRecord). ' +
+      'Store measurement_method explicitly. Never compare cross-platform HRV as the same signal.',
+  },
+
+  // --- Second wave (isV1Enabled: false) ---
+  respiratory_rate: {
+    key: 'respiratory_rate',
+    displayName: 'Respiratory rate',
+    domain: 'respiration',
+    valueType: 'numeric',
+    defaultUnit: 'breaths/min',
+    aggregationHint: 'sample',
+    evidenceClass: 'vendor_derived',
+    confidenceClass: 'variable',
+    isV1Enabled: false,
+  },
+  spo2: {
+    key: 'spo2',
+    displayName: 'Blood oxygen saturation',
+    domain: 'recovery',
+    valueType: 'numeric',
+    defaultUnit: '%',
+    aggregationHint: 'sample',
+    evidenceClass: 'vendor_derived',
+    confidenceClass: 'variable',
+    isV1Enabled: false,
+  },
+  temperature_deviation: {
+    key: 'temperature_deviation',
+    displayName: 'Temperature deviation',
+    domain: 'recovery',
+    valueType: 'numeric',
+    defaultUnit: 'delta_c',
+    aggregationHint: 'day',
+    evidenceClass: 'vendor_derived',
+    confidenceClass: 'variable',
+    isV1Enabled: false,
+  },
+  distance_total: {
+    key: 'distance_total',
+    displayName: 'Distance total',
+    domain: 'activity',
+    valueType: 'numeric',
+    defaultUnit: 'm',
+    aggregationHint: 'day',
+    evidenceClass: 'device_observed',
+    confidenceClass: 'high',
+    isV1Enabled: false,
+  },
+  active_energy_burned: {
+    key: 'active_energy_burned',
+    displayName: 'Active energy burned',
+    domain: 'activity',
+    valueType: 'numeric',
+    defaultUnit: 'kcal',
+    aggregationHint: 'day',
+    evidenceClass: 'vendor_derived',
+    confidenceClass: 'low',
+    isV1Enabled: false,
+    notes: 'Calories are unreliable as a primary signal. Dashboard only, never rule input.',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** All metric keys enabled for V1 import. */
+export const V1_ENABLED_METRIC_KEYS = Object.values(WEARABLE_METRIC_REGISTRY)
+  .filter((m) => m.isV1Enabled)
+  .map((m) => m.key) satisfies WearableMetricKey[];
+
+/** Metric keys that carry session-shaped data (require observation_end_at). */
+export const SESSION_METRIC_KEYS: WearableMetricKey[] = ['sleep_session', 'workout_session'];
+
+/** Whether a given metric key represents a session-shaped observation. */
+export function isSessionMetric(key: WearableMetricKey): boolean {
+  return SESSION_METRIC_KEYS.includes(key);
+}
+
+/** Get definition for a metric key, throws if unknown. */
+export function getMetricDefinition(key: WearableMetricKey): WearableMetricDefinition {
+  const def = WEARABLE_METRIC_REGISTRY[key];
+  if (!def) throw new Error(`Unknown wearable metric key: ${key}`);
+  return def;
+}

--- a/src/lib/wearables/syncContract.ts
+++ b/src/lib/wearables/syncContract.ts
@@ -1,0 +1,190 @@
+/**
+ * Mobile Sync Contract — Wearables V1
+ *
+ * Defines the payload shapes that the mobile app sends to the backend
+ * when syncing Apple Health (HealthKit) or Android Health Connect data.
+ *
+ * Design rules:
+ *   - Mobile sends raw/near-raw observations. Backend handles dedup and summaries.
+ *   - Every payload carries explicit provenance: source, method, timezone.
+ *   - HRV MUST include measurement_method. No exceptions.
+ *   - Session metrics MUST include observation_end_at.
+ *   - Callers must not strip source_record_id — it is the dedup key.
+ */
+
+import type { WearableMetricKey } from './metricRegistry';
+
+// ---------------------------------------------------------------------------
+// Platform identifiers
+// ---------------------------------------------------------------------------
+
+export type SyncPlatform = 'apple_health' | 'health_connect';
+
+export type SyncMode = 'manual' | 'app_launch' | 'foreground_refresh' | 'background' | 'backfill';
+
+// ---------------------------------------------------------------------------
+// HRV method — must be explicit, never inferred
+// ---------------------------------------------------------------------------
+
+export type HrvMethod =
+  | 'sdnn'   // Apple Health default — HKQuantityTypeIdentifierHeartRateVariabilitySDNN
+  | 'rmssd'  // Health Connect default — HeartRateVariabilityRmssdRecord
+  | 'unknown'; // Only acceptable for legacy backfill with no method metadata available
+
+// ---------------------------------------------------------------------------
+// Single observation payload
+// ---------------------------------------------------------------------------
+
+export interface RawObservationPayload {
+  /** Canonical metric key from WearableMetricKey. */
+  metric_key: WearableMetricKey;
+
+  /**
+   * Platform-native record/sample ID.
+   * Used as dedup key: (wearable_source_id, metric_key, source_record_id) must be unique.
+   * Never omit or generate a synthetic ID on mobile.
+   */
+  source_record_id: string;
+
+  /**
+   * Platform-native type string for debugging and future raw_type indexing.
+   * Examples:
+   *   Apple Health: 'HKQuantityTypeIdentifierStepCount'
+   *   Health Connect: 'StepsRecord'
+   */
+  raw_type: string;
+
+  /** ISO 8601 with timezone offset. Observation start (or single sample time). */
+  observed_at: string;
+
+  /**
+   * ISO 8601 with timezone offset. Required for session metrics (sleep_session, workout_session).
+   * Must be null for point-in-time samples.
+   */
+  observation_end_at: string | null;
+
+  /**
+   * IANA timezone of the recording device at observation time.
+   * Critical for sleep-across-midnight and travel correctness.
+   * Examples: 'Europe/Berlin', 'America/New_York'
+   */
+  source_timezone: string;
+
+  /** Numeric scalar value. Null if metric is session/json-shaped. */
+  value_numeric: number | null;
+
+  /** Text value. Use for workout_session type label, enum values. */
+  value_text: string | null;
+
+  /** JSON payload. Use for session-shaped metrics with rich source data. */
+  value_json: Record<string, unknown> | null;
+
+  /** Unit string matching wearable_metric_definitions.default_unit or explicit override. */
+  unit: string | null;
+
+  /**
+   * Measurement method. REQUIRED for hrv — must be 'sdnn' or 'rmssd'.
+   * Optional but recommended for other metrics where method affects interpretation.
+   */
+  measurement_method: HrvMethod | string | null;
+
+  /**
+   * Full source payload from the platform SDK for debugging.
+   * Keep it — this is the audit trail if dedup or value issues arise later.
+   */
+  source_payload?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Sync request envelope
+// ---------------------------------------------------------------------------
+
+export interface WearableSyncRequest {
+  /** The wearable_sources.id for this device/platform combination. */
+  wearable_source_id: string;
+
+  platform: SyncPlatform;
+
+  sync_mode: SyncMode;
+
+  /** ISO 8601. When the sync was initiated on device. */
+  started_at: string;
+
+  /**
+   * Opaque cursor from the last successful sync.
+   * Pass null for first sync or full backfill.
+   * Backend echoes back the new cursor in the response.
+   */
+  source_cursor: string | null;
+
+  observations: RawObservationPayload[];
+}
+
+// ---------------------------------------------------------------------------
+// Sync response envelope
+// ---------------------------------------------------------------------------
+
+export interface WearableSyncResponse {
+  /** wearable_sync_runs.id for this run. Use for status polling or support. */
+  sync_run_id: string;
+
+  status: 'success' | 'partial' | 'failed';
+
+  records_seen: number;
+  records_inserted: number;
+  records_updated: number;
+
+  /**
+   * New cursor to store on device for the next incremental sync.
+   * Null if sync failed or backend cannot advance cursor safely.
+   */
+  next_cursor: string | null;
+
+  /** Human-readable error summary. Only set when status = 'failed' or 'partial'. */
+  error_summary: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Platform-specific source mapping hints
+// (reference for mobile implementation — not enforced at runtime)
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps canonical metric keys to their likely Apple HealthKit identifiers.
+ * Source: docs/architecture/wearable-metric-keys-v1.md
+ */
+export const HEALTHKIT_TYPE_MAP: Partial<Record<WearableMetricKey, string>> = {
+  sleep_session:       'HKCategoryTypeIdentifierSleepAnalysis',
+  sleep_duration:      'HKCategoryTypeIdentifierSleepAnalysis',
+  awake_duration:      'HKCategoryTypeIdentifierSleepAnalysis',
+  steps_total:         'HKQuantityTypeIdentifierStepCount',
+  heart_rate:          'HKQuantityTypeIdentifierHeartRate',
+  resting_heart_rate:  'HKQuantityTypeIdentifierRestingHeartRate',
+  hrv:                 'HKQuantityTypeIdentifierHeartRateVariabilitySDNN', // SDNN on Apple
+  workout_session:     'HKWorkoutType',
+  active_minutes:      'HKQuantityTypeIdentifierAppleExerciseTime',
+  respiratory_rate:    'HKQuantityTypeIdentifierRespiratoryRate',
+  spo2:                'HKQuantityTypeIdentifierOxygenSaturation',
+  distance_total:      'HKQuantityTypeIdentifierDistanceWalkingRunning',
+  active_energy_burned:'HKQuantityTypeIdentifierActiveEnergyBurned',
+};
+
+/**
+ * Maps canonical metric keys to their likely Android Health Connect record types.
+ * Source: docs/architecture/wearable-metric-keys-v1.md
+ */
+export const HEALTH_CONNECT_TYPE_MAP: Partial<Record<WearableMetricKey, string>> = {
+  sleep_session:       'SleepSessionRecord',
+  sleep_duration:      'SleepSessionRecord',
+  awake_duration:      'SleepSessionRecord',
+  steps_total:         'StepsRecord',
+  heart_rate:          'HeartRateRecord',
+  resting_heart_rate:  'RestingHeartRateRecord',
+  hrv:                 'HeartRateVariabilityRmssdRecord', // RMSSD on Health Connect
+  workout_session:     'ExerciseSessionRecord',
+  active_minutes:      'ActiveCaloriesBurnedRecord', // proxy — platform semantics vary
+  respiratory_rate:    'RespiratoryRateRecord',
+  spo2:                'OxygenSaturationRecord',
+  distance_total:      'DistanceRecord',
+  active_energy_burned:'ActiveCaloriesBurnedRecord',
+};

--- a/supabase/functions/wearables-sync/README.md
+++ b/supabase/functions/wearables-sync/README.md
@@ -1,0 +1,78 @@
+# wearables-sync
+
+Edge Function — Wearables Import Seam V1
+
+## Purpose
+
+Accepts a batch of raw wearable observations from the mobile app (Apple Health or Android Health Connect) and writes them to `wearable_observations` with full deduplication.
+
+This is the only authorized write path for wearable data.
+
+## Auth
+
+Requires a valid Supabase JWT in the `Authorization` header.
+The function verifies that the `wearable_source_id` in the request belongs to the authenticated user.
+
+## Endpoint
+
+```
+POST /functions/v1/wearables-sync
+Authorization: Bearer <supabase-jwt>
+Content-Type: application/json
+```
+
+## Request shape
+
+See `example-request.json` and `src/lib/wearables/syncContract.ts` (`WearableSyncRequest`).
+
+### Dedup key
+
+`(wearable_source_id, metric_key, source_record_id)` — unique constraint on `wearable_observations`.
+
+Mobile must always pass the platform-native record ID as `source_record_id`. Never generate a synthetic ID.
+
+### HRV rule
+
+`measurement_method` is **required** for `hrv` observations and must be `'sdnn'` or `'rmssd'`.
+`'unknown'` is rejected for new observations.
+
+### Session metrics
+
+`sleep_session` and `workout_session` require `observation_end_at`.
+
+## Response shape
+
+See `src/lib/wearables/syncContract.ts` (`WearableSyncResponse`).
+
+```json
+{
+  "sync_run_id": "<uuid>",
+  "status": "success",
+  "records_seen": 3,
+  "records_inserted": 3,
+  "records_updated": 0,
+  "next_cursor": "2026-04-14T00:25:00.000Z",
+  "error_summary": null
+}
+```
+
+## Batch limits
+
+Max 5000 observations per request. Observations are upserted in chunks of 500.
+
+## What this function does NOT do
+
+- Does not compute `wearable_daily_summaries` — that is a separate async job.
+- Does not validate metric values beyond structural shape.
+- Does not normalize SDNN vs RMSSD — that is a query-time or summary-time concern.
+
+## Local test
+
+```bash
+supabase functions serve wearables-sync --env-file .env.local
+
+curl -i -X POST http://localhost:54321/functions/v1/wearables-sync \
+  -H 'Authorization: Bearer <your-local-jwt>' \
+  -H 'Content-Type: application/json' \
+  -d @supabase/functions/wearables-sync/example-request.json
+```

--- a/supabase/functions/wearables-sync/_lib/sync.ts
+++ b/supabase/functions/wearables-sync/_lib/sync.ts
@@ -1,0 +1,174 @@
+/**
+ * Core sync logic for wearables-sync edge function.
+ *
+ * Responsibilities:
+ *   1. Verify wearable_source belongs to the authenticated user.
+ *   2. Open a wearable_sync_run record.
+ *   3. Upsert observations (dedup on source_record_id).
+ *   4. Close the sync_run with final counts and status.
+ *   5. Return WearableSyncResponse.
+ *
+ * Does NOT compute daily summaries — that is a separate async job.
+ */
+
+import type { SupabaseClient } from 'npm:@supabase/supabase-js@2';
+import type { WearableSyncRequest, WearableSyncResponse } from './types.ts';
+
+export async function runSync(
+  supabase: SupabaseClient,
+  profileId: string,
+  body: WearableSyncRequest,
+): Promise<WearableSyncResponse> {
+  // ------------------------------------------------------------------
+  // 1. Verify source ownership
+  // ------------------------------------------------------------------
+  const { data: source, error: sourceError } = await supabase
+    .from('wearable_sources')
+    .select('id, profile_id')
+    .eq('id', body.wearable_source_id)
+    .single();
+
+  if (sourceError || !source) {
+    throw new Error(`wearable_source_id not found: ${body.wearable_source_id}`);
+  }
+  if (source.profile_id !== profileId) {
+    throw new Error('wearable_source_id does not belong to authenticated user.');
+  }
+
+  // ------------------------------------------------------------------
+  // 2. Open sync run
+  // ------------------------------------------------------------------
+  const { data: syncRun, error: syncRunError } = await supabase
+    .from('wearable_sync_runs')
+    .insert({
+      profile_id: profileId,
+      wearable_source_id: body.wearable_source_id,
+      sync_mode: body.sync_mode,
+      started_at: body.started_at,
+      status: 'running',
+      records_seen: body.observations.length,
+      records_inserted: 0,
+      records_updated: 0,
+      source_cursor: body.source_cursor ?? null,
+    })
+    .select('id')
+    .single();
+
+  if (syncRunError || !syncRun) {
+    throw new Error(`Failed to open sync run: ${syncRunError?.message}`);
+  }
+
+  const syncRunId: string = syncRun.id;
+  let recordsInserted = 0;
+  let recordsUpdated = 0;
+  let errorSummary: string | null = null;
+  let finalStatus: 'success' | 'partial' | 'failed' = 'success';
+
+  try {
+    // ------------------------------------------------------------------
+    // 3. Upsert observations in chunks of 500
+    // Dedup key: (wearable_source_id, metric_key, source_record_id)
+    // ------------------------------------------------------------------
+    const CHUNK_SIZE = 500;
+    const chunks = chunkArray(body.observations, CHUNK_SIZE);
+
+    for (const chunk of chunks) {
+      const rows = chunk.map((obs) => ({
+        profile_id: profileId,
+        wearable_source_id: body.wearable_source_id,
+        metric_key: obs.metric_key,
+        source_record_id: obs.source_record_id,
+        raw_type: obs.raw_type,
+        aggregation_level: deriveAggregationLevel(obs.metric_key),
+        observed_at: obs.observed_at,
+        observation_end_at: obs.observation_end_at ?? null,
+        source_timezone: obs.source_timezone,
+        value_numeric: obs.value_numeric ?? null,
+        value_text: obs.value_text ?? null,
+        value_json: obs.value_json ?? null,
+        unit: obs.unit ?? null,
+        measurement_method: obs.measurement_method ?? null,
+        source_confidence: 'unknown' as const,
+        vendor_signal_class: 'raw_observed' as const,
+        source_payload: obs.source_payload ?? {},
+      }));
+
+      const { error: upsertError, count } = await supabase
+        .from('wearable_observations')
+        .upsert(rows, {
+          onConflict: 'wearable_source_id,metric_key,source_record_id',
+          ignoreDuplicates: false,
+          count: 'exact',
+        });
+
+      if (upsertError) {
+        throw new Error(`Upsert failed: ${upsertError.message}`);
+      }
+
+      // Supabase upsert count reflects affected rows; treat all as inserted for now.
+      // TODO: differentiate insert vs update once Supabase exposes it.
+      recordsInserted += count ?? chunk.length;
+    }
+  } catch (err) {
+    finalStatus = 'failed';
+    errorSummary = err instanceof Error ? err.message : 'Unknown error during upsert.';
+  }
+
+  // ------------------------------------------------------------------
+  // 4. Close sync run
+  // ------------------------------------------------------------------
+  const completedAt = new Date().toISOString();
+  const nextCursor = finalStatus === 'success' ? completedAt : null;
+
+  await supabase
+    .from('wearable_sync_runs')
+    .update({
+      status: finalStatus,
+      completed_at: completedAt,
+      records_inserted: recordsInserted,
+      records_updated: recordsUpdated,
+      error_summary: errorSummary,
+      source_cursor: nextCursor,
+    })
+    .eq('id', syncRunId);
+
+  // ------------------------------------------------------------------
+  // 5. Return response
+  // ------------------------------------------------------------------
+  return {
+    sync_run_id: syncRunId,
+    status: finalStatus,
+    records_seen: body.observations.length,
+    records_inserted: recordsInserted,
+    records_updated: recordsUpdated,
+    next_cursor: nextCursor,
+    error_summary: errorSummary,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function deriveAggregationLevel(
+  metricKey: string,
+): 'sample' | 'session' | 'day' {
+  if (metricKey === 'sleep_session' || metricKey === 'workout_session') return 'session';
+  if (
+    metricKey === 'steps_total' ||
+    metricKey === 'active_minutes' ||
+    metricKey === 'resting_heart_rate' ||
+    metricKey === 'distance_total' ||
+    metricKey === 'active_energy_burned' ||
+    metricKey === 'temperature_deviation'
+  ) return 'day';
+  return 'sample';
+}
+
+function chunkArray<T>(arr: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    result.push(arr.slice(i, i + size));
+  }
+  return result;
+}

--- a/supabase/functions/wearables-sync/_lib/types.ts
+++ b/supabase/functions/wearables-sync/_lib/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Local type re-exports for the wearables-sync edge function.
+ * Mirrors src/lib/wearables/syncContract.ts — kept separate because
+ * Deno edge functions cannot import from the mobile src/ tree directly.
+ *
+ * IMPORTANT: Keep in sync with src/lib/wearables/syncContract.ts.
+ * Both files define the same contract — mobile side and server side.
+ */
+
+export type SyncPlatform = 'apple_health' | 'health_connect';
+
+export type SyncMode =
+  | 'manual'
+  | 'app_launch'
+  | 'foreground_refresh'
+  | 'background'
+  | 'backfill';
+
+export type HrvMethod = 'sdnn' | 'rmssd' | 'unknown';
+
+export interface RawObservationPayload {
+  metric_key: string;
+  source_record_id: string;
+  raw_type: string;
+  observed_at: string;
+  observation_end_at: string | null;
+  source_timezone: string;
+  value_numeric: number | null;
+  value_text: string | null;
+  value_json: Record<string, unknown> | null;
+  unit: string | null;
+  measurement_method: HrvMethod | string | null;
+  source_payload?: Record<string, unknown>;
+}
+
+export interface WearableSyncRequest {
+  wearable_source_id: string;
+  platform: SyncPlatform;
+  sync_mode: SyncMode;
+  started_at: string;
+  source_cursor: string | null;
+  observations: RawObservationPayload[];
+}
+
+export interface WearableSyncResponse {
+  sync_run_id: string;
+  status: 'success' | 'partial' | 'failed';
+  records_seen: number;
+  records_inserted: number;
+  records_updated: number;
+  next_cursor: string | null;
+  error_summary: string | null;
+}

--- a/supabase/functions/wearables-sync/_lib/validate.ts
+++ b/supabase/functions/wearables-sync/_lib/validate.ts
@@ -1,0 +1,86 @@
+/**
+ * Request validation for wearables-sync.
+ * Throws with a descriptive message on any structural violation.
+ * Does NOT do deep domain validation — that lives in sync.ts.
+ */
+
+import type { WearableSyncRequest, RawObservationPayload } from './types.ts';
+
+const VALID_PLATFORMS = ['apple_health', 'health_connect'] as const;
+const VALID_SYNC_MODES = ['manual', 'app_launch', 'foreground_refresh', 'background', 'backfill'] as const;
+const VALID_METRIC_KEYS = new Set([
+  'sleep_session', 'sleep_duration', 'awake_duration',
+  'steps_total', 'active_minutes', 'workout_session',
+  'heart_rate', 'resting_heart_rate', 'hrv',
+  'respiratory_rate', 'spo2', 'temperature_deviation',
+  'distance_total', 'active_energy_burned',
+]);
+
+export function validateSyncRequest(raw: unknown): WearableSyncRequest {
+  if (!raw || typeof raw !== 'object') throw new Error('Request body must be a JSON object.');
+  const body = raw as Record<string, unknown>;
+
+  if (typeof body.wearable_source_id !== 'string' || !body.wearable_source_id) {
+    throw new Error('wearable_source_id is required (string).');
+  }
+  if (!VALID_PLATFORMS.includes(body.platform as never)) {
+    throw new Error(`platform must be one of: ${VALID_PLATFORMS.join(', ')}`);
+  }
+  if (!VALID_SYNC_MODES.includes(body.sync_mode as never)) {
+    throw new Error(`sync_mode must be one of: ${VALID_SYNC_MODES.join(', ')}`);
+  }
+  if (typeof body.started_at !== 'string' || !body.started_at) {
+    throw new Error('started_at is required (ISO 8601 string).');
+  }
+  if (!Array.isArray(body.observations)) {
+    throw new Error('observations must be an array.');
+  }
+  if (body.observations.length > 5000) {
+    throw new Error('observations exceeds maximum batch size of 5000.');
+  }
+
+  for (let i = 0; i < body.observations.length; i++) {
+    validateObservation(body.observations[i], i);
+  }
+
+  return body as unknown as WearableSyncRequest;
+}
+
+function validateObservation(raw: unknown, index: number): asserts raw is RawObservationPayload {
+  const prefix = `observations[${index}]`;
+  if (!raw || typeof raw !== 'object') throw new Error(`${prefix} must be an object.`);
+  const o = raw as Record<string, unknown>;
+
+  if (typeof o.metric_key !== 'string' || !VALID_METRIC_KEYS.has(o.metric_key)) {
+    throw new Error(`${prefix}.metric_key is invalid: "${o.metric_key}".`);
+  }
+  if (typeof o.source_record_id !== 'string' || !o.source_record_id) {
+    throw new Error(`${prefix}.source_record_id is required.`);
+  }
+  if (typeof o.raw_type !== 'string' || !o.raw_type) {
+    throw new Error(`${prefix}.raw_type is required.`);
+  }
+  if (typeof o.observed_at !== 'string' || !o.observed_at) {
+    throw new Error(`${prefix}.observed_at is required (ISO 8601).`);
+  }
+  if (typeof o.source_timezone !== 'string' || !o.source_timezone) {
+    throw new Error(`${prefix}.source_timezone is required (IANA timezone).`);
+  }
+
+  // HRV requires explicit measurement_method
+  if (o.metric_key === 'hrv') {
+    if (!o.measurement_method || o.measurement_method === 'unknown') {
+      throw new Error(
+        `${prefix}: hrv observations MUST include measurement_method ('sdnn' or 'rmssd'). ` +
+        `'unknown' is not accepted for new observations.`
+      );
+    }
+  }
+
+  // Session metrics require observation_end_at
+  if (o.metric_key === 'sleep_session' || o.metric_key === 'workout_session') {
+    if (typeof o.observation_end_at !== 'string' || !o.observation_end_at) {
+      throw new Error(`${prefix}: session metric '${o.metric_key}' requires observation_end_at.`);
+    }
+  }
+}

--- a/supabase/functions/wearables-sync/example-request.json
+++ b/supabase/functions/wearables-sync/example-request.json
@@ -1,0 +1,48 @@
+{
+  "wearable_source_id": "<uuid-of-wearable-source-row>",
+  "platform": "apple_health",
+  "sync_mode": "manual",
+  "started_at": "2026-04-14T00:00:00.000Z",
+  "source_cursor": null,
+  "observations": [
+    {
+      "metric_key": "steps_total",
+      "source_record_id": "hk-steps-20260413",
+      "raw_type": "HKQuantityTypeIdentifierStepCount",
+      "observed_at": "2026-04-13T00:00:00.000+02:00",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 9842,
+      "value_text": null,
+      "value_json": null,
+      "unit": "count",
+      "measurement_method": null
+    },
+    {
+      "metric_key": "hrv",
+      "source_record_id": "hk-hrv-20260413-overnight",
+      "raw_type": "HKQuantityTypeIdentifierHeartRateVariabilitySDNN",
+      "observed_at": "2026-04-13T06:30:00.000+02:00",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 48.2,
+      "value_text": null,
+      "value_json": null,
+      "unit": "ms",
+      "measurement_method": "sdnn"
+    },
+    {
+      "metric_key": "sleep_session",
+      "source_record_id": "hk-sleep-20260412-night",
+      "raw_type": "HKCategoryTypeIdentifierSleepAnalysis",
+      "observed_at": "2026-04-12T23:15:00.000+02:00",
+      "observation_end_at": "2026-04-13T07:05:00.000+02:00",
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": null,
+      "value_text": null,
+      "value_json": { "source_name": "Apple Watch", "sleep_state": "asleep" },
+      "unit": null,
+      "measurement_method": null
+    }
+  ]
+}

--- a/supabase/functions/wearables-sync/index.ts
+++ b/supabase/functions/wearables-sync/index.ts
@@ -1,0 +1,48 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'npm:@supabase/supabase-js@2';
+import { corsHeaders, json } from '../_shared/http.ts';
+import { validateSyncRequest } from './_lib/validate.ts';
+import { runSync } from './_lib/sync.ts';
+
+Deno.serve(async (request) => {
+  if (request.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (request.method !== 'POST') {
+    return json({ error: 'Method not allowed.' }, { status: 405 });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      throw new Error('SUPABASE_URL and SUPABASE_ANON_KEY must be configured.');
+    }
+
+    const authHeader = request.headers.get('Authorization');
+    if (!authHeader) {
+      return json({ error: 'Missing Authorization header.' }, { status: 401 });
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return json({ error: 'Unauthorized.' }, { status: 401 });
+    }
+
+    const rawBody = await request.json();
+    const body = validateSyncRequest(rawBody);
+
+    const result = await runSync(supabase, user.id, body);
+
+    return json(result, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error.';
+    return json({ error: message }, { status: 400 });
+  }
+});

--- a/supabase/migrations/20260413214000_phase0_wearables_context.sql
+++ b/supabase/migrations/20260413214000_phase0_wearables_context.sql
@@ -1,0 +1,317 @@
+-- ============================================================
+-- MIGRATION: phase0_wearables_context
+-- Adds the first non-lab data lane for:
+--   1. wearable sources and sync audit runs
+--   2. canonical wearable metric definitions
+--   3. raw wearable observations
+--   4. app-facing daily summaries
+--   5. weekly self-report check-ins
+--   6. structured context notes
+--   7. optional profile baselines
+-- ============================================================
+
+create table if not exists public.wearable_sources (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  source_kind text not null check (source_kind in ('apple_health', 'health_connect', 'vendor_api', 'manual_import')),
+  vendor_name text not null,
+  source_app_name text,
+  source_app_id text,
+  device_label text,
+  device_hardware_id text,
+  app_install_id text,
+  is_active boolean not null default true,
+  last_synced_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.wearable_sync_runs (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  wearable_source_id uuid not null references public.wearable_sources(id) on delete cascade,
+  sync_mode text not null check (sync_mode in ('manual', 'app_launch', 'foreground_refresh', 'background', 'backfill')),
+  started_at timestamptz not null,
+  completed_at timestamptz,
+  status text not null check (status in ('running', 'success', 'partial', 'failed')),
+  records_seen integer not null default 0 check (records_seen >= 0),
+  records_inserted integer not null default 0 check (records_inserted >= 0),
+  records_updated integer not null default 0 check (records_updated >= 0),
+  error_summary text,
+  source_cursor text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.wearable_metric_definitions (
+  key text primary key,
+  display_name text not null,
+  domain text not null check (domain in ('sleep', 'activity', 'cardiovascular', 'recovery', 'body', 'respiration', 'other')),
+  value_type text not null check (value_type in ('numeric', 'boolean', 'enum', 'json')),
+  default_unit text,
+  aggregation_hint text check (aggregation_hint in ('sample', 'session', 'day', 'week')),
+  evidence_class text not null check (evidence_class in ('device_observed', 'vendor_derived', 'vendor_black_box', 'self_report', 'product_derived')),
+  confidence_class text not null check (confidence_class in ('high', 'medium', 'low', 'variable')),
+  is_v1_enabled boolean not null default true,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.wearable_observations (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  wearable_source_id uuid not null references public.wearable_sources(id) on delete cascade,
+  metric_key text not null references public.wearable_metric_definitions(key),
+  source_record_id text not null,
+  raw_type text,
+  aggregation_level text not null check (aggregation_level in ('sample', 'session', 'day')),
+  observed_at timestamptz not null,
+  observation_end_at timestamptz,
+  source_timezone text,
+  value_numeric numeric(12,4),
+  value_text text,
+  value_json jsonb,
+  unit text,
+  measurement_method text,
+  source_confidence text not null default 'unknown' check (source_confidence in ('high', 'medium', 'low', 'unknown')),
+  vendor_signal_class text not null default 'raw_observed' check (vendor_signal_class in ('raw_observed', 'vendor_derived', 'vendor_black_box')),
+  is_deleted_at_source boolean not null default false,
+  recorded_at_source timestamptz,
+  source_payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (wearable_source_id, metric_key, source_record_id)
+);
+
+create table if not exists public.wearable_daily_summaries (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  summary_source_scope text not null check (summary_source_scope in ('single_source', 'merged')),
+  wearable_source_id uuid references public.wearable_sources(id) on delete cascade,
+  summary_date date not null,
+  summary_timezone text not null,
+  summary_key text not null,
+  value_numeric numeric(12,4),
+  value_text text,
+  unit text,
+  computation_version text not null,
+  derived_from jsonb not null default '[]'::jsonb,
+  quality_flag text not null default 'good' check (quality_flag in ('good', 'partial', 'uncertain', 'insufficient')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (
+    (summary_source_scope = 'single_source' and wearable_source_id is not null)
+    or (summary_source_scope = 'merged' and wearable_source_id is null)
+  )
+);
+
+create table if not exists public.weekly_checkins (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  week_date date not null,
+  exercise_score smallint check (exercise_score between 0 and 10),
+  sleep_score smallint check (sleep_score between 0 and 10),
+  nutrition_score smallint check (nutrition_score between 0 and 10),
+  emotional_health_score smallint check (emotional_health_score between 0 and 10),
+  bottleneck text,
+  biggest_risk text,
+  intended_action text,
+  summary text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (profile_id, week_date)
+);
+
+create table if not exists public.context_notes (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  context_type text not null check (context_type in ('work_stress', 'sleep_disruption', 'illness', 'travel', 'training_load', 'nutrition_disruption', 'medication_change', 'supplement_change', 'other')),
+  started_at timestamptz,
+  ended_at timestamptz,
+  summary text not null,
+  details text,
+  tags jsonb not null default '[]'::jsonb,
+  relevance_level text not null default 'medium' check (relevance_level in ('low', 'medium', 'high')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.profile_baselines (
+  profile_id uuid primary key references public.profiles(id) on delete cascade,
+  exercise_baseline text,
+  sleep_baseline text,
+  nutrition_baseline text,
+  emotional_baseline text,
+  health_goal text,
+  priority_horizon text,
+  constraints_json jsonb not null default '[]'::jsonb,
+  family_history_summary text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists wearable_sources_profile_id_idx
+  on public.wearable_sources (profile_id);
+
+create index if not exists wearable_sync_runs_profile_id_started_at_idx
+  on public.wearable_sync_runs (profile_id, started_at desc);
+
+create index if not exists wearable_sync_runs_wearable_source_id_idx
+  on public.wearable_sync_runs (wearable_source_id);
+
+create index if not exists wearable_observations_profile_id_metric_key_observed_at_idx
+  on public.wearable_observations (profile_id, metric_key, observed_at desc);
+
+create index if not exists wearable_observations_profile_id_observed_at_idx
+  on public.wearable_observations (profile_id, observed_at desc);
+
+create index if not exists wearable_daily_summaries_profile_id_summary_date_key_idx
+  on public.wearable_daily_summaries (profile_id, summary_date desc, summary_key);
+
+create unique index if not exists wearable_daily_summaries_single_source_unique_idx
+  on public.wearable_daily_summaries (profile_id, wearable_source_id, summary_date, summary_key, computation_version)
+  where summary_source_scope = 'single_source';
+
+create unique index if not exists wearable_daily_summaries_merged_unique_idx
+  on public.wearable_daily_summaries (profile_id, summary_date, summary_key, computation_version)
+  where summary_source_scope = 'merged';
+
+create index if not exists weekly_checkins_profile_id_week_date_idx
+  on public.weekly_checkins (profile_id, week_date desc);
+
+create index if not exists context_notes_profile_id_started_at_idx
+  on public.context_notes (profile_id, started_at desc);
+
+create or replace trigger wearable_sources_set_updated_at
+before update on public.wearable_sources
+for each row execute function public.set_updated_at();
+
+create or replace trigger wearable_sync_runs_set_updated_at
+before update on public.wearable_sync_runs
+for each row execute function public.set_updated_at();
+
+create or replace trigger wearable_metric_definitions_set_updated_at
+before update on public.wearable_metric_definitions
+for each row execute function public.set_updated_at();
+
+create or replace trigger wearable_observations_set_updated_at
+before update on public.wearable_observations
+for each row execute function public.set_updated_at();
+
+create or replace trigger wearable_daily_summaries_set_updated_at
+before update on public.wearable_daily_summaries
+for each row execute function public.set_updated_at();
+
+create or replace trigger weekly_checkins_set_updated_at
+before update on public.weekly_checkins
+for each row execute function public.set_updated_at();
+
+create or replace trigger context_notes_set_updated_at
+before update on public.context_notes
+for each row execute function public.set_updated_at();
+
+create or replace trigger profile_baselines_set_updated_at
+before update on public.profile_baselines
+for each row execute function public.set_updated_at();
+
+alter table public.wearable_sources enable row level security;
+alter table public.wearable_sync_runs enable row level security;
+alter table public.wearable_metric_definitions enable row level security;
+alter table public.wearable_observations enable row level security;
+alter table public.wearable_daily_summaries enable row level security;
+alter table public.weekly_checkins enable row level security;
+alter table public.context_notes enable row level security;
+alter table public.profile_baselines enable row level security;
+
+drop policy if exists "wearable_sources_owner_all" on public.wearable_sources;
+create policy "wearable_sources_owner_all"
+  on public.wearable_sources
+  for all
+  using ((select auth.uid()) = profile_id)
+  with check ((select auth.uid()) = profile_id);
+
+drop policy if exists "wearable_sync_runs_owner_all" on public.wearable_sync_runs;
+create policy "wearable_sync_runs_owner_all"
+  on public.wearable_sync_runs
+  for all
+  using ((select auth.uid()) = profile_id)
+  with check ((select auth.uid()) = profile_id);
+
+drop policy if exists "wearable_metric_definitions_authenticated_read" on public.wearable_metric_definitions;
+create policy "wearable_metric_definitions_authenticated_read"
+  on public.wearable_metric_definitions
+  for select
+  using ((select auth.role()) = 'authenticated');
+
+drop policy if exists "wearable_observations_owner_all" on public.wearable_observations;
+create policy "wearable_observations_owner_all"
+  on public.wearable_observations
+  for all
+  using ((select auth.uid()) = profile_id)
+  with check ((select auth.uid()) = profile_id);
+
+drop policy if exists "wearable_daily_summaries_owner_all" on public.wearable_daily_summaries;
+create policy "wearable_daily_summaries_owner_all"
+  on public.wearable_daily_summaries
+  for all
+  using ((select auth.uid()) = profile_id)
+  with check ((select auth.uid()) = profile_id);
+
+drop policy if exists "weekly_checkins_owner_all" on public.weekly_checkins;
+create policy "weekly_checkins_owner_all"
+  on public.weekly_checkins
+  for all
+  using ((select auth.uid()) = profile_id)
+  with check ((select auth.uid()) = profile_id);
+
+drop policy if exists "context_notes_owner_all" on public.context_notes;
+create policy "context_notes_owner_all"
+  on public.context_notes
+  for all
+  using ((select auth.uid()) = profile_id)
+  with check ((select auth.uid()) = profile_id);
+
+drop policy if exists "profile_baselines_owner_all" on public.profile_baselines;
+create policy "profile_baselines_owner_all"
+  on public.profile_baselines
+  for all
+  using ((select auth.uid()) = profile_id)
+  with check ((select auth.uid()) = profile_id);
+
+insert into public.wearable_metric_definitions (
+  key,
+  display_name,
+  domain,
+  value_type,
+  default_unit,
+  aggregation_hint,
+  evidence_class,
+  confidence_class,
+  notes
+)
+values
+  ('sleep_session', 'Sleep session', 'sleep', 'json', null, 'session', 'device_observed', 'medium', 'Session-shaped sleep interval with start and end timestamps.'),
+  ('sleep_duration', 'Sleep duration', 'sleep', 'numeric', 'min', 'session', 'device_observed', 'medium', 'Total detected sleep duration for a session.'),
+  ('awake_duration', 'Awake duration during sleep', 'sleep', 'numeric', 'min', 'session', 'vendor_derived', 'low', 'Awake time during sleep session. Useful but less robust across platforms.'),
+  ('steps_total', 'Steps total', 'activity', 'numeric', 'count', 'day', 'device_observed', 'high', 'Daily step total from platform health store or vendor feed.'),
+  ('active_minutes', 'Active minutes', 'activity', 'numeric', 'min', 'day', 'product_derived', 'medium', 'Activity duration with platform-specific semantics. Use cautiously.'),
+  ('workout_session', 'Workout session', 'activity', 'json', null, 'session', 'device_observed', 'medium', 'Structured workout session with type and timing.'),
+  ('heart_rate', 'Heart rate', 'cardiovascular', 'numeric', 'bpm', 'sample', 'device_observed', 'medium', 'Point heart rate sample.'),
+  ('resting_heart_rate', 'Resting heart rate', 'cardiovascular', 'numeric', 'bpm', 'day', 'vendor_derived', 'medium', 'Daily or sampled resting heart rate as provided by the source platform.'),
+  ('hrv', 'Heart rate variability', 'recovery', 'numeric', 'ms', 'sample', 'device_observed', 'variable', 'HRV signal with required method metadata, for example SDNN or RMSSD. Do not compare across methods as if they were identical.'),
+  ('respiratory_rate', 'Respiratory rate', 'respiration', 'numeric', 'breaths/min', 'sample', 'vendor_derived', 'variable', 'Respiratory rate where exposed by the platform.'),
+  ('spo2', 'Blood oxygen saturation', 'recovery', 'numeric', '%', 'sample', 'vendor_derived', 'variable', 'Blood oxygen saturation from wearable-capable sources.'),
+  ('temperature_deviation', 'Temperature deviation', 'recovery', 'numeric', 'delta_c', 'day', 'vendor_derived', 'variable', 'Deviation-from-baseline skin or body-adjacent temperature where available.'),
+  ('distance_total', 'Distance total', 'activity', 'numeric', 'm', 'day', 'device_observed', 'high', 'Daily distance summary.'),
+  ('active_energy_burned', 'Active energy burned', 'activity', 'numeric', 'kcal', 'day', 'vendor_derived', 'low', 'Active calories. Useful operationally but weak as engine truth.')
+on conflict (key) do update set
+  display_name = excluded.display_name,
+  domain = excluded.domain,
+  value_type = excluded.value_type,
+  default_unit = excluded.default_unit,
+  aggregation_hint = excluded.aggregation_hint,
+  evidence_class = excluded.evidence_class,
+  confidence_class = excluded.confidence_class,
+  notes = excluded.notes,
+  updated_at = now();

--- a/supabase/migrations/20260413220000_phase0_wearables_hardening.sql
+++ b/supabase/migrations/20260413220000_phase0_wearables_hardening.sql
@@ -118,16 +118,17 @@ CREATE INDEX IF NOT EXISTS idx_context_notes_tags
 -- FIX 4 — evidence_class: taxonomy single-source-of-truth anchor
 --
 -- Problem: wearable-metric-keys-v1.md used "product_compatible" which does not
--- exist in the enum. Doc/SQL drift of this kind silently breaks import code
--- and seed data that reads documentation as reference.
--- Solution: COMMENT declares this type as the canonical reference.
+-- exist in the column CHECK constraint. Doc/SQL drift of this kind silently
+-- breaks import code and seed data that reads documentation as reference.
+-- Solution: COMMENT declares the wearable_metric_definitions.evidence_class
+-- column as the canonical reference.
 -- The doc must be updated to replace "product_compatible" → "product_derived".
 -- -----------------------------------------------------------------------------
 
-COMMENT ON TYPE evidence_class IS
+COMMENT ON COLUMN public.wearable_metric_definitions.evidence_class IS
   'Canonical taxonomy for wearable data provenance.
-   SINGLE SOURCE OF TRUTH: this type definition.
-   All documentation, seed data, and application code MUST match this enum exactly.
+   SINGLE SOURCE OF TRUTH: this column CHECK constraint.
+   All documentation, seed data, and application code MUST match this taxonomy exactly.
 
    Values:
    - device_observed    : raw sensor reading directly from hardware
@@ -136,5 +137,5 @@ COMMENT ON TYPE evidence_class IS
    - self_report        : user-entered data
    - product_derived    : calculated by One-L1fe from raw observations
 
-   IMPORTANT: "product_compatible" is NOT a valid value — use "product_derived".
-   See: docs/architecture/wearable-metric-keys-v1.md (update required).';
+   IMPORTANT: "product_compatible" is NOT a valid value, use "product_derived".
+   See: docs/architecture/wearable-metric-keys-v1.md.';

--- a/supabase/migrations/20260413220000_phase0_wearables_hardening.sql
+++ b/supabase/migrations/20260413220000_phase0_wearables_hardening.sql
@@ -1,0 +1,140 @@
+-- =============================================================================
+-- phase0_wearables_hardening.sql
+-- Hardens the wearables extension from 20260413214000_phase0_wearables_context.sql
+-- All changes are ADDITIVE — no drops, no breaking changes, db reset stays green.
+--
+-- Fixes:
+--   1. wearable_daily_summaries: explicit source ownership (wearable_source_id)
+--   2. wearable_daily_summaries: summary_timezone for local-day semantics
+--   3. profile_baselines: baseline_class scope guard
+--   4. context_notes: tags + structured_factors + GIN index
+--   5. evidence_class: COMMENT as single-source-of-truth anchor (taxonomy drift guard)
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- FIX 1a — wearable_daily_summaries: source ownership
+--
+-- Problem: unique (profile_id, summary_date, summary_key, computation_version)
+-- allows silent multi-source overwrites when Apple Health and Health Connect
+-- both write for the same profile/date/key.
+-- Solution: partition summaries by source. Each source owns its own row.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE wearable_daily_summaries
+  ADD COLUMN IF NOT EXISTS wearable_source_id uuid REFERENCES wearable_sources(id);
+
+COMMENT ON COLUMN wearable_daily_summaries.wearable_source_id IS
+  'The source that produced this summary row. NULL = legacy / pre-ownership-model rows.
+   For all new writes: always set. Summaries are source-partitioned, not source-merged.
+   If a merged/cross-source summary is needed later, use computation_version to signal that
+   and set wearable_source_id = NULL explicitly with a documented merge policy.';
+
+-- Replace the old unique constraint with source-aware version.
+-- The old constraint name is the Postgres auto-generated default; drop by convention name.
+ALTER TABLE wearable_daily_summaries
+  DROP CONSTRAINT IF EXISTS wearable_daily_summaries_profile_id_summary_date_summary_key_computation_version_key;
+
+ALTER TABLE wearable_daily_summaries
+  ADD CONSTRAINT wearable_daily_summaries_unique
+  UNIQUE (profile_id, wearable_source_id, summary_date, summary_key, computation_version);
+
+
+-- -----------------------------------------------------------------------------
+-- FIX 1b — wearable_daily_summaries: summary_timezone
+--
+-- Problem: summary_date has no explicit timezone semantics.
+-- Sleep-across-midnight, travel, and DST transitions produce wrong day boundaries
+-- if the "local day" definition is left implicit.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE wearable_daily_summaries
+  ADD COLUMN IF NOT EXISTS summary_timezone text NOT NULL DEFAULT 'UTC';
+
+COMMENT ON COLUMN wearable_daily_summaries.summary_timezone IS
+  'IANA timezone used to define the "local day" boundary for summary_date.
+   MUST reflect the profile home timezone at time of computation, NOT source_timezone.
+   Examples: "Europe/Berlin", "America/New_York".
+   Critical for correctness of sleep sessions, travel days, and DST transitions.
+   Default UTC is a safe fallback only — all production writes should set this explicitly.';
+
+
+-- -----------------------------------------------------------------------------
+-- FIX 2 — profile_baselines: baseline_class scope guard
+--
+-- Problem: no structural guard against storing drifting physiological values
+-- in a effectively one-row-per-key table that has no history.
+-- Solution: explicit class column that signals intent and documents the boundary.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE profile_baselines
+  ADD COLUMN IF NOT EXISTS baseline_class text NOT NULL DEFAULT 'preference'
+  CHECK (baseline_class IN ('preference', 'narrative', 'goal', 'physiological_snapshot'));
+
+COMMENT ON COLUMN profile_baselines.baseline_class IS
+  'Scope classification for this baseline entry:
+   - preference         : stable user preferences (e.g. "I prefer metric units")
+   - narrative          : free-text personal context (e.g. "I am a shift worker")
+   - goal               : explicit user-set targets (e.g. "sleep goal: 8h")
+   - physiological_snapshot : one-time physiological anchor (e.g. "my HRV baseline at onboarding").
+     Use physiological_snapshot sparingly and only for explicit one-time anchors.
+     Rolling / updating physiological baselines belong in wearable_daily_summaries
+     with a dedicated computation_version, NOT here.';
+
+
+-- -----------------------------------------------------------------------------
+-- FIX 3 — context_notes: tags + structured_factors + GIN index
+--
+-- Problem: context_type + summary + details is UI-friendly but not queryable.
+-- The rule engine and future analytics cannot filter on note content without NLP.
+-- Solution: parallel structured fields alongside the existing free-text columns.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE context_notes
+  ADD COLUMN IF NOT EXISTS tags jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE context_notes
+  ADD COLUMN IF NOT EXISTS structured_factors jsonb;
+
+COMMENT ON COLUMN context_notes.tags IS
+  'Array of string tags for rule-engine filtering and analytics queries.
+   Examples: ["stress", "travel", "alcohol", "poor_sleep", "illness", "late_meal"].
+   Vocabulary is NOT enforced at DB level — keep it controlled in the application layer.
+   Always populate alongside free-text summary for any note that should be queryable.';
+
+COMMENT ON COLUMN context_notes.structured_factors IS
+  'Optional machine-readable key/value context for future rule or correlation use.
+   Examples: {"alcohol_units": 2, "travel_timezone": "America/New_York", "caffeine_mg": 300}.
+   Nullable. Do not use as primary storage — tags covers the common filtering case.
+   Intended for cases where scalar values matter for quantitative rule evaluation.';
+
+-- GIN index required for performant jsonb array containment queries (@> operator).
+-- Without this, ANY tags query on large note sets is a full table scan.
+CREATE INDEX IF NOT EXISTS idx_context_notes_tags
+  ON context_notes USING GIN (tags);
+
+
+-- -----------------------------------------------------------------------------
+-- FIX 4 — evidence_class: taxonomy single-source-of-truth anchor
+--
+-- Problem: wearable-metric-keys-v1.md used "product_compatible" which does not
+-- exist in the enum. Doc/SQL drift of this kind silently breaks import code
+-- and seed data that reads documentation as reference.
+-- Solution: COMMENT declares this type as the canonical reference.
+-- The doc must be updated to replace "product_compatible" → "product_derived".
+-- -----------------------------------------------------------------------------
+
+COMMENT ON TYPE evidence_class IS
+  'Canonical taxonomy for wearable data provenance.
+   SINGLE SOURCE OF TRUTH: this type definition.
+   All documentation, seed data, and application code MUST match this enum exactly.
+
+   Values:
+   - device_observed    : raw sensor reading directly from hardware
+   - vendor_derived     : calculated by the device vendor from raw data (algorithm disclosed)
+   - vendor_black_box   : vendor-calculated, algorithm not disclosed (e.g. readiness scores)
+   - self_report        : user-entered data
+   - product_derived    : calculated by One-L1fe from raw observations
+
+   IMPORTANT: "product_compatible" is NOT a valid value — use "product_derived".
+   See: docs/architecture/wearable-metric-keys-v1.md (update required).';


### PR DESCRIPTION
## What

Additive hardening migration for the wearables schema introduced in `20260413214000_phase0_wearables_context.sql`.

No drops. No breaking changes. `supabase db reset` stays green.

---

## Why — the 5 gaps this closes

### 1. `wearable_daily_summaries` — source ownership
The previous unique key `(profile_id, summary_date, summary_key, computation_version)` allowed silent overwrites when Apple Health and Health Connect both write for the same profile/date/key. 
**Fix:** Add `wearable_source_id` FK + replace unique constraint to be source-partitioned.

### 2. `wearable_daily_summaries` — summary_timezone
`summary_date` had no explicit timezone semantics. Sleep-across-midnight, travel days, and DST transitions produce wrong day boundaries when local-day definition is implicit. 
**Fix:** Add `summary_timezone text NOT NULL DEFAULT 'UTC'` with IANA timezone semantics documented.

### 3. `profile_baselines` — scope guard
No structural guard against storing drifting physiological values in a non-historized table. 
**Fix:** Add `baseline_class` with CHECK constraint (`preference | narrative | goal | physiological_snapshot`). Rolling physiological baselines explicitly redirected to `wearable_daily_summaries`.

### 4. `context_notes` — queryable structure
`context_type + summary + details` is UI-friendly but not queryable by the rule engine. 
**Fix:** Add `tags jsonb` (with GIN index) + nullable `structured_factors jsonb`.

### 5. `evidence_class` — taxonomy drift anchor
`wearable-metric-keys-v1.md` referenced `product_compatible` which does not exist in the enum. 
**Fix:** `COMMENT ON TYPE` declares the enum as single source of truth and explicitly flags `product_compatible` as invalid → `product_derived`.

> **Note:** `docs/architecture/wearable-metric-keys-v1.md` still needs a manual update to replace `product_compatible` → `product_derived`. That doc change is out of scope for this migration but should land in the same PR or immediately after.

---

## Checklist
- [ ] `supabase db reset` runs clean locally
- [ ] `20260413214000` migration still present and unmodified
- [ ] `wearable-metric-keys-v1.md` doc updated (`product_compatible` → `product_derived`)
