### PR TITLE
feat: compute-daily-summaries edge function (v1, single_source)

### DIFF
--- a/supabase/functions/compute-daily-summaries/README.md
+++ b/supabase/functions/compute-daily-summaries/README.md
@@ -1,0 +1,63 @@
+# compute-daily-summaries
+
+Edge function that materialises per-day aggregates from `wearable_observations` into `wearable_daily_summaries`.
+
+## When to call
+
+Call this function **after** a successful `wearables-sync` call, passing the same `wearable_source_id` and the date range that was just synced.
+
+The function is idempotent — it is safe to re-run for the same source and date range.
+
+## Request
+
+```json
+{
+  "wearable_source_id": "<uuid>",
+  "date_from": "2026-04-14",
+  "date_to": "2026-04-14"
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `wearable_source_id` | UUID string | ✅ | Must belong to the authenticated user |
+| `date_from` | YYYY-MM-DD | ❌ | Defaults to today (UTC) |
+| `date_to` | YYYY-MM-DD | ❌ | Defaults to `date_from`; max 31-day window |
+
+## Response
+
+```json
+{
+  "wearable_source_id": "<uuid>",
+  "date_from": "2026-04-14",
+  "date_to": "2026-04-14",
+  "summaries_written": 5,
+  "computation_version": "v1",
+  "error_summary": null
+}
+```
+
+## Error codes
+
+| `error` field | HTTP | Meaning |
+|---|---|---|
+| `MISSING_AUTH` | 401 | No `Authorization` header |
+| `UNAUTHORIZED` | 401 | Invalid or expired JWT |
+| `INVALID_REQUEST` | 400 | Validation failed — see `message` |
+| `COMPUTE_ERROR` | 500 | Aggregation or DB error |
+| `SERVER_MISCONFIGURED` | 500 | Missing env vars |
+
+## v1 scope
+
+- Only processes `aggregation_level = 'day'` observations.
+- `summary_source_scope` is always `single_source` — no cross-source merging.
+- One summary row per `(profile_id, wearable_source_id, summary_date, summary_key)`.
+- Multiple observations for the same `(date, metric_key)` are averaged; `quality_flag` is set to `partial`.
+- `summary_timezone` is hardcoded to `UTC` in v1 — per-source timezone handling is a v2 item.
+
+## Out of scope (v1)
+
+- `merged` scope across multiple sources
+- `sample` or `session` aggregation_level inputs
+- Derived metrics spanning multiple metric_keys
+- pg_cron auto-trigger (manual call after sync for now)

--- a/supabase/functions/compute-daily-summaries/_lib/compute.ts
+++ b/supabase/functions/compute-daily-summaries/_lib/compute.ts
@@ -1,0 +1,195 @@
+/**
+ * Core aggregation logic for compute-daily-summaries.
+ *
+ * v1 scope:
+ *   - Only processes aggregation_level = 'day' observations.
+ *   - summary_source_scope is always 'single_source'.
+ *   - One summary row per (profile_id, wearable_source_id, summary_date, summary_key).
+ *   - computation_version = 'v1'.
+ *   - Upserts are idempotent: safe to re-run after a sync.
+ *
+ * Out of scope for v1 (document, do not implement):
+ *   - 'merged' scope across sources.
+ *   - 'sample' or 'session' aggregation_level inputs.
+ *   - Derived metrics that span multiple metric_keys.
+ */
+
+import type { SupabaseClient } from 'npm:@supabase/supabase-js@2';
+import type {
+  ComputeDailySummariesRequest,
+  ComputeDailySummariesResponse,
+  DailySummaryRow,
+} from './types.ts';
+
+const COMPUTATION_VERSION = 'v1';
+
+export async function computeDailySummaries(
+  supabase: SupabaseClient,
+  profileId: string,
+  body: ComputeDailySummariesRequest,
+): Promise<ComputeDailySummariesResponse> {
+  // ------------------------------------------------------------------
+  // 1. Verify source ownership
+  // ------------------------------------------------------------------
+  const { data: source, error: sourceError } = await supabase
+    .from('wearable_sources')
+    .select('id, profile_id')
+    .eq('id', body.wearable_source_id)
+    .single();
+
+  if (sourceError || !source) {
+    throw new Error(`wearable_source_id not found: ${body.wearable_source_id}`);
+  }
+  if (source.profile_id !== profileId) {
+    throw new Error('wearable_source_id does not belong to authenticated user.');
+  }
+
+  const dateFrom = body.date_from!;
+  const dateTo = body.date_to!;
+
+  // ------------------------------------------------------------------
+  // 2. Fetch day-level observations for the requested window
+  // ------------------------------------------------------------------
+  const { data: observations, error: obsError } = await supabase
+    .from('wearable_observations')
+    .select(
+      'metric_key, observed_at, value_numeric, value_text, unit, source_timezone, source_record_id',
+    )
+    .eq('profile_id', profileId)
+    .eq('wearable_source_id', body.wearable_source_id)
+    .eq('aggregation_level', 'day')
+    .eq('is_deleted_at_source', false)
+    .gte('observed_at', `${dateFrom}T00:00:00Z`)
+    .lte('observed_at', `${dateTo}T23:59:59Z`);
+
+  if (obsError) {
+    throw new Error(`Failed to fetch observations: ${obsError.message}`);
+  }
+
+  if (!observations || observations.length === 0) {
+    return {
+      wearable_source_id: body.wearable_source_id,
+      date_from: dateFrom,
+      date_to: dateTo,
+      summaries_written: 0,
+      computation_version: COMPUTATION_VERSION,
+      error_summary: null,
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // 3. Group by (summary_date, metric_key) and derive summary rows
+  // For day-level observations, one observation = one summary in v1.
+  // Multiple observations for the same (date, metric_key) are averaged.
+  // ------------------------------------------------------------------
+  type GroupKey = string; // `${summary_date}::${metric_key}`
+  const groups = new Map<
+    GroupKey,
+    {
+      metric_key: string;
+      summary_date: string;
+      values: number[];
+      value_text: string | null;
+      unit: string | null;
+      source_timezone: string | null;
+      source_record_ids: string[];
+    }
+  >();
+
+  for (const obs of observations) {
+    const summaryDate = obs.observed_at.slice(0, 10);
+    const key: GroupKey = `${summaryDate}::${obs.metric_key}`;
+
+    if (!groups.has(key)) {
+      groups.set(key, {
+        metric_key: obs.metric_key,
+        summary_date: summaryDate,
+        values: [],
+        value_text: null,
+        unit: obs.unit ?? null,
+        source_timezone: obs.source_timezone ?? null,
+        source_record_ids: [],
+      });
+    }
+
+    const group = groups.get(key)!;
+    if (obs.value_numeric !== null) {
+      group.values.push(obs.value_numeric);
+    }
+    if (obs.value_text !== null) {
+      group.value_text = obs.value_text;
+    }
+    group.source_record_ids.push(obs.source_record_id);
+  }
+
+  // ------------------------------------------------------------------
+  // 4. Build upsert rows
+  // ------------------------------------------------------------------
+  const rows: DailySummaryRow[] = [];
+
+  for (const group of groups.values()) {
+    const hasNumeric = group.values.length > 0;
+    const avgNumeric = hasNumeric
+      ? group.values.reduce((a, b) => a + b, 0) / group.values.length
+      : null;
+
+    const qualityFlag: DailySummaryRow['quality_flag'] =
+      group.values.length === 1 ? 'good'
+      : group.values.length > 1 ? 'partial'
+      : group.value_text !== null ? 'good'
+      : 'insufficient';
+
+    rows.push({
+      summary_key: group.metric_key,
+      summary_date: group.summary_date,
+      value_numeric: avgNumeric !== null ? Math.round(avgNumeric * 10000) / 10000 : null,
+      value_text: group.value_text,
+      unit: group.unit,
+      quality_flag: qualityFlag,
+      derived_from: group.source_record_ids,
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // 5. Upsert into wearable_daily_summaries
+  // Conflict target: single_source unique index
+  //   (profile_id, wearable_source_id, summary_date, summary_key, computation_version)
+  // ------------------------------------------------------------------
+  const upsertRows = rows.map((r) => ({
+    profile_id: profileId,
+    wearable_source_id: body.wearable_source_id,
+    summary_source_scope: 'single_source' as const,
+    summary_date: r.summary_date,
+    summary_timezone: 'UTC',
+    summary_key: r.summary_key,
+    value_numeric: r.value_numeric,
+    value_text: r.value_text,
+    unit: r.unit,
+    computation_version: COMPUTATION_VERSION,
+    derived_from: r.derived_from,
+    quality_flag: r.quality_flag,
+  }));
+
+  const { error: upsertError } = await supabase
+    .from('wearable_daily_summaries')
+    .upsert(upsertRows, {
+      onConflict: 'profile_id,wearable_source_id,summary_date,summary_key,computation_version',
+      ignoreDuplicates: false,
+    });
+
+  if (upsertError) {
+    throw new Error(`Failed to upsert daily summaries: ${upsertError.message}`);
+  }
+
+  // ------------------------------------------------------------------
+  // 6. Return
+  // ------------------------------------------------------------------
+  return {
+    wearable_source_id: body.wearable_source_id,
+    date_from: dateFrom,
+    date_to: dateTo,
+    summaries_written: rows.length,
+    computation_version: COMPUTATION_VERSION,
+    error_summary: null,
+  };
+}

--- a/supabase/functions/compute-daily-summaries/_lib/types.ts
+++ b/supabase/functions/compute-daily-summaries/_lib/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Types for compute-daily-summaries edge function.
+ *
+ * Kept local to this function — not shared with mobile.
+ * The response shape is stable and suitable for the mobile layer to consume
+ * after a wearables-sync call.
+ */
+
+export interface ComputeDailySummariesRequest {
+  /** Source to compute summaries for. Must belong to the authenticated user. */
+  wearable_source_id: string;
+  /**
+   * Inclusive start date in YYYY-MM-DD format.
+   * Defaults to today in UTC if omitted.
+   */
+  date_from?: string;
+  /**
+   * Inclusive end date in YYYY-MM-DD format.
+   * Defaults to date_from (i.e. single day) if omitted.
+   * Maximum window: 31 days to prevent runaway queries.
+   */
+  date_to?: string;
+}
+
+export interface DailySummaryRow {
+  summary_key: string;
+  summary_date: string;
+  value_numeric: number | null;
+  value_text: string | null;
+  unit: string | null;
+  quality_flag: 'good' | 'partial' | 'uncertain' | 'insufficient';
+  derived_from: string[];
+}
+
+export interface ComputeDailySummariesResponse {
+  wearable_source_id: string;
+  date_from: string;
+  date_to: string;
+  summaries_written: number;
+  computation_version: string;
+  error_summary: string | null;
+}

--- a/supabase/functions/compute-daily-summaries/_lib/validate.ts
+++ b/supabase/functions/compute-daily-summaries/_lib/validate.ts
@@ -1,0 +1,43 @@
+import type { ComputeDailySummariesRequest } from './types.ts';
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_WINDOW_DAYS = 31;
+
+export function validateComputeRequest(raw: unknown): ComputeDailySummariesRequest {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('VALIDATION: Request body must be a JSON object.');
+  }
+
+  const body = raw as Record<string, unknown>;
+
+  if (typeof body['wearable_source_id'] !== 'string' || !body['wearable_source_id'].trim()) {
+    throw new Error('VALIDATION: wearable_source_id must be a non-empty string.');
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+  const dateFrom = body['date_from'] !== undefined ? body['date_from'] : today;
+  const dateTo = body['date_to'] !== undefined ? body['date_to'] : dateFrom;
+
+  if (typeof dateFrom !== 'string' || !ISO_DATE_RE.test(dateFrom)) {
+    throw new Error('VALIDATION: date_from must be in YYYY-MM-DD format.');
+  }
+  if (typeof dateTo !== 'string' || !ISO_DATE_RE.test(dateTo)) {
+    throw new Error('VALIDATION: date_to must be in YYYY-MM-DD format.');
+  }
+  if (dateFrom > dateTo) {
+    throw new Error('VALIDATION: date_from must be <= date_to.');
+  }
+
+  const msPerDay = 86_400_000;
+  const windowDays =
+    (new Date(dateTo).getTime() - new Date(dateFrom).getTime()) / msPerDay + 1;
+  if (windowDays > MAX_WINDOW_DAYS) {
+    throw new Error(`VALIDATION: Date window must not exceed ${MAX_WINDOW_DAYS} days.`);
+  }
+
+  return {
+    wearable_source_id: body['wearable_source_id'].trim(),
+    date_from: dateFrom,
+    date_to: dateTo,
+  };
+}

--- a/supabase/functions/compute-daily-summaries/index.ts
+++ b/supabase/functions/compute-daily-summaries/index.ts
@@ -1,0 +1,70 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'npm:@supabase/supabase-js@2';
+import { corsHeaders, json } from '../_shared/http.ts';
+import { validateComputeRequest } from './_lib/validate.ts';
+import { computeDailySummaries } from './_lib/compute.ts';
+
+/**
+ * compute-daily-summaries
+ *
+ * Triggered by the mobile app (or a cron/pg_cron job) after a successful
+ * wearables-sync call to materialise per-day aggregates into
+ * wearable_daily_summaries.
+ *
+ * Design constraints:
+ *   - Runs per profile_id + wearable_source_id + date range.
+ *   - Only processes aggregation_level = 'day' observations in v1.
+ *   - Uses upsert so it is safe to re-run (idempotent).
+ *   - Does NOT merge across sources — summary_source_scope is always
+ *     'single_source' in v1.
+ *   - Requires a valid JWT; the caller must be the profile owner.
+ */
+Deno.serve(async (request) => {
+  if (request.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (request.method !== 'POST') {
+    return json({ error: 'METHOD_NOT_ALLOWED', message: 'Only POST is accepted.' }, { status: 405 });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return json(
+        { error: 'SERVER_MISCONFIGURED', message: 'SUPABASE_URL and SUPABASE_ANON_KEY must be set.' },
+        { status: 500 },
+      );
+    }
+
+    const authHeader = request.headers.get('Authorization');
+    if (!authHeader) {
+      return json({ error: 'MISSING_AUTH', message: 'Missing Authorization header.' }, { status: 401 });
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return json({ error: 'UNAUTHORIZED', message: 'Invalid or expired token.' }, { status: 401 });
+    }
+
+    const rawBody = await request.json();
+    const body = validateComputeRequest(rawBody);
+
+    const result = await computeDailySummaries(supabase, user.id, body);
+
+    return json(result, { status: 200 });
+  } catch (error) {
+    const isValidation = error instanceof Error && error.message.startsWith('VALIDATION:');
+    const message = error instanceof Error ? error.message : 'Unknown error.';
+    return json(
+      { error: isValidation ? 'INVALID_REQUEST' : 'COMPUTE_ERROR', message },
+      { status: isValidation ? 400 : 500 },
+    );
+  }
+});


### PR DESCRIPTION
## What

Adds the `compute-daily-summaries` edge function — the missing piece that materialises `wearable_observations` → `wearable_daily_summaries`.

This is the "separate async job" explicitly referenced in `wearables-sync/sync.ts` comments.

## Files

```
supabase/functions/compute-daily-summaries/
  index.ts              — entry point, auth + routing
  README.md             — usage, request/response, error codes, v1 scope
  _lib/types.ts         — ComputeDailySummariesRequest / Response types
  _lib/validate.ts      — input validation (dates, window cap, source_id)
  _lib/compute.ts       — aggregation logic + wearable_daily_summaries upsert

packages/domain/
  wearableDailySummary.ts            — domain types (ComputeDailySummariesRequest,
                                       WearableDailySummary, ComputeDailySummariesResult)
                                       + pure aggregation (aggregateByMethod,
                                       METRIC_AGGREGATION_METHOD, aggregationMethodForKey)
  wearableDailySummary.assertions.ts — assertion suite: sum/mean/last/max,
                                       empty observations, unknown key fallback,
                                       v1 registry completeness

CHECKPOINT.md — updated last_verified 2026-04-17, reflects full wearable pipeline state
```

## Behaviour

- **Input**: `wearable_source_id` + optional `date_from` / `date_to` (max 31-day window)
- **Auth**: JWT required; source ownership verified before any DB read
- **Aggregation**: groups `aggregation_level = 'day'` observations by `(date, metric_key)`, averages multiple values, sets `quality_flag`
- **Upsert**: idempotent — safe to re-run for the same source+date range
- **Scope**: `single_source` only in v1; `merged` and session/sample inputs are explicitly out of scope
- **Error codes**: structured (`MISSING_AUTH`, `UNAUTHORIZED`, `INVALID_REQUEST`, `COMPUTE_ERROR`, `SERVER_MISCONFIGURED`)

## v1 scope constraints (intentional)

- Only `aggregation_level = 'day'` observations processed
- No new migration needed — `wearable_daily_summaries` already in `20260413214000_phase0_wearables_context.sql`
- No scheduled cron — mobile fires this after a successful sync
- `computation_version = 'v1'`

## How to smoke-test

```bash
curl -X POST https://<project>.supabase.co/functions/v1/compute-daily-summaries \
  -H "Authorization: Bearer <jwt>" \
  -H "Content-Type: application/json" \
  -d '{"wearable_source_id": "<uuid>", "date_from": "2026-04-14"}'
```

Expected: `{ "summaries_written": N, "computation_version": "v1", "error_summary": null }`

## Smoke test checklist

- [ ] Deploy via `supabase functions deploy compute-daily-summaries`
- [ ] Run a `wearables-sync` call to land at least one `aggregation_level = 'day'` observation
- [ ] POST with valid JWT → expect HTTP 200, `summaries_written` > 0
- [ ] Verify rows in `wearable_daily_summaries` with correct `profile_id`, `summary_date`, `value_numeric`
- [ ] Re-run same POST → idempotent, no duplicate rows
- [ ] POST with wrong JWT → expect 401
- [ ] POST with `wearable_source_id` belonging to different user → expect error

## Out of scope (follow-ups)

- Mobile `WearableSyncScreen.tsx` auto-trigger after sync (Front 3)
- `MOCK_APP_INSTALL_ID` replacement (blocked on real Garmin device)
- `as any` in `minimumSliceMobileIntegration.assertions.ts` (blocked on type stabilisation)
- Android Health Connect wiring (outside repo)

## Risk

Low — additive. No changes to existing functions or migrations.