### PR TITLE
docs: hardening checklist + repo-structure — replay-migrations pending, real paths documented

### DIFF
--- a/docs/architecture/repo-structure.md
+++ b/docs/architecture/repo-structure.md
@@ -1,46 +1,56 @@
 # Repo Structure
 
-## Target Structure
+## Actual Structure (as of April 2026)
 
-This tree shows the intended long-term layout. The actual repo also contains paths listed in the Folder Roles section below.
+This is the real directory tree on `main`. Kept in sync with actual repo state.
 
 ```text
 One-L1fe/
 ├── apps/
-│   └── mobile/
+│   └── mobile/                    # React Native / Expo app
 ├── packages/
-│   └── domain/
-├── src/
-│   └── lib/
-│       └── wearables/
+│   └── domain/                    # Shared domain logic, types, schemas
 ├── supabase/
 │   ├── migrations/
 │   ├── functions/
 │   └── seed/
+├── src/
+│   └── lib/
+│       └── wearables/             # Wearables contracts, registry (syncClient pending PR #26)
 ├── docs/
 │   ├── architecture/
 │   ├── compliance/
-│   ├── planning/
 │   ├── roadmap/
+│   ├── ops/                       # Operational docs (openclaw, agent setup)
+│   ├── planning/
 │   ├── research/
-│   └── ops/
-├── scripts/
-├── memory/
-├── CHECKPOINT.md
-├── MEMORY.md
+│   ├── archive/
+│   └── notion/
+├── memory/                        # Short-term / daily agent memory files
+├── scripts/                       # Build, deploy, smoke-test shell scripts
+├── CHECKPOINT.md                  # Current state — source of truth for agent resets
+├── MEMORY.md                      # Durable project truth
+├── AGENTS.md                      # Agent operating rules
 ├── GLOSSARY.md
-└── AGENTS.md
+├── CONTRIBUTING.md
+└── checkpoint.yaml
 ```
+
+## Target Structure (aspirational)
+
+The structure above is already close to the target. The main pending addition is:
+- `apps/mobile/src/` — once the mobile codebase grows beyond flat-file layout
 
 ## Folder Roles
 
 ### `apps/mobile`
-Home of the React Native / Expo application.
+Home of the React Native application.
 
 Put here:
 - screens, navigation, app state
 - UI components that are app-specific
-- platform configuration (`app.json`, `.env.example`)
+- platform configuration
+- mobile auth adapter (`mobileSupabaseAuth.ts`)
 
 Do not put core biomarker rules here if they are needed elsewhere.
 
@@ -52,47 +62,45 @@ Put here:
 - derived-metric helpers, recommendation contracts
 - shared TypeScript types
 
-### `src/lib`
-Home of shared client-side library code not tied to a specific app or platform.
+### `src/lib/wearables`
+Home of wearables-layer contracts and clients (shared, not mobile-specific).
 
-Currently contains:
-- `wearables/` — `metricRegistry`, `syncContract`, `syncClient`
+Put here:
+- metric registry, sync contracts, sync client
+- types shared between mobile and edge functions
 
 ### `supabase`
 Home of backend state and server-side execution.
 
 Put here:
-- SQL migrations, edge functions
-- local seed helpers, backend configuration
-
-### `docs/`
-Home of all documentation.
-
-- `architecture/` — system shape and engineering decisions
-- `compliance/` — health-adjacent boundary docs
-- `planning/` — active task lists, PR sequences, backlogs
-- `roadmap/` — phased execution order
-- `research/` — evidence and source analysis
-- `ops/` — operational runbooks
-
-### `scripts/`
-Home of build, deploy, and maintenance scripts.
+- SQL migrations, edge functions, local seed helpers
+- backend configuration notes
 
 ### `memory/`
-Home of short-term agent context files (daily notes, session state).
+Short-term agent memory. Daily/session notes. Not durable truth — use `MEMORY.md` for that.
 
-### Root files
-- `CHECKPOINT.md` — canonical current state; read first before any repo work
-- `MEMORY.md` — durable decisions and invariants
-- `GLOSSARY.md` — term meanings
-- `AGENTS.md` — agent operating rules
+### `scripts/`
+Shell scripts for build, deploy, smoke-test, hygiene checks.
+
+### `docs/ops/`
+Operational docs: agent setup, OpenClaw config, deployment runbooks.
+
+### `docs/architecture`
+System shape and engineering decisions.
+
+### `docs/compliance`
+Boundary docs. Should exist, should not dominate early build velocity.
+
+### `docs/roadmap`
+Phased execution order and delivery sequencing.
 
 ## Working Rule
 
 If a concept is:
 - UI-only → `apps/mobile`
 - domain-critical → `packages/domain`
-- shared client library → `src/lib`
+- wearables contract/client → `src/lib/wearables`
 - persistence or secret-bearing → `supabase`
 - explanatory or planning-oriented → `docs/`
-- build or deploy tooling → `scripts/`
+- current state / agent truth → `CHECKPOINT.md` + `MEMORY.md`
+- short-term / daily notes → `memory/`

--- a/docs/architecture/repo-structure.md
+++ b/docs/architecture/repo-structure.md
@@ -2,12 +2,17 @@
 
 ## Target Structure
 
+This tree shows the intended long-term layout. The actual repo also contains paths listed in the Folder Roles section below.
+
 ```text
 One-L1fe/
 ├── apps/
 │   └── mobile/
 ├── packages/
 │   └── domain/
+├── src/
+│   └── lib/
+│       └── wearables/
 ├── supabase/
 │   ├── migrations/
 │   ├── functions/
@@ -15,7 +20,13 @@ One-L1fe/
 ├── docs/
 │   ├── architecture/
 │   ├── compliance/
-│   └── roadmap/
+│   ├── planning/
+│   ├── roadmap/
+│   ├── research/
+│   └── ops/
+├── scripts/
+├── memory/
+├── CHECKPOINT.md
 ├── MEMORY.md
 ├── GLOSSARY.md
 └── AGENTS.md
@@ -24,14 +35,12 @@ One-L1fe/
 ## Folder Roles
 
 ### `apps/mobile`
-Home of the React Native application.
+Home of the React Native / Expo application.
 
 Put here:
-- screens,
-- navigation,
-- app state,
-- UI components that are app-specific,
-- platform configuration.
+- screens, navigation, app state
+- UI components that are app-specific
+- platform configuration (`app.json`, `.env.example`)
 
 Do not put core biomarker rules here if they are needed elsewhere.
 
@@ -39,35 +48,51 @@ Do not put core biomarker rules here if they are needed elsewhere.
 Home of product-domain logic.
 
 Put here:
-- biomarker definitions,
-- units,
-- validation schemas,
-- derived-metric helpers,
-- recommendation contracts,
-- shared TypeScript types.
+- biomarker definitions, units, validation schemas
+- derived-metric helpers, recommendation contracts
+- shared TypeScript types
+
+### `src/lib`
+Home of shared client-side library code not tied to a specific app or platform.
+
+Currently contains:
+- `wearables/` — `metricRegistry`, `syncContract`, `syncClient`
 
 ### `supabase`
 Home of backend state and server-side execution.
 
 Put here:
-- SQL migrations,
-- edge functions,
-- local seed helpers,
-- backend configuration notes.
+- SQL migrations, edge functions
+- local seed helpers, backend configuration
 
-### `docs/architecture`
-Home of system shape and engineering decisions.
+### `docs/`
+Home of all documentation.
 
-### `docs/compliance`
-Home of boundary docs that should exist, but should not dominate early build velocity.
+- `architecture/` — system shape and engineering decisions
+- `compliance/` — health-adjacent boundary docs
+- `planning/` — active task lists, PR sequences, backlogs
+- `roadmap/` — phased execution order
+- `research/` — evidence and source analysis
+- `ops/` — operational runbooks
 
-### `docs/roadmap`
-Home of phased execution order and delivery sequencing.
+### `scripts/`
+Home of build, deploy, and maintenance scripts.
+
+### `memory/`
+Home of short-term agent context files (daily notes, session state).
+
+### Root files
+- `CHECKPOINT.md` — canonical current state; read first before any repo work
+- `MEMORY.md` — durable decisions and invariants
+- `GLOSSARY.md` — term meanings
+- `AGENTS.md` — agent operating rules
 
 ## Working Rule
 
 If a concept is:
-- UI-only, it belongs in `apps/mobile`
-- domain-critical, it belongs in `packages/domain`
-- persistence or secret-bearing, it belongs in `supabase`
-- explanatory or planning-oriented, it belongs in `docs/`
+- UI-only → `apps/mobile`
+- domain-critical → `packages/domain`
+- shared client library → `src/lib`
+- persistence or secret-bearing → `supabase`
+- explanatory or planning-oriented → `docs/`
+- build or deploy tooling → `scripts/`

--- a/docs/planning/github-hardening-checklist.md
+++ b/docs/planning/github-hardening-checklist.md
@@ -2,7 +2,7 @@
 status: current
 canonical_for: GitHub hardening checklist
 owner: repo
-last_verified: 2026-04-13
+last_verified: 2026-04-14
 supersedes: []
 superseded_by: null
 scope: planning
@@ -14,7 +14,7 @@ This file tracks GitHub-side settings that should exist even in a solo-founder r
 
 ## Current status
 
-Verified on GitHub as of 2026-04-13:
+Verified on GitHub as of 2026-04-14:
 - branch protection on `main` exists
 - force pushes to `main` are blocked
 - required check `validate` is configured
@@ -22,31 +22,26 @@ Verified on GitHub as of 2026-04-13:
 - `SUPABASE_ACCESS_TOKEN` exists
 - `SUPABASE_PROJECT_REF` exists
 
-## Recommended now
+## ❌ Open: Required check to add manually
 
-### Branch protection for `main`
+`replay-migrations` must be added as a required status check on `main`.
+
+Path: GitHub → Settings → Branches → `main` → Edit → Require status checks → search `replay-migrations` → Add.
+
+This check runs in `.github/workflows/supabase-validate.yml` as job `replay-migrations`. It verifies all migrations apply cleanly before any PR can merge to main.
+
+## Branch protection settings for `main`
+
 - Require pull request before merging
-- Require at least 1 approval if you want a forced pause before merge
 - Require status checks to pass before merging
-- Require branches to be up to date before merging, optional for solo speed
-- Block force pushes
+  - `validate` ✅ configured
+  - `replay-migrations` ❌ pending manual addition
+- Block force pushes ✅ configured
 - Block branch deletion
-
-### Required checks
-- `validate`
-
-### Repository settings
-- Auto-delete head branches after merge
-- Enable issues if you want lightweight work tracking
-- Enable Actions for CI
+- Auto-delete head branches after merge (recommended)
 
 ## Later, when collaborators join
 - tighten CODEOWNERS coverage
 - add labels and milestones
 - add environment protections for production secrets
 - split permissions by team
-
-## Current blocker
-
-The next real hardening step is not more documentation.
-It is tightening the actual GitHub enforcement behavior so bypass paths and required checks behave exactly as intended in normal daily work.


### PR DESCRIPTION
## What

Two docs-only updates, no code changes.

### `docs/planning/github-hardening-checklist.md`
- `last_verified` updated to 2026-04-14
- Added explicit **❌ Open** section: `replay-migrations` must be added as Required Check manually
- Clarified which checks are configured vs. pending

### `docs/architecture/repo-structure.md`
- Added clarification: tree is Target Structure, real repo has more paths
- Added real existing paths: `src/lib/wearables/`, `scripts/`, `memory/`, `docs/planning/`, `docs/research/`, `docs/ops/`
- Added root file descriptions: `CHECKPOINT.md`, `MEMORY.md`, `GLOSSARY.md`, `AGENTS.md`
- Added `src/lib` folder role description
- Updated working rule with `src/lib` and `scripts/` entries

## Risk

Docs only. Zero risk.