### PR TITLE
chore: repo-wide audit — gitignore, package.json, checkpoint.yaml, AGENTS, MEMORY, CONTRIBUTING, dependabot, session notes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
 
+  - package-ecosystem: "npm"
+    directory: "/apps/mobile"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,26 @@
+# dependencies
 node_modules/
+
+# build output
 dist/
+
+# environment files
+.env
+.env.local
+.env.*.local
+
+# Expo / React Native
+.expo/
+*.orig.*
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/
+
+# Supabase local
+supabase/.branches/
+supabase/.temp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 status: current
 canonical_for: agent working rules
 owner: repo
-last_verified: 2026-04-13
+last_verified: 2026-04-14
 supersedes: []
 superseded_by: null
 scope: repo
@@ -28,8 +28,8 @@ Read deeper files only on demand:
 ### 1. Verdict first
 Lead with the conclusion, recommendation, or decision. Supporting detail comes after.
 
-### 2. Epistemisch transparent
-State what is known, what is inferred, what is uncertain, and what still needs evidence.
+### 2. Epistemically transparent
+State what is known, what is inferred, what is uncertain, and what still needs evidence. Label claims as [Fact], [Inference], or [Assumption] when the distinction matters.
 
 ### 3. Fail fast
 Surface blockers, contradictions, missing inputs, or unsafe assumptions immediately instead of hiding them behind polished wording.
@@ -37,68 +37,52 @@ Surface blockers, contradictions, missing inputs, or unsafe assumptions immediat
 ### 4. Keep the memory layer current
 If a durable project assumption changes, update `MEMORY.md` and, if needed, `GLOSSARY.md` in the same workstream.
 
+### 5. Prefer the smallest safe delta
+Do not rewrite what works. Make targeted changes. Leave unrelated code untouched.
+
+### 6. Verify before claiming done
+A task is done when it is verifiable — deployed, tested, merged, or confirmed via a live check. Not when it is written.
+
 ## Agent Roles
 
 ### Phase 1: Orchestrator
 Primary role during setup and early execution.
 
 Responsibilities:
-- maintain project structure,
-- sequence work,
-- keep docs aligned,
-- identify blockers and decisions,
-- protect scope and compliance boundaries.
+- maintain project structure
+- sequence work
+- keep docs aligned
+- identify blockers and decisions
+- protect scope and compliance boundaries
 
 ### Phase 2: Analyst + Advisor
 Role activated once product data models, evidence patterns, and recommendation surfaces exist.
 
 Responsibilities:
-- analyze patterns,
-- summarize evidence,
-- produce bounded recommendations,
-- make uncertainty explicit,
-- defer diagnosis or treatment framing.
+- analyze patterns
+- summarize evidence
+- produce bounded recommendations
+- make uncertainty explicit
+- defer diagnosis or treatment framing
 
 ## Safety Escalation
 
 ### Safety States
 
 #### Green
-Low-risk work.
-Examples:
-- documentation,
-- architecture planning,
-- code organization,
-- non-sensitive product implementation.
+Low-risk work. Examples: documentation, architecture planning, code organization, non-sensitive product implementation.
 
 Action: proceed normally.
 
 #### Amber
-Health-adjacent or policy-sensitive work.
-Examples:
-- recommendation wording,
-- biomarker interpretation logic,
-- compliance-sensitive copy,
-- schema changes that will eventually touch protected health data.
+Health-adjacent or policy-sensitive work. Examples: recommendation wording, biomarker interpretation logic, compliance-sensitive copy, schema changes that will eventually touch protected health data.
 
-Action:
-- slow down,
-- expose assumptions,
-- cite evidence when possible,
-- keep the product and intended-use boundary explicit,
-- ask for review when uncertainty is material.
+Action: slow down, expose assumptions, cite evidence when possible, keep the product and intended-use boundary explicit, ask for review when uncertainty is material.
 
 #### Red
-Unsafe or out-of-bounds work.
-Examples:
-- diagnosis or treatment requests,
-- emergency or symptom-triage behavior,
-- committing raw health data,
-- requests to disable sandboxing,
-- installing or trusting unvetted third-party agent assets,
-- major compliance uncertainty with no human decision.
+Unsafe or out-of-bounds work. Examples: diagnosis or treatment requests, emergency or symptom-triage behavior, committing raw health data, requests to disable sandboxing, installing or trusting unvetted third-party agent assets, major compliance uncertainty with no human decision.
 
-Action: stop, escalate to a human, and do not continue that path autonomously.
+Action: stop, escalate to a human, do not continue that path autonomously.
 
 ## Red Lines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 status: current
 canonical_for: contribution workflow
 owner: repo
-last_verified: 2026-04-13
+last_verified: 2026-04-14
 supersedes: []
 superseded_by: null
 scope: repo
@@ -16,13 +16,14 @@ This repo is currently run with a solo-founder workflow. The goal is speed with 
 
 - `main` is the stable branch.
 - Do not stack unrelated work in one change.
-- Prefer short-lived branches such as `feat/...`, `fix/...`, or `chore/...`.
+- Prefer short-lived branches such as `feat/...`, `fix/...`, `docs/...`, or `chore/...`.
 - Merge only after checks pass and the change description is clear.
 
 Example branch names:
 - `feat/mobile-client-wrapper`
 - `fix/minimum-slice-contract`
 - `chore/repo-hygiene`
+- `docs/checkpoint-update`
 
 ## Source of truth
 
@@ -30,6 +31,7 @@ Use the repo layers on purpose:
 
 - `README.md` = project entry point
 - `CHECKPOINT.md` = current state and next step
+- `checkpoint.yaml` = machine-readable current state (same source of truth as CHECKPOINT.md)
 - `MEMORY.md` = durable project assumptions and decisions
 - `memory/` = short-term working notes and daily continuity
 - `docs/architecture/` = technical decisions that should stay true over time
@@ -50,6 +52,7 @@ AI is welcome here, but repo trust matters more than speed.
 - Prefer one focused change at a time.
 - Keep architecture tied to the next implementable step.
 - If AI proposes stronger health claims than the current boundary allows, reject them.
+- When AI writes RLS policies, ensure `(select auth.uid())` is used instead of bare `auth.uid()` on joined tables.
 
 ## Minimum review checklist
 
@@ -58,8 +61,9 @@ Before merging a meaningful change:
 1. Can I explain what changed in plain language?
 2. Does `npm run typecheck` pass?
 3. Does `npm run test:domain` pass?
-4. If behavior changed, did I update the right source-of-truth doc?
-5. Did I avoid adding raw personal health data or unsafe health claims?
+4. If a mobile change: does `npm run typecheck:mobile` pass?
+5. If behavior changed, did I update the right source-of-truth doc?
+6. Did I avoid adding raw personal health data or unsafe health claims?
 
 ## Pull requests and issues
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -2,7 +2,7 @@
 status: current
 canonical_for: durable project assumptions
 owner: repo
-last_verified: 2026-04-13
+last_verified: 2026-04-14
 supersedes: []
 superseded_by: null
 scope: repo
@@ -32,9 +32,10 @@ Important: this file stores project memory, not personal health records. Do not 
 - Keep the Priority Score framed as a bounded prioritization aid, not a clinical risk score.
 - Keep shared domain imports cross-runtime safe when the same files must run under both Node-based tests and Supabase Edge Functions.
 - For the first real mobile app seam, use Expo scaffolding first and avoid `expo-router` until there is a concrete navigation need.
-- The Expo scaffold under `apps/mobile/` uses a real Supabase auth session through `mobileSupabaseAuth.ts` (`auth.getSession()`), with real Expo env keys for Supabase URL and anon key instead of auth placeholders.
+- The Expo scaffold under `apps/mobile/` uses a real Supabase auth session through `mobileSupabaseAuth.ts` with `AsyncStorage`-backed session persistence, `autoRefreshToken: true`, and `persistSession: true`. Auth is accessed via `getFreshAccessToken()` as the central token path.
 - Keep the mobile auth/session architecture thin and explicit: `useAuthSession.ts` owns auth-state subscription, `LoginScreen.tsx` owns sign-in UI, `MinimumSliceScreen.tsx` owns the signed-in minimum-slice form, and `App.tsx` stays a small auth-gate shell that wires those pieces together.
 - For wearables, keep daily summaries explicit about source scope (`single_source` vs `merged`) and timezone semantics, and keep context notes minimally structured with tags instead of free text only.
+- `getFreshAccessToken()` is the canonical mobile token path. Any code that needs a JWT (e.g. `wearablesSyncClient`) must use `getFreshAccessToken()`, not `client.auth.getSession()` directly.
 
 ## Durable repo operations posture
 
@@ -51,6 +52,7 @@ Important: this file stores project memory, not personal health records. Do not 
 - The minimum-slice hosted backend seam is green only when all are true: hosted migrations match repo, RLS/policies are live, the function is deployed, and an authenticated hosted smoke call returns 200 with writes succeeding.
 - Use `docs/compliance/data-handling-and-redaction.md` as the canonical operational policy for fixtures, screenshots, logs, smoke tests, and copied examples.
 - Use `docs/ops/openclaw.md` as the canonical OpenClaw operating guide for startup order, promotion rules, and short-term memory usage.
+- RLS policies on `lab_result_entries` and `interpreted_entries` use `(select auth.uid())` — not `auth.uid()` directly — to prevent per-row re-evaluation. This pattern must be followed for all future RLS policies on joined tables.
 
 ## Startup rule
 

--- a/checkpoint.yaml
+++ b/checkpoint.yaml
@@ -1,14 +1,23 @@
 status: current
-last_verified: 2026-04-13
+last_verified: 2026-04-14
 repo: gzug/One-L1fe
 branch: main
-current_seam: expo mobile seam over shared minimum-slice controller and hosted Supabase function
+current_seam: mobile seam hardening in progress (PR #36); wearables sync client on PR #26
 next_best_steps:
-  - wire a real app auth session source into the mobile controller path
-  - validate one authenticated Expo submission against the hosted endpoint
-  - choose the next thin mobile seam after the first hosted path is confirmed
+  - merge PR #36 (mobile seam hardening) after CI green
+  - merge PR #35 (CHECKPOINT docs update)
+  - merge PR #37 (hardening checklist + repo-structure docs)
+  - merge PR #25 (compute-daily-summaries) after replay-migrations Required Check added
+  - merge PR #26 (wearables sync client) after PR #36 on main
+  - build PR #29 HealthKit reader after PR #26 on main
 active_blockers:
-  - mobile auth still uses environment placeholders instead of a real app session source
+  - replay-migrations not yet set as Required Check on main (manual GitHub Settings step)
+  - Leaked Password Protection disabled in Supabase Auth (manual Dashboard step)
+completed_since_last_checkpoint:
+  - RLS auth initplan performance fixed on lab_result_entries + interpreted_entries (8 policies, migration 20260414024917)
+  - PR #36 opened for mobile seam hardening
+  - PR #35 opened for CHECKPOINT master audit
+  - PR #37 opened for hardening checklist + repo-structure docs
 startup_truth:
   - CHECKPOINT.md
   - README.md only for broad orientation

--- a/memory/2026-04-14.md
+++ b/memory/2026-04-14.md
@@ -1,0 +1,33 @@
+# 2026-04-14
+
+## Session notes
+
+- Repo-wide audit completed. All automatisierbare fixes committed in `chore/repo-wide-audit-fixes`.
+- RLS performance migration applied to production: `20260414024917_fix_rls_auth_initplan_lab_result_entries_interpreted_entries`. 8 WARN → resolved.
+- PR #36 open: mobile seam hardening (deps, AsyncStorage auth, getFreshAccessToken, mobile CI).
+- PR #35 open: CHECKPOINT master audit (docs only).
+- PR #37 open: hardening checklist + repo-structure real paths (docs only).
+- PR #24: superseded by #35, to be closed.
+- `checkpoint.yaml` updated to reflect current state.
+- `MEMORY.md`: added `getFreshAccessToken()` canonical pattern + RLS `(select auth.uid())` rule.
+- `CONTRIBUTING.md`: added `typecheck:mobile` to review checklist, `docs/` branch type, `checkpoint.yaml` to source-of-truth table, RLS pattern note.
+- `.gitignore` extended: `.env`, `.expo/`, `.DS_Store`, `.vscode/`, `supabase/.temp/`.
+- `dependabot.yml`: added `apps/mobile` npm ecosystem entry.
+- `package.json`: added `typecheck:mobile` script.
+- `AGENTS.md`: added principles 5 (smallest safe delta) and 6 (verify before claiming done), fixed typo (Epistemisch → Epistemically).
+
+## Open tasks for next session
+
+1. Manual: add `replay-migrations` as Required Check on main (GitHub Settings)
+2. Manual: enable Leaked Password Protection (Supabase Auth Dashboard)
+3. Merge PR #36 after CI green
+4. Merge PR #35, #37 (docs only, no risk)
+5. Close PR #24
+6. Merge PR #25 after point 1
+7. Merge PR #26 after PR #36 on main
+8. Build PR #29 (HealthKit reader)
+
+## Open questions
+
+- After PR #36 lands and first live Expo session is verified with `getFreshAccessToken()`, is `LoginScreen.tsx` kept as UI-direct login or moved to a controller?
+- Which signed-in screen or flow comes immediately after the HealthKit smoke test succeeds?

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "typecheck:mobile": "npm --prefix apps/mobile run typecheck",
     "build:domain": "tsc -p tsconfig.json",
     "test:domain": "npm run build:domain && node dist/packages/domain/runMinimumSliceAssertions.js",
     "generate:evidence-sql": "npm run build:domain && node scripts/generate-evidence-registry-sql.js",


### PR DESCRIPTION
## What

Repo-wide audit sweep. All changes are low-risk correctness/completeness fixes. No logic or behavior changes.

## File-by-file

### `.gitignore` — extended
- Added: `.env`, `.env.local`, `.env.*.local` — env files were not ignored
- Added: `.expo/`, `*.orig.*` — Expo/RN artifacts
- Added: `.DS_Store`, `Thumbs.db` — OS noise
- Added: `.vscode/`, `.idea/` — IDE noise
- Added: `supabase/.branches/`, `supabase/.temp/` — Supabase local artifacts

### `package.json` — +1 script
- Added `typecheck:mobile` — runs `npm --prefix apps/mobile run typecheck`
- Closes the "Optional" gap from the audit list

### `checkpoint.yaml` — fully updated
- `last_verified` → `2026-04-14`
- `current_seam` → accurate (PR #36 in progress, wearables on PR #26)
- `next_best_steps` → full PR merge sequence
- `active_blockers` → 2 manual steps documented
- `completed_since_last_checkpoint` → RLS migration + PRs opened

### `AGENTS.md` — 2 new principles + typo
- Added Principle 5: **Prefer the smallest safe delta**
- Added Principle 6: **Verify before claiming done**
- Fixed typo: `Epistemisk` → `Epistemically`
- `last_verified` → `2026-04-14`

### `MEMORY.md` — 2 new durable rules
- Added: `getFreshAccessToken()` is the canonical mobile token path — any code needing a JWT must use it
- Added: RLS policies on joined tables must use `(select auth.uid())` — documents the pattern enforced by migration `20260414024917`
- `last_verified` → `2026-04-14`

### `CONTRIBUTING.md` — 4 additions
- Added `docs/...` to branch naming examples
- Added `checkpoint.yaml` to source-of-truth table
- Added step 4b: `typecheck:mobile` to minimum review checklist for mobile changes
- Added RLS policy note to AI-assisted development rules
- `last_verified` → `2026-04-14`

### `.github/dependabot.yml` — +1 ecosystem
- Added `apps/mobile` npm ecosystem entry — mobile deps were not covered by Dependabot at all

### `memory/2026-04-14.md` — new daily session file
- Captures today's session: RLS migration, PRs opened, all fixes committed
- Open tasks for next session
- Open questions to carry forward

## Risk

Zero production risk. All changes are docs, config, or scripts. No compiled code, no migrations, no edge functions.