### PR TITLE
docs(architecture): update repo-structure — actual vs target tree, all real dirs

### DIFF
--- a/docs/architecture/repo-structure.md
+++ b/docs/architecture/repo-structure.md
@@ -1,25 +1,45 @@
 # Repo Structure
 
-## Target Structure
+## Actual Structure (as of April 2026)
+
+This is the real directory tree on `main`. Kept in sync with actual repo state.
 
 ```text
 One-L1fe/
 ├── apps/
-│   └── mobile/
+│   └── mobile/                    # React Native / Expo app
 ├── packages/
-│   └── domain/
+│   └── domain/                    # Shared domain logic, types, schemas
 ├── supabase/
 │   ├── migrations/
 │   ├── functions/
 │   └── seed/
+├── src/
+│   └── lib/
+│       └── wearables/             # Wearables contracts, registry (syncClient pending PR #26)
 ├── docs/
 │   ├── architecture/
 │   ├── compliance/
-│   └── roadmap/
-├── MEMORY.md
+│   ├── roadmap/
+│   ├── ops/                       # Operational docs (openclaw, agent setup)
+│   ├── planning/
+│   ├── research/
+│   ├── archive/
+│   └── notion/
+├── memory/                        # Short-term / daily agent memory files
+├── scripts/                       # Build, deploy, smoke-test shell scripts
+├── CHECKPOINT.md                  # Current state — source of truth for agent resets
+├── MEMORY.md                      # Durable project truth
+├── AGENTS.md                      # Agent operating rules
 ├── GLOSSARY.md
-└── AGENTS.md
+├── CONTRIBUTING.md
+└── checkpoint.yaml
 ```
+
+## Target Structure (aspirational)
+
+The structure above is already close to the target. The main pending addition is:
+- `apps/mobile/src/` — once the mobile codebase grows beyond flat-file layout
 
 ## Folder Roles
 
@@ -27,11 +47,10 @@ One-L1fe/
 Home of the React Native application.
 
 Put here:
-- screens,
-- navigation,
-- app state,
-- UI components that are app-specific,
-- platform configuration.
+- screens, navigation, app state
+- UI components that are app-specific
+- platform configuration
+- mobile auth adapter (`mobileSupabaseAuth.ts`)
 
 Do not put core biomarker rules here if they are needed elsewhere.
 
@@ -39,35 +58,49 @@ Do not put core biomarker rules here if they are needed elsewhere.
 Home of product-domain logic.
 
 Put here:
-- biomarker definitions,
-- units,
-- validation schemas,
-- derived-metric helpers,
-- recommendation contracts,
-- shared TypeScript types.
+- biomarker definitions, units, validation schemas
+- derived-metric helpers, recommendation contracts
+- shared TypeScript types
+
+### `src/lib/wearables`
+Home of wearables-layer contracts and clients (shared, not mobile-specific).
+
+Put here:
+- metric registry, sync contracts, sync client
+- types shared between mobile and edge functions
 
 ### `supabase`
 Home of backend state and server-side execution.
 
 Put here:
-- SQL migrations,
-- edge functions,
-- local seed helpers,
-- backend configuration notes.
+- SQL migrations, edge functions, local seed helpers
+- backend configuration notes
+
+### `memory/`
+Short-term agent memory. Daily/session notes. Not durable truth — use `MEMORY.md` for that.
+
+### `scripts/`
+Shell scripts for build, deploy, smoke-test, hygiene checks.
+
+### `docs/ops/`
+Operational docs: agent setup, OpenClaw config, deployment runbooks.
 
 ### `docs/architecture`
-Home of system shape and engineering decisions.
+System shape and engineering decisions.
 
 ### `docs/compliance`
-Home of boundary docs that should exist, but should not dominate early build velocity.
+Boundary docs. Should exist, should not dominate early build velocity.
 
 ### `docs/roadmap`
-Home of phased execution order and delivery sequencing.
+Phased execution order and delivery sequencing.
 
 ## Working Rule
 
 If a concept is:
-- UI-only, it belongs in `apps/mobile`
-- domain-critical, it belongs in `packages/domain`
-- persistence or secret-bearing, it belongs in `supabase`
-- explanatory or planning-oriented, it belongs in `docs/`
+- UI-only → `apps/mobile`
+- domain-critical → `packages/domain`
+- wearables contract/client → `src/lib/wearables`
+- persistence or secret-bearing → `supabase`
+- explanatory or planning-oriented → `docs/`
+- current state / agent truth → `CHECKPOINT.md` + `MEMORY.md`
+- short-term / daily notes → `memory/`


### PR DESCRIPTION
## What

Updates `docs/architecture/repo-structure.md` to reflect the actual repo on `main`.

## Changes

- Renames `## Target Structure` section to `## Actual Structure (as of April 2026)` — the file was describing a simplified target, not the real tree
- Adds all missing real directories to the tree:
  - `src/lib/wearables/` (wearables contracts, registry)
  - `memory/` (short-term agent memory)
  - `scripts/` (build, deploy, smoke-test scripts)
  - `docs/ops/`, `docs/planning/`, `docs/research/`, `docs/archive/`, `docs/notion/`
  - `CHECKPOINT.md`, `CONTRIBUTING.md`, `checkpoint.yaml`
- Adds a `## Target Structure (aspirational)` section explaining what's still to come
- Expands folder role descriptions for new dirs (`memory/`, `scripts/`, `docs/ops/`, `src/lib/wearables/`)
- Updates Working Rule table to include wearables layer and CHECKPOINT/MEMORY distinction

## Why

The previous version was verifably incomplete against the real repo tree. Any agent starting fresh would have a wrong map of the repo.

## Risk

Docs only. No code changes.