### PR TITLE
fix(edge-functions): add missing edge-runtime import, compact JSON response

### DIFF
--- a/supabase/functions/_shared/http.ts
+++ b/supabase/functions/_shared/http.ts
@@ -5,7 +5,7 @@ export const corsHeaders: Record<string, string> = {
 };
 
 export function json(body: unknown, init?: ResponseInit): Response {
-  return new Response(JSON.stringify(body, null, 2), {
+  return new Response(JSON.stringify(body), {
     ...init,
     headers: {
       'Content-Type': 'application/json',

--- a/supabase/functions/save-minimum-slice-interpretation/index.ts
+++ b/supabase/functions/save-minimum-slice-interpretation/index.ts
@@ -1,3 +1,4 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 import { createClient } from 'npm:@supabase/supabase-js@2';
 
 import {


### PR DESCRIPTION
## What

Two small but correct fixes to the production edge functions.

## Changes

### `supabase/functions/save-minimum-slice-interpretation/index.ts`
- Added missing `import 'jsr:@supabase/functions-js/edge-runtime.d.ts'`
- `wearables-sync/index.ts` already had this import — `save-minimum-slice-interpretation` was missing it
- Without this import, the Deno edge runtime type declarations (`Deno.serve`, etc.) rely on ambient inference rather than explicit declaration — can cause issues on Supabase deploy pipeline version bumps

### `supabase/functions/_shared/http.ts`
- Removed pretty-print indent from `JSON.stringify(body, null, 2)` → `JSON.stringify(body)`
- API response bodies should never be pretty-printed in production — adds unnecessary bytes to every response payload
- Both edge functions use this shared helper, so both benefit immediately

## Risk

Minimal. Both changes are additive/neutral in behavior. No logic changed.