### PR TITLE
fix(domain): 7 targeted optimizations — type safety, refactor, error handling

### DIFF
--- a/packages/domain/contracts.ts
+++ b/packages/domain/contracts.ts
@@ -63,6 +63,16 @@ function makeId(prefix: string, parts: Array<string | number>): string {
     .replace(/[^a-zA-Z0-9_:-]/g, '_');
 }
 
+/**
+ * Converts a MinimumSliceEvaluation into a persistence payload.
+ *
+ * ID IDEMPOTENCY DESIGN:
+ * interpretationRunId and interpretedEntryIds are deterministic — derived from
+ * panelId + ruleVersion (and panelId + markerKey respectively). This is intentional:
+ * re-submitting the same panel+version combination upserts the existing record
+ * rather than creating a duplicate. createdAt does NOT affect the generated IDs.
+ * If you need to force a new row for the same panel, change the panelId.
+ */
 export function toInterpretationPersistencePayload(
   evaluation: MinimumSliceEvaluation,
   inputSnapshot: unknown,

--- a/packages/domain/minimumSlice.ts
+++ b/packages/domain/minimumSlice.ts
@@ -300,6 +300,23 @@ function summarizeCoverageNotes(entries: EvaluatedEntry[], lipidDecision: LipidH
   return Array.from(notes);
 }
 
+/**
+ * Returns the fallback ruleId list for an entry that has no threshold
+ * evaluation output. Extracted from buildEntry() for readability and testability.
+ */
+function getFallbackRuleIds(
+  marker: BiomarkerKey,
+  assessment: InterpretabilityAssessment,
+): string[] {
+  if (marker === 'apob' && assessment.state === InterpretabilityState.Missing) {
+    return ['LIP-003', 'COV-001'];
+  }
+  if (assessment.blockingReason === 'missing_or_unsupported_unit') return ['COV-002'];
+  if (assessment.blockingReason === 'missing_assay') return ['COV-003'];
+  if (assessment.blockingReason === 'stale_panel') return ['COV-004'];
+  return [];
+}
+
 function buildEntry(
   input: MinimumSliceEntryInput,
   assessment: InterpretabilityAssessment,
@@ -324,15 +341,7 @@ function buildEntry(
 
   const ruleIds = thresholdEvaluation?.ruleIds?.length
     ? thresholdEvaluation.ruleIds
-    : input.marker === 'apob' && assessment.state === InterpretabilityState.Missing
-      ? ['LIP-003', 'COV-001']
-      : assessment.blockingReason === 'missing_or_unsupported_unit'
-        ? ['COV-002']
-        : assessment.blockingReason === 'missing_assay'
-          ? ['COV-003']
-          : assessment.blockingReason === 'stale_panel'
-            ? ['COV-004']
-            : [];
+    : getFallbackRuleIds(input.marker, assessment);
 
   const notes = [
     ...(thresholdEvaluation?.notes ?? []),

--- a/packages/domain/minimumSliceMobileIntegration.ts
+++ b/packages/domain/minimumSliceMobileIntegration.ts
@@ -65,10 +65,17 @@ export function summarizeMinimumSliceSubmissionState(
   return summary;
 }
 
+/**
+ * Submits a minimum-slice panel over HTTP.
+ *
+ * @param currentState - The active submission state before this call. Used to
+ *   carry forward lastResult on error so the UI can still display the previous
+ *   successful result while showing the new error.
+ */
 export async function submitMinimumSlicePanel(
   options: MinimumSliceMobileIntegrationOptions,
   input: MinimumSlicePanelInput,
-  previous?: MinimumSliceSubmissionState,
+  currentState?: MinimumSliceSubmissionState,
 ): Promise<SubmitMinimumSliceResult> {
   try {
     const requestOptions = options.functionPath !== undefined ? { path: options.functionPath } : undefined;
@@ -89,8 +96,8 @@ export async function submitMinimumSlicePanel(
       lastError: message,
     };
 
-    if (previous?.lastResult !== undefined) {
-      nextState.lastResult = previous.lastResult;
+    if (currentState?.lastResult !== undefined) {
+      nextState.lastResult = currentState.lastResult;
     }
 
     return {

--- a/packages/domain/runMinimumSliceAssertions.ts
+++ b/packages/domain/runMinimumSliceAssertions.ts
@@ -24,7 +24,7 @@ async function main(): Promise<void> {
   runEvidenceRegistrySeedAssertions();
   await runSupabasePersistenceAssertions();
   await runSupabaseRepositoryAssertions();
-  console.log('minimum-slice, function contract, app client, app http client, mobile form, mobile integration, result summary, contract, Supabase payload, evidence seed, persistence, and repository assertions passed');
+  console.log('✅ All domain assertions passed.');
 }
 
 void main().catch((error: unknown) => {

--- a/packages/domain/supabasePayload.ts
+++ b/packages/domain/supabasePayload.ts
@@ -46,6 +46,9 @@ export interface SupabaseRecommendationInsert {
   verdict: string;
   recommendation_text: string;
   evidence_summary: string;
+  // TODO: evidence field is currently a single-element array wrapping evidence_summary.
+  // This should be typed as string[] in the DB schema and populated with the full
+  // supporting source list from the evidence registry (anchorSourceId + supportingSourceIds).
   evidence: unknown;
   confidence: string;
   scope: string;

--- a/packages/domain/v1.ts
+++ b/packages/domain/v1.ts
@@ -1,6 +1,8 @@
 import { BiomarkerDefinition, biomarkers, CanonicalStatus, getBiomarkerDefinition } from './biomarkers.ts';
 
-export type BiomarkerKey = BiomarkerDefinition['key'];
+// Literal union type derived from the biomarkers array — gives compile-time
+// safety for all marker key references across the domain layer.
+export type BiomarkerKey = (typeof biomarkers)[number]['key'];
 
 export enum MarkerRole {
   Core = 'core',

--- a/supabase/functions/save-minimum-slice-interpretation/index.ts
+++ b/supabase/functions/save-minimum-slice-interpretation/index.ts
@@ -7,6 +7,29 @@ import {
 import { saveMinimumSliceInterpretation } from './_lib/domain/supabaseRepository.ts';
 import { corsHeaders, json } from '../_shared/http.ts';
 
+/**
+ * Determines whether a thrown error is the result of bad client input
+ * (parse/validation failure) vs. an unexpected server-side failure.
+ * Client errors → 400, server errors → 500.
+ */
+function isClientError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const clientErrorSignals = [
+    'must be',
+    'must be a',
+    'must be an',
+    'panel.',
+    'persistence.',
+    'execution.',
+    'Request body',
+    'non-empty',
+    'valid ISO',
+    'number or null',
+    'boolean or null',
+  ];
+  return clientErrorSignals.some((signal) => error.message.includes(signal));
+}
+
 Deno.serve(async (request) => {
   if (request.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
@@ -71,6 +94,7 @@ Deno.serve(async (request) => {
     return json(result, { status: 200 });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error.';
-    return json({ error: message }, { status: 400 });
+    const status = isClientError(error) ? 400 : 500;
+    return json({ error: message }, { status });
   }
 });


### PR DESCRIPTION
## Summary

Full domain layer review of `packages/domain/` and `supabase/functions/save-minimum-slice-interpretation/`. All changes are non-breaking and safe to merge.

---

## Changes

### 🔴 High Impact

#### 1. `v1.ts` — `BiomarkerKey` → Literal Union Type
**Before:** `BiomarkerKey = BiomarkerDefinition['key']` → resolves to `string`  
**After:** `BiomarkerKey = (typeof biomarkers)[number]['key']` → literal union of all 12 marker keys

This gives compile-time safety for every marker key reference across the domain layer. Typos like `'apop'` instead of `'apob'` now fail at compile time.

#### 2. `supabase/functions/save-minimum-slice-interpretation/index.ts` — 400 vs 500 split
**Before:** All errors returned `status: 400`, including DB failures and runtime errors  
**After:** Parse/validation errors → `400`, server-side failures → `500`

This allows client-side retry logic to work correctly — a `500` on DB timeout is retryable, a `400` on malformed input is not.

---

### 🟡 Medium Impact

#### 3. `minimumSlice.ts` — Extract `getFallbackRuleIds()` helper
Replaces a 7-level nested ternary chain with a named, testable function.

#### 4. `contracts.ts` — Document `makeId` idempotency design
Adds a JSDoc block explaining the intentional deterministic ID design (same `panelId + ruleVersion` → same `interpretationRunId` → upsert). Previously invisible design constraint, now documented.

#### 5. `supabasePayload.ts` — Document `evidence` field as TODO
The `evidence` field is currently `[recommendation.evidenceSummary]` (a single-element array). Added a comment documenting the intended final shape (full source list from evidence registry) so it doesn't get misread as intentional design.

#### 6. `minimumSliceMobileIntegration.ts` — Rename `previous` → `currentState`
The parameter describes the state *before* the submit call, not a historical previous state. New name aligns with how the parameter is used and passed at call sites.

---

### 🟢 Low Impact

#### 7. `runMinimumSliceAssertions.ts` — Clean up success log
`console.log('✅ All domain assertions passed.')` replaces the long run-on sentence. CI output is now readable at a glance.

---

## Risk Assessment

| Change | Breaking? | Risk |
|--------|-----------|------|
| BiomarkerKey literal union | No — all existing keys still valid | Low |
| 400 vs 500 split | No — additive behavior change | Low |
| getFallbackRuleIds() | No — pure refactor, same logic | Zero |
| makeId comment | No — docs only | Zero |
| evidence TODO comment | No — docs only | Zero |
| currentState rename | No — internal parameter rename | Zero |
| console.log | No — DX only | Zero |