### PR TITLE
feat(wearables): add wearable-source-resolve provisioning seam

### DIFF
--- a/apps/mobile/src/hooks/useWearableSource.ts
+++ b/apps/mobile/src/hooks/useWearableSource.ts
@@ -1,0 +1,52 @@
+import {
+  createGarminProvisioningRequest,
+  provisionWearableSourceForCurrentUser,
+} from '../../wearableSourceProvisioning';
+import type {
+  ResolveWearableSourceOptions,
+  ResolveWearableSourceRequest,
+  ResolveWearableSourceResponse,
+} from '../../wearableSourceProvisioning';
+
+export const WearableConnectState = {
+  Idle: 'Idle',
+  Loading: 'Loading',
+  Success: 'Success',
+  AlreadyLinked: 'AlreadyLinked',
+  Error: 'Error',
+} as const;
+
+export type WearableConnectStateValue =
+  (typeof WearableConnectState)[keyof typeof WearableConnectState];
+
+export type WearableConnectResult = {
+  wearable_source_id: string;
+  created: boolean;
+};
+
+export type WearableConnectStateProps = {
+  state: WearableConnectStateValue | null;
+  error?: string;
+  result?: WearableConnectResult;
+};
+
+function toConnectResult(response: ResolveWearableSourceResponse): WearableConnectResult {
+  return {
+    wearable_source_id: response.wearable_source_id,
+    created: response.created,
+  };
+}
+
+export async function fetchWearableSource(
+  request: ResolveWearableSourceRequest,
+  options?: ResolveWearableSourceOptions,
+): Promise<WearableConnectResult> {
+  return toConnectResult(await provisionWearableSourceForCurrentUser(request, options));
+}
+
+export async function fetchGarminWearableSource(
+  appInstallId: string,
+  options?: ResolveWearableSourceOptions,
+): Promise<WearableConnectResult> {
+  return fetchWearableSource(createGarminProvisioningRequest({ app_install_id: appInstallId }), options);
+}

--- a/apps/mobile/wearableSourceProvisioning.ts
+++ b/apps/mobile/wearableSourceProvisioning.ts
@@ -1,0 +1,144 @@
+import { ONE_L1FE_SUPABASE_PROJECT_REF, getOneL1feSupabaseUrl } from './minimumSliceHostedConfig.ts';
+import { FreshAccessTokenResult, getFreshAccessToken } from './mobileSupabaseAuth.ts';
+
+export type WearableSourceKind =
+  | 'apple_health'
+  | 'health_connect'
+  | 'vendor_api'
+  | 'manual_import';
+
+export const GARMIN_SOURCE_KIND: WearableSourceKind = 'vendor_api';
+export const GARMIN_VENDOR_NAME = 'garmin';
+export const GARMIN_CONNECT_SOURCE_APP_ID = 'com.garmin.android.apps.connectmobile';
+export const GARMIN_CONNECT_SOURCE_APP_NAME = 'Garmin Connect';
+
+export interface ResolveWearableSourceRequest {
+  source_kind: WearableSourceKind;
+  vendor_name: string;
+  source_app_id?: string | null;
+  source_app_name?: string | null;
+  device_hardware_id?: string | null;
+  device_label?: string | null;
+  app_install_id?: string | null;
+}
+
+export interface ResolveWearableSourceResponse {
+  wearable_source_id: string;
+  profile_id: string;
+  source_kind: WearableSourceKind;
+  vendor_name: string;
+  created: boolean;
+}
+
+export interface ResolveWearableSourceOptions {
+  functionPath?: string;
+  getToken?: () => Promise<FreshAccessTokenResult>;
+  fetchImpl?: typeof fetch;
+}
+
+export interface GarminProvisioningRequestOverrides {
+  app_install_id: string;
+  source_app_id?: string | null;
+  source_app_name?: string | null;
+  device_hardware_id?: string | null;
+  device_label?: string | null;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function getMobileFunctionsBaseUrl(): string {
+  const supabaseUrl =
+    process.env.EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL ??
+    getOneL1feSupabaseUrl(ONE_L1FE_SUPABASE_PROJECT_REF);
+
+  return `${trimTrailingSlash(supabaseUrl)}/functions/v1`;
+}
+
+function assertResolveResponse(value: unknown): ResolveWearableSourceResponse {
+  if (typeof value !== 'object' || value === null) {
+    throw new Error('wearable-source-resolve returned a non-object response.');
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (
+    typeof candidate.wearable_source_id !== 'string' ||
+    typeof candidate.profile_id !== 'string' ||
+    typeof candidate.source_kind !== 'string' ||
+    typeof candidate.vendor_name !== 'string' ||
+    typeof candidate.created !== 'boolean'
+  ) {
+    throw new Error('wearable-source-resolve returned an unexpected response shape.');
+  }
+
+  return candidate as unknown as ResolveWearableSourceResponse;
+}
+
+export async function resolveWearableSourceForCurrentUser(
+  request: ResolveWearableSourceRequest,
+  options: ResolveWearableSourceOptions = {},
+): Promise<ResolveWearableSourceResponse> {
+  const tokenResult = await (options.getToken ?? getFreshAccessToken)();
+
+  if (tokenResult.kind === 'signed-out') {
+    throw new Error('No active session. Please sign in first.');
+  }
+
+  if (tokenResult.kind === 'error') {
+    throw new Error(tokenResult.message);
+  }
+
+  const functionPath = options.functionPath ?? 'wearable-source-resolve';
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const requestUrl = `${getMobileFunctionsBaseUrl()}/${functionPath}`;
+  const anonKey = process.env.EXPO_PUBLIC_ONE_L1FE_SUPABASE_ANON_KEY;
+  const response = await fetchImpl(requestUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(typeof anonKey === 'string' && anonKey.trim().length > 0
+        ? { apikey: anonKey.trim() }
+        : {}),
+      Authorization: `Bearer ${tokenResult.accessToken}`,
+    },
+    body: JSON.stringify(request),
+  });
+
+  let responseJson: unknown;
+  try {
+    responseJson = await response.json();
+  } catch {
+    responseJson = undefined;
+  }
+
+  if (response.status >= 400) {
+    const apiMessage =
+      typeof responseJson === 'object' &&
+      responseJson !== null &&
+      'error' in responseJson &&
+      typeof (responseJson as { error?: unknown }).error === 'string'
+        ? (responseJson as { error: string }).error
+        : `wearable-source-resolve failed with status ${response.status}.`;
+
+    throw new Error(apiMessage);
+  }
+
+  return assertResolveResponse(responseJson);
+}
+
+export function createGarminProvisioningRequest(
+  overrides: GarminProvisioningRequestOverrides,
+): ResolveWearableSourceRequest {
+  return {
+    source_kind: GARMIN_SOURCE_KIND,
+    vendor_name: GARMIN_VENDOR_NAME,
+    source_app_id: overrides.source_app_id ?? GARMIN_CONNECT_SOURCE_APP_ID,
+    source_app_name: overrides.source_app_name ?? GARMIN_CONNECT_SOURCE_APP_NAME,
+    device_hardware_id: overrides.device_hardware_id ?? null,
+    device_label: overrides.device_label ?? null,
+    app_install_id: overrides.app_install_id,
+  };
+}
+
+export const provisionWearableSourceForCurrentUser = resolveWearableSourceForCurrentUser;

--- a/supabase/functions/README.md
+++ b/supabase/functions/README.md
@@ -9,3 +9,5 @@ Use this area for:
 
 Current function paths:
 - `save-minimum-slice-interpretation/` for authenticated minimum-slice evaluation and persistence writes into `interpretation_runs`, `interpreted_entries`, and `recommendations`.
+- `wearable-source-resolve/` as the single authenticated wearable provisioning seam for `wearable_source_id` ownership before ingestion.
+- `wearables-sync/` for authenticated wearable observation ingest/upsert tied to an owned `wearable_source_id`.

--- a/supabase/functions/wearable-source-resolve/README.md
+++ b/supabase/functions/wearable-source-resolve/README.md
@@ -1,0 +1,79 @@
+# wearable-source-resolve
+
+Edge Function, chosen provisioning seam for owned wearable sources (V1)
+
+## Purpose
+
+Resolves a stable `wearable_source_id` for the authenticated profile.
+If an active source already exists for the same owned source instance, the function returns it.
+Otherwise it provisions a new row in `wearable_sources`.
+
+This is the only provisioning step that should run before `wearables-sync`.
+
+## Auth
+
+Requires a valid Supabase JWT in the `Authorization` header.
+Ownership is always anchored to the authenticated user returned by `supabase.auth.getUser()`.
+
+## Endpoint
+
+```
+POST /functions/v1/wearable-source-resolve
+Authorization: Bearer <supabase-jwt>
+Content-Type: application/json
+```
+
+## Request
+
+Required:
+- `source_kind` (`apple_health` | `health_connect` | `vendor_api` | `manual_import`)
+- `vendor_name`
+- at least one instance-level identifier: `app_install_id` or `device_hardware_id`
+
+Optional metadata:
+- `source_app_id`
+- `source_app_name`
+- `device_label`
+
+### Garmin-first contract
+
+Until a real Garmin device/app path exists, the device-free request contract should be:
+- `source_kind = "vendor_api"`
+- `vendor_name = "garmin"`
+- `app_install_id = <stable mobile install id>`
+- `source_app_id = "com.garmin.android.apps.connectmobile"` (metadata, not identity)
+- `source_app_name = "Garmin Connect"`
+
+See:
+- `example-request.json` for the initial Garmin-first mock
+- `example-request.hardware-backfill.json` for a later enrich call when a real hardware id exists
+- `example-request.invalid-missing-instance-identity.json` for a negative-path validation case
+
+## Response
+
+```json
+{
+  "wearable_source_id": "<uuid>",
+  "profile_id": "<auth.uid()>",
+  "source_kind": "vendor_api",
+  "vendor_name": "garmin",
+  "created": true
+}
+```
+
+- `created = false`: existing source resolved
+- `created = true`: new source provisioned
+
+## Ownership + matching rules
+
+- Never returns or creates a source for a different profile.
+- Does not require the client to send `profile_id`.
+- Matching is done only on owned instance identifiers: `app_install_id` and `device_hardware_id`.
+- `source_app_id` is connector metadata only and must not be treated as the sole identity key.
+- When an existing row is matched, missing metadata fields are backfilled from the new request.
+
+## Negative paths expected
+
+- Missing or invalid auth returns `401`.
+- Missing `app_install_id` and `device_hardware_id` returns `400`.
+- Invalid `source_kind` returns `400`.

--- a/supabase/functions/wearable-source-resolve/_lib/resolve.ts
+++ b/supabase/functions/wearable-source-resolve/_lib/resolve.ts
@@ -1,0 +1,176 @@
+import type { SupabaseClient } from 'npm:@supabase/supabase-js@2';
+import type {
+  WearableSourceResolveRequest,
+  WearableSourceResolveResponse,
+} from './types.ts';
+
+type SourceRow = {
+  id: string;
+  profile_id: string;
+  source_kind: WearableSourceResolveRequest['source_kind'];
+  vendor_name: string;
+  source_app_id: string | null;
+  source_app_name: string | null;
+  device_hardware_id: string | null;
+  device_label: string | null;
+  app_install_id: string | null;
+};
+
+type UpdatableSourceFields = Pick<
+  WearableSourceResolveRequest,
+  'source_app_id' | 'source_app_name' | 'device_hardware_id' | 'device_label' | 'app_install_id'
+>;
+
+function isPresent(value: string | null | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function buildSourcePatch(existing: SourceRow, request: WearableSourceResolveRequest): Partial<UpdatableSourceFields> {
+  const patch: Partial<UpdatableSourceFields> = {};
+
+  if (!isPresent(existing.app_install_id) && isPresent(request.app_install_id)) {
+    patch.app_install_id = request.app_install_id;
+  }
+
+  if (!isPresent(existing.device_hardware_id) && isPresent(request.device_hardware_id)) {
+    patch.device_hardware_id = request.device_hardware_id;
+  }
+
+  if (!isPresent(existing.source_app_id) && isPresent(request.source_app_id)) {
+    patch.source_app_id = request.source_app_id;
+  }
+
+  if (!isPresent(existing.source_app_name) && isPresent(request.source_app_name)) {
+    patch.source_app_name = request.source_app_name;
+  }
+
+  if (!isPresent(existing.device_label) && isPresent(request.device_label)) {
+    patch.device_label = request.device_label;
+  }
+
+  return patch;
+}
+
+async function enrichExistingSource(
+  supabase: SupabaseClient,
+  existing: SourceRow,
+  request: WearableSourceResolveRequest,
+): Promise<void> {
+  const patch = buildSourcePatch(existing, request);
+  if (Object.keys(patch).length === 0) {
+    return;
+  }
+
+  const { error } = await supabase
+    .from('wearable_sources')
+    .update(patch)
+    .eq('id', existing.id)
+    .eq('profile_id', existing.profile_id);
+
+  if (error) {
+    throw new Error(`Failed to enrich wearable source metadata: ${error.message}`);
+  }
+}
+
+function isUniqueConflict(error: { code?: string } | null | undefined): boolean {
+  return error?.code === '23505';
+}
+
+async function findExistingSource(
+  supabase: SupabaseClient,
+  profileId: string,
+  request: WearableSourceResolveRequest,
+): Promise<SourceRow | null> {
+  const identifierFilters = [
+    { column: 'app_install_id', value: request.app_install_id },
+    { column: 'device_hardware_id', value: request.device_hardware_id },
+  ].filter((item) => item.value !== undefined && item.value !== null);
+
+  for (const filter of identifierFilters) {
+    const { data, error } = await supabase
+      .from('wearable_sources')
+      .select(
+        'id, profile_id, source_kind, vendor_name, source_app_id, source_app_name, device_hardware_id, device_label, app_install_id',
+      )
+      .eq('profile_id', profileId)
+      .eq('source_kind', request.source_kind)
+      .eq('vendor_name', request.vendor_name)
+      .eq(filter.column, filter.value)
+      .eq('is_active', true)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Failed to resolve existing wearable source: ${error.message}`);
+    }
+
+    if (data) {
+      return data as SourceRow;
+    }
+  }
+
+  return null;
+}
+
+export async function resolveWearableSource(
+  supabase: SupabaseClient,
+  profileId: string,
+  request: WearableSourceResolveRequest,
+): Promise<WearableSourceResolveResponse> {
+  const existing = await findExistingSource(supabase, profileId, request);
+  if (existing) {
+    await enrichExistingSource(supabase, existing, request);
+
+    return {
+      wearable_source_id: existing.id,
+      profile_id: existing.profile_id,
+      source_kind: existing.source_kind,
+      vendor_name: existing.vendor_name,
+      created: false,
+    };
+  }
+
+  const { data: created, error: createError } = await supabase
+    .from('wearable_sources')
+    .insert({
+      profile_id: profileId,
+      source_kind: request.source_kind,
+      vendor_name: request.vendor_name,
+      source_app_id: request.source_app_id ?? null,
+      source_app_name: request.source_app_name ?? null,
+      device_hardware_id: request.device_hardware_id ?? null,
+      device_label: request.device_label ?? null,
+      app_install_id: request.app_install_id ?? null,
+      is_active: true,
+    })
+    .select('id, profile_id, source_kind, vendor_name')
+    .single();
+
+  if (createError || !created) {
+    if (isUniqueConflict(createError)) {
+      const concurrentExisting = await findExistingSource(supabase, profileId, request);
+      if (concurrentExisting) {
+        await enrichExistingSource(supabase, concurrentExisting, request);
+
+        return {
+          wearable_source_id: concurrentExisting.id,
+          profile_id: concurrentExisting.profile_id,
+          source_kind: concurrentExisting.source_kind,
+          vendor_name: concurrentExisting.vendor_name,
+          created: false,
+        };
+      }
+    }
+
+    throw new Error(`Failed to create wearable source: ${createError?.message}`);
+  }
+
+  return {
+    wearable_source_id: created.id,
+    profile_id: created.profile_id,
+    source_kind: created.source_kind,
+    vendor_name: created.vendor_name,
+    created: true,
+  };
+}

--- a/supabase/functions/wearable-source-resolve/_lib/types.ts
+++ b/supabase/functions/wearable-source-resolve/_lib/types.ts
@@ -1,0 +1,23 @@
+export type WearableSourceKind =
+  | 'apple_health'
+  | 'health_connect'
+  | 'vendor_api'
+  | 'manual_import';
+
+export interface WearableSourceResolveRequest {
+  source_kind: WearableSourceKind;
+  vendor_name: string;
+  source_app_id?: string | null;
+  source_app_name?: string | null;
+  device_hardware_id?: string | null;
+  device_label?: string | null;
+  app_install_id?: string | null;
+}
+
+export interface WearableSourceResolveResponse {
+  wearable_source_id: string;
+  profile_id: string;
+  source_kind: WearableSourceKind;
+  vendor_name: string;
+  created: boolean;
+}

--- a/supabase/functions/wearable-source-resolve/_lib/validate.ts
+++ b/supabase/functions/wearable-source-resolve/_lib/validate.ts
@@ -1,0 +1,59 @@
+import type { WearableSourceResolveRequest } from './types.ts';
+
+const VALID_SOURCE_KINDS = [
+  'apple_health',
+  'health_connect',
+  'vendor_api',
+  'manual_import',
+] as const;
+
+function normalizeOptionalString(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== 'string') {
+    throw new Error('Optional source identifier fields must be strings, null, or omitted.');
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function validateWearableSourceResolveRequest(
+  raw: unknown,
+): WearableSourceResolveRequest {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Request body must be a JSON object.');
+  }
+
+  const body = raw as Record<string, unknown>;
+  const sourceKind = body.source_kind;
+  if (!VALID_SOURCE_KINDS.includes(sourceKind as never)) {
+    throw new Error(
+      `source_kind must be one of: ${VALID_SOURCE_KINDS.join(', ')}.`,
+    );
+  }
+
+  if (typeof body.vendor_name !== 'string' || body.vendor_name.trim().length === 0) {
+    throw new Error('vendor_name is required (non-empty string).');
+  }
+
+  const appInstallId = normalizeOptionalString(body.app_install_id);
+  const deviceHardwareId = normalizeOptionalString(body.device_hardware_id);
+  const sourceAppId = normalizeOptionalString(body.source_app_id);
+
+  if (!appInstallId && !deviceHardwareId) {
+    throw new Error(
+      'At least one instance-level identifier is required: app_install_id or device_hardware_id.',
+    );
+  }
+
+  return {
+    source_kind: sourceKind as WearableSourceResolveRequest['source_kind'],
+    vendor_name: body.vendor_name.trim().toLowerCase(),
+    app_install_id: appInstallId,
+    device_hardware_id: deviceHardwareId,
+    source_app_id: sourceAppId,
+    source_app_name: normalizeOptionalString(body.source_app_name),
+    device_label: normalizeOptionalString(body.device_label),
+  };
+}

--- a/supabase/functions/wearable-source-resolve/example-request.hardware-backfill.json
+++ b/supabase/functions/wearable-source-resolve/example-request.hardware-backfill.json
@@ -1,0 +1,9 @@
+{
+  "source_kind": "vendor_api",
+  "vendor_name": "garmin",
+  "source_app_id": "com.garmin.android.apps.connectmobile",
+  "source_app_name": "Garmin Connect",
+  "device_hardware_id": "garmin-fenix-7-pro-serial-redacted",
+  "device_label": "Garmin Fenix 7 Pro",
+  "app_install_id": "android-install-garmin-61c5f4ca-10dc-472f-a2a8-e8c8baf7d0a1"
+}

--- a/supabase/functions/wearable-source-resolve/example-request.invalid-missing-instance-identity.json
+++ b/supabase/functions/wearable-source-resolve/example-request.invalid-missing-instance-identity.json
@@ -1,0 +1,6 @@
+{
+  "source_kind": "vendor_api",
+  "vendor_name": "garmin",
+  "source_app_id": "com.garmin.android.apps.connectmobile",
+  "source_app_name": "Garmin Connect"
+}

--- a/supabase/functions/wearable-source-resolve/example-request.json
+++ b/supabase/functions/wearable-source-resolve/example-request.json
@@ -1,0 +1,9 @@
+{
+  "source_kind": "vendor_api",
+  "vendor_name": "garmin",
+  "source_app_id": "com.garmin.android.apps.connectmobile",
+  "source_app_name": "Garmin Connect",
+  "device_hardware_id": null,
+  "device_label": null,
+  "app_install_id": "android-install-garmin-61c5f4ca-10dc-472f-a2a8-e8c8baf7d0a1"
+}

--- a/supabase/functions/wearable-source-resolve/index.ts
+++ b/supabase/functions/wearable-source-resolve/index.ts
@@ -1,0 +1,50 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'npm:@supabase/supabase-js@2';
+import { corsHeaders, json } from '../_shared/http.ts';
+import { resolveWearableSource } from './_lib/resolve.ts';
+import { validateWearableSourceResolveRequest } from './_lib/validate.ts';
+
+Deno.serve(async (request) => {
+  if (request.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (request.method !== 'POST') {
+    return json({ error: 'Method not allowed.' }, { status: 405 });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      throw new Error('SUPABASE_URL and SUPABASE_ANON_KEY must be configured.');
+    }
+
+    const authHeader = request.headers.get('Authorization');
+    if (!authHeader) {
+      return json({ error: 'Missing Authorization header.' }, { status: 401 });
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return json({ error: 'Unauthorized.' }, { status: 401 });
+    }
+
+    const rawBody = await request.json();
+    const body = validateWearableSourceResolveRequest(rawBody);
+
+    const result = await resolveWearableSource(supabase, user.id, body);
+    return json(result, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error.';
+    return json({ error: message }, { status: 400 });
+  }
+});

--- a/supabase/migrations/20260417093000_wearable_source_identity_guards.sql
+++ b/supabase/migrations/20260417093000_wearable_source_identity_guards.sql
@@ -1,0 +1,14 @@
+-- ============================================================================
+-- wearable_source_identity_guards
+-- Adds minimal identity uniqueness guards for owned wearable source provisioning.
+-- ============================================================================
+
+-- One app install id should map to at most one active source per profile + source kind.
+create unique index if not exists wearable_sources_profile_kind_app_install_unique_idx
+  on public.wearable_sources (profile_id, source_kind, app_install_id)
+  where app_install_id is not null;
+
+-- One hardware identifier should map to at most one active source per profile + source kind.
+create unique index if not exists wearable_sources_profile_kind_device_hardware_unique_idx
+  on public.wearable_sources (profile_id, source_kind, device_hardware_id)
+  where device_hardware_id is not null;


### PR DESCRIPTION
## Merge order
Merge this first.
This PR establishes the provisioning seam that the follow-on PRs build on.

## What this PR does
- adds the `wearable-source-resolve` provisioning seam
- adds the local mobile provisioning helper and `useWearableSource` hook
- adds instance-identity validation and identity-guard migration support
- documents the provisioning flow and request shapes with concrete examples

## Why
This creates the clean ownership and provisioning boundary that the ingest and field-state work can depend on.

## Reviewer focus
Please verify:
- the seam path and naming are correct
- mobile auth reuse stays anchored to the existing mobile auth seam
- identity validation and source ownership assumptions are sound
- the migration and function behavior match the intended provisioning model
