### PR TITLE
feat(wearables-sync): enforce inactive-source guardrails and add ingest examples

### DIFF
--- a/supabase/functions/wearables-sync/README.md
+++ b/supabase/functions/wearables-sync/README.md
@@ -12,6 +12,7 @@ This is the only authorized write path for wearable data.
 
 Requires a valid Supabase JWT in the `Authorization` header.
 The function verifies that the `wearable_source_id` in the request belongs to the authenticated user.
+Inactive `wearable_sources` are rejected and must be reactivated before syncing.
 
 ## Endpoint
 
@@ -23,7 +24,12 @@ Content-Type: application/json
 
 ## Request shape
 
-See `example-request.json` and `src/lib/wearables/syncContract.ts` (`WearableSyncRequest`).
+See:
+- `example-request.json` for the current Apple Health example
+- `examples/garmin-health-connect-day1.json`
+- `examples/garmin-health-connect-day2.json`
+- `examples/garmin-health-connect-day3.json`
+- `src/lib/wearables/syncContract.ts` (`WearableSyncRequest`)
 
 ### Dedup key
 
@@ -35,10 +41,19 @@ Mobile must always pass the platform-native record ID as `source_record_id`. Nev
 
 `measurement_method` is **required** for `hrv` observations and must be `'sdnn'` or `'rmssd'`.
 `'unknown'` is rejected for new observations.
+Do not merge or trend SDNN and RMSSD together.
 
 ### Session metrics
 
 `sleep_session` and `workout_session` require `observation_end_at`.
+
+### Garmin-first device-free prep note
+
+Current contract caveats:
+- `platform` currently accepts `apple_health` or `health_connect` only.
+- Garmin-first mocks in `examples/` therefore model the near-term path as Garmin-originated data arriving through a `health_connect`-compatible ingest shape, not as a separate `platform = garmin` contract yet.
+- request payloads do **not** currently accept client-written `source_confidence` or `vendor_signal_class`; preserve extra source hints inside `source_payload` until the server-side mapping becomes explicit.
+- `steps_total` may safely leave `measurement_method = null`; HRV may not.
 
 ## Response shape
 
@@ -75,4 +90,13 @@ curl -i -X POST http://localhost:54321/functions/v1/wearables-sync \
   -H 'Authorization: Bearer <your-local-jwt>' \
   -H 'Content-Type: application/json' \
   -d @supabase/functions/wearables-sync/example-request.json
+```
+
+Garmin-first mock example:
+
+```bash
+curl -i -X POST http://localhost:54321/functions/v1/wearables-sync \
+  -H 'Authorization: Bearer <your-local-jwt>' \
+  -H 'Content-Type: application/json' \
+  -d @supabase/functions/wearables-sync/examples/garmin-health-connect-day1.json
 ```

--- a/supabase/functions/wearables-sync/_lib/sync.ts
+++ b/supabase/functions/wearables-sync/_lib/sync.ts
@@ -24,7 +24,7 @@ export async function runSync(
   // ------------------------------------------------------------------
   const { data: source, error: sourceError } = await supabase
     .from('wearable_sources')
-    .select('id, profile_id')
+    .select('id, profile_id, is_active')
     .eq('id', body.wearable_source_id)
     .single();
 
@@ -33,6 +33,9 @@ export async function runSync(
   }
   if (source.profile_id !== profileId) {
     throw new Error('wearable_source_id does not belong to authenticated user.');
+  }
+  if (source.is_active !== true) {
+    throw new Error('wearable_source is inactive. Reactivate before syncing.');
   }
 
   // ------------------------------------------------------------------

--- a/supabase/functions/wearables-sync/examples/garmin-health-connect-day1.json
+++ b/supabase/functions/wearables-sync/examples/garmin-health-connect-day1.json
@@ -1,0 +1,65 @@
+{
+  "wearable_source_id": "{{source_uuid}}",
+  "platform": "health_connect",
+  "sync_mode": "foreground_refresh",
+  "started_at": "2026-04-14T07:15:00.000Z",
+  "source_cursor": null,
+  "observations": [
+    {
+      "metric_key": "resting_heart_rate",
+      "source_record_id": "garmin-rhr-20260414",
+      "raw_type": "GarminRestingHeartRateSummary",
+      "observed_at": "2026-04-14T06:00:00.000Z",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 52,
+      "value_text": null,
+      "value_json": null,
+      "unit": "bpm",
+      "measurement_method": "vendor_derived_daily_min",
+      "source_payload": { "garmin_type": "DAILY_SUMMARY", "confidence_hint": "high" }
+    },
+    {
+      "metric_key": "sleep_duration",
+      "source_record_id": "garmin-sleep-duration-20260414",
+      "raw_type": "GarminSleepDurationSummary",
+      "observed_at": "2026-04-14T06:48:00.000Z",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 463,
+      "value_text": null,
+      "value_json": null,
+      "unit": "min",
+      "measurement_method": "garmin_sleep_algorithm",
+      "source_payload": { "garmin_type": "SLEEP", "deep_min": 95, "rem_min": 112 }
+    },
+    {
+      "metric_key": "steps_total",
+      "source_record_id": "garmin-steps-20260414",
+      "raw_type": "GarminDailySteps",
+      "observed_at": "2026-04-14T23:59:00.000Z",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 9840,
+      "value_text": null,
+      "value_json": null,
+      "unit": "count",
+      "measurement_method": null,
+      "source_payload": { "garmin_type": "DAILY_SUMMARY" }
+    },
+    {
+      "metric_key": "hrv",
+      "source_record_id": "garmin-hrv-20260414",
+      "raw_type": "GarminHrvSummary",
+      "observed_at": "2026-04-14T04:30:00.000Z",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 58,
+      "value_text": null,
+      "value_json": null,
+      "unit": "ms",
+      "measurement_method": "rmssd",
+      "source_payload": { "garmin_type": "HRV_SUMMARY", "sample_count": 240, "window": "nightly" }
+    }
+  ]
+}

--- a/supabase/functions/wearables-sync/examples/garmin-health-connect-day2.json
+++ b/supabase/functions/wearables-sync/examples/garmin-health-connect-day2.json
@@ -1,0 +1,65 @@
+{
+  "wearable_source_id": "{{source_uuid}}",
+  "platform": "health_connect",
+  "sync_mode": "foreground_refresh",
+  "started_at": "2026-04-15T07:30:00.000Z",
+  "source_cursor": "2026-04-14T07:15:00.000Z",
+  "observations": [
+    {
+      "metric_key": "resting_heart_rate",
+      "source_record_id": "garmin-rhr-20260415",
+      "raw_type": "GarminRestingHeartRateSummary",
+      "observed_at": "2026-04-15T06:00:00.000Z",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 56,
+      "value_text": null,
+      "value_json": null,
+      "unit": "bpm",
+      "measurement_method": "vendor_derived_daily_min",
+      "source_payload": { "garmin_type": "DAILY_SUMMARY", "confidence_hint": "high" }
+    },
+    {
+      "metric_key": "sleep_duration",
+      "source_record_id": "garmin-sleep-duration-20260415",
+      "raw_type": "GarminSleepDurationSummary",
+      "observed_at": "2026-04-15T06:15:00.000Z",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 390,
+      "value_text": null,
+      "value_json": null,
+      "unit": "min",
+      "measurement_method": "garmin_sleep_algorithm",
+      "source_payload": { "garmin_type": "SLEEP", "deep_min": 68, "rem_min": 89 }
+    },
+    {
+      "metric_key": "steps_total",
+      "source_record_id": "garmin-steps-20260415",
+      "raw_type": "GarminDailySteps",
+      "observed_at": "2026-04-15T23:59:00.000Z",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 14200,
+      "value_text": null,
+      "value_json": null,
+      "unit": "count",
+      "measurement_method": null,
+      "source_payload": { "garmin_type": "DAILY_SUMMARY" }
+    },
+    {
+      "metric_key": "hrv",
+      "source_record_id": "garmin-hrv-20260415",
+      "raw_type": "GarminHrvSummary",
+      "observed_at": "2026-04-15T04:15:00.000Z",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 44,
+      "value_text": null,
+      "value_json": null,
+      "unit": "ms",
+      "measurement_method": "rmssd",
+      "source_payload": { "garmin_type": "HRV_SUMMARY", "sample_count": 198, "window": "nightly" }
+    }
+  ]
+}

--- a/supabase/functions/wearables-sync/examples/garmin-health-connect-day3.json
+++ b/supabase/functions/wearables-sync/examples/garmin-health-connect-day3.json
@@ -1,0 +1,65 @@
+{
+  "wearable_source_id": "{{source_uuid}}",
+  "platform": "health_connect",
+  "sync_mode": "foreground_refresh",
+  "started_at": "2026-04-16T08:00:00.000Z",
+  "source_cursor": "2026-04-15T07:30:00.000Z",
+  "observations": [
+    {
+      "metric_key": "resting_heart_rate",
+      "source_record_id": "garmin-rhr-20260416",
+      "raw_type": "GarminRestingHeartRateSummary",
+      "observed_at": "2026-04-16T06:00:00.000Z",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 54,
+      "value_text": null,
+      "value_json": null,
+      "unit": "bpm",
+      "measurement_method": "vendor_derived_daily_min",
+      "source_payload": { "garmin_type": "DAILY_SUMMARY", "confidence_hint": "high" }
+    },
+    {
+      "metric_key": "sleep_duration",
+      "source_record_id": "garmin-sleep-duration-20260416",
+      "raw_type": "GarminSleepDurationSummary",
+      "observed_at": "2026-04-16T07:35:00.000Z",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 525,
+      "value_text": null,
+      "value_json": null,
+      "unit": "min",
+      "measurement_method": "garmin_sleep_algorithm",
+      "source_payload": { "garmin_type": "SLEEP", "deep_min": 110, "rem_min": 128 }
+    },
+    {
+      "metric_key": "steps_total",
+      "source_record_id": "garmin-steps-20260416",
+      "raw_type": "GarminDailySteps",
+      "observed_at": "2026-04-16T23:59:00.000Z",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 4300,
+      "value_text": null,
+      "value_json": null,
+      "unit": "count",
+      "measurement_method": null,
+      "source_payload": { "garmin_type": "DAILY_SUMMARY" }
+    },
+    {
+      "metric_key": "hrv",
+      "source_record_id": "garmin-hrv-20260416",
+      "raw_type": "GarminHrvSummary",
+      "observed_at": "2026-04-16T04:45:00.000Z",
+      "observation_end_at": null,
+      "source_timezone": "Europe/Berlin",
+      "value_numeric": 51,
+      "value_text": null,
+      "value_json": null,
+      "unit": "ms",
+      "measurement_method": "rmssd",
+      "source_payload": { "garmin_type": "HRV_SUMMARY", "sample_count": 221, "window": "nightly" }
+    }
+  ]
+}


### PR DESCRIPTION
## Merge order
Merge after PR A (`pr-a-provisioning-seam`).
This PR adds ingest guardrails on top of the provisioning seam and should land before broader follow-on integration.

## What this PR does
- hardens `wearables-sync` to reject inactive `wearable_sources`
- updates the wearables sync README to reflect the stricter ingest behavior
- adds Garmin-first example payloads in the current contract shape using `platform = health_connect`

## Why
This keeps ownership-only checks from being treated as sufficient and gives the next implementation steps realistic ingest examples to build against.

## Reviewer focus
Please verify:
- inactive-source rejection is correct and explicit
- the example payloads match the intended first-slice contract
- the README matches actual sync behavior
