### PR TITLE
feat(field-state): add shared contract and first mobile state flow

### DIFF
--- a/apps/mobile/MinimumSliceScreen.tsx
+++ b/apps/mobile/MinimumSliceScreen.tsx
@@ -11,6 +11,11 @@ import {
 } from 'react-native';
 import { MinimumSliceScreenModel } from './minimumSliceScreenModel.ts';
 import { MinimumSliceScreenController } from './minimumSliceScreenController.ts';
+import {
+  createOptionalFieldMetadata,
+  getOptionalFieldMetadata,
+  OptionalMinimumSliceMarkerKey,
+} from '../../packages/domain/minimumSliceMobileForm.ts';
 
 const FIELD_ORDER = [
   { key: 'panelId', label: 'Panel ID', keyboardType: 'default' },
@@ -35,6 +40,13 @@ function renderTopDrivers(state: MinimumSliceScreenModel): string {
   return topDrivers !== undefined && topDrivers.length > 0
     ? topDrivers.join(', ')
     : 'none';
+}
+
+function getOptionalMarkerState(state: MinimumSliceScreenModel, marker: OptionalMinimumSliceMarkerKey): 'provided' | 'missing' | 'disabled' {
+  const meta = getOptionalFieldMetadata(state.draft, marker);
+  if (meta?.fieldState === 'disabled') return 'disabled';
+  if (meta?.fieldState === 'provided') return 'provided';
+  return 'missing';
 }
 
 interface MinimumSliceScreenProps {
@@ -83,7 +95,25 @@ export default function MinimumSliceScreen({
 
   const handleChange = useCallback(
     (field: FieldKey, value: string): void => {
-      const nextState = controller.patchDraft({ [field]: value });
+      const patch: Record<string, unknown> = { [field]: value };
+
+      if (field === 'lpa') {
+        patch.lpaMeta = createOptionalFieldMetadata('provided');
+      }
+
+      if (field === 'crp') {
+        patch.crpMeta = createOptionalFieldMetadata('provided');
+      }
+
+      const nextState = controller.patchDraft(patch as Partial<MinimumSliceScreenModel['draft']>);
+      setScreenState(nextState);
+    },
+    [controller],
+  );
+
+  const handleOptionalMarkerStateChange = useCallback(
+    (marker: OptionalMinimumSliceMarkerKey, fieldState: 'provided' | 'missing' | 'disabled'): void => {
+      const nextState = controller.setOptionalMarkerFieldState(marker, fieldState);
       setScreenState(nextState);
     },
     [controller],
@@ -112,6 +142,35 @@ export default function MinimumSliceScreen({
               style={styles.input}
               value={screenState.draft[field.key]}
             />
+            {(field.key === 'lpa' || field.key === 'crp') ? (
+              <View style={styles.optionRow}>
+                {(['provided', 'missing', 'disabled'] as const).map((stateOption) => {
+                  const isActive = getOptionalMarkerState(screenState, field.key) === stateOption;
+                  return (
+                    <Pressable
+                      key={stateOption}
+                      onPress={() => handleOptionalMarkerStateChange(field.key, stateOption)}
+                      style={[styles.optionChip, isActive ? styles.optionChipActive : null]}
+                    >
+                      <Text style={[styles.optionChipText, isActive ? styles.optionChipTextActive : null]}>
+                        {stateOption === 'provided'
+                          ? 'Active'
+                          : stateOption === 'missing'
+                            ? 'Missing'
+                            : 'Not provided'}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            ) : null}
+            {(field.key === 'lpa' || field.key === 'crp') && getOptionalMarkerState(screenState, field.key) !== 'provided' ? (
+              <Text style={styles.fieldHint}>
+                {getOptionalMarkerState(screenState, field.key) === 'disabled'
+                  ? `${field.label} is intentionally excluded from use.`
+                  : `${field.label} is currently unavailable and should not break calculations.`}
+              </Text>
+            ) : null}
           </View>
         ))}
       </View>
@@ -203,6 +262,37 @@ const styles = StyleSheet.create({
     fontSize: 16,
     paddingHorizontal: 12,
     paddingVertical: 10,
+  },
+  optionRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 6,
+  },
+  optionChip: {
+    backgroundColor: '#eef2ff',
+    borderColor: '#c7d2fe',
+    borderRadius: 999,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  optionChipActive: {
+    backgroundColor: '#4263eb',
+    borderColor: '#4263eb',
+  },
+  optionChipText: {
+    color: '#334155',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  optionChipTextActive: {
+    color: '#ffffff',
+  },
+  fieldHint: {
+    color: '#52607a',
+    fontSize: 13,
+    lineHeight: 18,
   },
   sectionTitle: {
     color: '#152033',

--- a/apps/mobile/minimumSliceScreenController.ts
+++ b/apps/mobile/minimumSliceScreenController.ts
@@ -4,10 +4,11 @@ import {
   MinimumSliceMobileSession,
   MinimumSliceScreenModel,
   patchMinimumSliceDraft,
+  setOptionalMarkerFieldState,
   submitMinimumSliceScreen,
 } from './minimumSliceScreenModel.ts';
 import { ONE_L1FE_SUPABASE_PROJECT_REF, getOneL1feSupabaseUrl } from './minimumSliceHostedConfig.ts';
-import { MinimumSliceMobileFormDraft } from '../../packages/domain/minimumSliceMobileForm.ts';
+import { MinimumSliceMobileFormDraft, OptionalMinimumSliceMarkerKey } from '../../packages/domain/minimumSliceMobileForm.ts';
 
 export interface MinimumSliceAuthenticatedUser {
   id: string;
@@ -25,12 +26,14 @@ export interface MinimumSliceAuthSessionProvider {
 export interface MinimumSliceScreenControllerOptions {
   authSessionProvider: MinimumSliceAuthSessionProvider;
   supabaseUrl?: string;
+  supabaseAnonKey?: string;
   functionPath?: string;
 }
 
 export interface MinimumSliceScreenController {
   getState(): MinimumSliceScreenModel;
   patchDraft(patch: Partial<MinimumSliceMobileFormDraft>): MinimumSliceScreenModel;
+  setOptionalMarkerFieldState(marker: OptionalMinimumSliceMarkerKey, fieldState: 'provided' | 'missing' | 'disabled'): MinimumSliceScreenModel;
   reset(): MinimumSliceScreenModel;
   submit(): Promise<MinimumSliceScreenModel>;
 }
@@ -40,6 +43,7 @@ function resolveSession(session: MinimumSliceAuthSession, options: MinimumSliceS
     profileId: session.user.id,
     accessToken: session.accessToken,
     supabaseUrl: options.supabaseUrl ?? getOneL1feSupabaseUrl(ONE_L1FE_SUPABASE_PROJECT_REF),
+    ...(options.supabaseAnonKey !== undefined ? { supabaseAnonKey: options.supabaseAnonKey } : {}),
     ...(options.functionPath !== undefined ? { functionPath: options.functionPath } : {}),
   };
 }
@@ -57,6 +61,11 @@ export function createMinimumSliceScreenController(
 
     patchDraft(patch: Partial<MinimumSliceMobileFormDraft>): MinimumSliceScreenModel {
       state = patchMinimumSliceDraft(state, patch);
+      return state;
+    },
+
+    setOptionalMarkerFieldState(marker: OptionalMinimumSliceMarkerKey, fieldState: 'provided' | 'missing' | 'disabled'): MinimumSliceScreenModel {
+      state = setOptionalMarkerFieldState(state, marker, fieldState);
       return state;
     },
 

--- a/apps/mobile/minimumSliceScreenModel.ts
+++ b/apps/mobile/minimumSliceScreenModel.ts
@@ -1,8 +1,12 @@
 import {
   buildMinimumSlicePanelInputFromMobileDraft,
+  createOptionalFieldMetadata,
   createMinimumSliceMobileFormDraft,
+  getOptionalMarkerConfig,
   MinimumSliceMobileFormDraft,
+  OptionalMinimumSliceMarkerKey,
 } from '../../packages/domain/minimumSliceMobileForm.ts';
+import { FieldState } from '../../packages/domain/fieldValueState.ts';
 import {
   createIdleMinimumSliceSubmissionState,
   createSubmittingMinimumSliceSubmissionState,
@@ -16,6 +20,7 @@ export interface MinimumSliceMobileSession {
   profileId: string;
   accessToken: string;
   supabaseUrl: string;
+  supabaseAnonKey?: string;
   functionPath?: string;
 }
 
@@ -69,6 +74,24 @@ export function patchMinimumSliceDraft(
   };
 }
 
+export function setOptionalMarkerFieldState(
+  state: MinimumSliceScreenModel,
+  marker: OptionalMinimumSliceMarkerKey,
+  fieldState: Extract<FieldState, 'provided' | 'missing' | 'disabled'>,
+): MinimumSliceScreenModel {
+  const config = getOptionalMarkerConfig(marker);
+  const nextMetadata = createOptionalFieldMetadata(fieldState);
+
+  return {
+    ...state,
+    draft: {
+      ...state.draft,
+      ...(fieldState === 'disabled' ? { [marker]: '' } : {}),
+      [config.metadataKey]: nextMetadata,
+    },
+  };
+}
+
 export async function submitMinimumSliceScreen(
   state: MinimumSliceScreenModel,
   session: MinimumSliceMobileSession,
@@ -82,6 +105,9 @@ export async function submitMinimumSliceScreen(
   const options = {
     baseUrl: `${trimTrailingSlash(session.supabaseUrl)}/functions/v1`,
     getAccessToken: () => session.accessToken,
+    ...(session.supabaseAnonKey !== undefined
+      ? { supabaseAnonKey: session.supabaseAnonKey }
+      : {}),
     ...(session.functionPath !== undefined ? { functionPath: session.functionPath } : {}),
   };
 

--- a/packages/domain/fieldValueState.assertions.ts
+++ b/packages/domain/fieldValueState.assertions.ts
@@ -1,0 +1,24 @@
+import {
+  ACTIVE_FIELD_STATES,
+  isActiveFieldState,
+  requiresNullValueForFieldState,
+} from './fieldValueState.ts';
+
+function assert(condition: unknown, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+export function runFieldValueStateAssertions(): void {
+  assert(ACTIVE_FIELD_STATES.length === 3, 'Expected three active field states.');
+  assert(isActiveFieldState('provided') === true, 'provided should be active.');
+  assert(isActiveFieldState('synced') === true, 'synced should be active.');
+  assert(isActiveFieldState('manual_override') === true, 'manual_override should be active.');
+  assert(isActiveFieldState('missing') === false, 'missing should not be active.');
+  assert(isActiveFieldState('disabled') === false, 'disabled should not be active.');
+  assert(requiresNullValueForFieldState('missing') === true, 'missing should require a null value.');
+  assert(requiresNullValueForFieldState('disabled') === true, 'disabled should require a null value.');
+  assert(requiresNullValueForFieldState('provided') === false, 'provided should not require a null value.');
+}
+

--- a/packages/domain/fieldValueState.ts
+++ b/packages/domain/fieldValueState.ts
@@ -1,0 +1,45 @@
+export type FieldState =
+  | 'provided'
+  | 'synced'
+  | 'manual_override'
+  | 'missing'
+  | 'disabled';
+
+export type FieldValueSource =
+  | 'manual'
+  | 'wearable_sync'
+  | 'vendor_import'
+  | 'lab'
+  | 'derived'
+  | 'unknown';
+
+export type FieldStateReason =
+  | 'not_available'
+  | 'not_known'
+  | 'prefer_not_to_answer'
+  | 'sync_failed'
+  | 'sync_partial'
+  | 'sync_suspect'
+  | 'user_corrected'
+  | 'user_disabled'
+  | 'out_of_scope';
+
+export interface AppFieldValue<T> {
+  value: T | null;
+  field_state: FieldState;
+  value_source: FieldValueSource;
+  state_reason?: FieldStateReason | null;
+  updated_at?: string | null;
+  source_updated_at?: string | null;
+}
+
+export const ACTIVE_FIELD_STATES: FieldState[] = ['provided', 'synced', 'manual_override'];
+
+export function isActiveFieldState(state: FieldState): boolean {
+  return ACTIVE_FIELD_STATES.includes(state);
+}
+
+export function requiresNullValueForFieldState(state: FieldState): boolean {
+  return state === 'missing' || state === 'disabled';
+}
+

--- a/packages/domain/minimumSlice.assertions.ts
+++ b/packages/domain/minimumSlice.assertions.ts
@@ -1,5 +1,6 @@
 import { CanonicalStatus } from './biomarkers.ts';
 import { fixtureExpectations, runFixtureSet } from './fixtures.v1.ts';
+import { evaluateMinimumSlice } from './minimumSlice.ts';
 
 function assert(condition: unknown, message: string): void {
   if (!condition) {
@@ -58,4 +59,26 @@ export function runMinimumSliceAssertions(): void {
 
   const apobEntry = primary.entries.find((entry) => entry.marker === 'apob');
   assert(apobEntry?.canonicalStatus === CanonicalStatus.High, 'Primary fixture should map ApoB 118 mg/dL to high.');
+
+  const disabledOptional = evaluateMinimumSlice({
+    profileId: 'profile_disabled_optional_1',
+    panelId: 'panel_disabled_optional_1',
+    collectedAt: '2026-04-13T09:00:00.000Z',
+    entries: [
+      { marker: 'apob', value: 118, unit: 'mg/dL' },
+      { marker: 'ldl', value: 152, unit: 'mg/dL' },
+      { marker: 'hba1c', value: 5.8, unit: '%' },
+      { marker: 'glucose', value: 104, unit: 'mg/dL', fastingContext: true },
+      { marker: 'lpa', value: null, field_state: 'disabled', value_source: 'manual', state_reason: 'user_disabled' },
+    ],
+  });
+
+  assert(
+    disabledOptional.coverage.notes.some((note) => note.includes('intentionally not provided')),
+    'Disabled optional entries should appear as intentionally not provided in coverage notes.',
+  );
+  assert(
+    !disabledOptional.recommendations.some((recommendation) => recommendation.verdict.includes('Lp(a) is missing')),
+    'Disabled optional entries should not emit collect-more-data recommendations.',
+  );
 }

--- a/packages/domain/minimumSlice.ts
+++ b/packages/domain/minimumSlice.ts
@@ -3,6 +3,7 @@ import { getRuleProvenance, ProductEvidenceClass, RuleOrigin } from './provenanc
 import { evaluateByThreshold } from './thresholds.ts';
 import {
   BiomarkerKey,
+  FieldState,
   FreshnessState,
   InterpretabilityAssessment,
   InterpretationInput,
@@ -53,6 +54,7 @@ export interface EvaluatedEntry {
   marker: BiomarkerKey;
   displayName: string;
   value: number | null | undefined;
+  fieldState?: FieldState;
   unit: string | null | undefined;
   interpretableState: InterpretabilityState;
   freshness: FreshnessState;
@@ -103,6 +105,10 @@ function dedupeRecommendations(recommendations: Recommendation[]): Recommendatio
 }
 
 function buildCoverageRecommendation(entry: EvaluatedEntry): Recommendation | null {
+  if (entry.fieldState === 'disabled') {
+    return null;
+  }
+
   if (entry.interpretableState === InterpretabilityState.Missing) {
     return {
       type: 'collect_more_data',
@@ -279,6 +285,11 @@ function summarizeCoverageNotes(entries: EvaluatedEntry[], lipidDecision: LipidH
   const notes = new Set<string>();
 
   for (const entry of entries) {
+    if (entry.fieldState === 'disabled') {
+      notes.add(`${entry.displayName} was intentionally not provided and is excluded from active use.`);
+      continue;
+    }
+
     if (entry.interpretableState === InterpretabilityState.Missing) {
       notes.add(`Missing ${entry.displayName}.`);
     }
@@ -307,7 +318,11 @@ function summarizeCoverageNotes(entries: EvaluatedEntry[], lipidDecision: LipidH
 function getFallbackRuleIds(
   marker: BiomarkerKey,
   assessment: InterpretabilityAssessment,
+  input: MinimumSliceEntryInput,
 ): string[] {
+  if (input.field_state === 'disabled') {
+    return [];
+  }
   if (marker === 'apob' && assessment.state === InterpretabilityState.Missing) {
     return ['LIP-003', 'COV-001'];
   }
@@ -341,7 +356,7 @@ function buildEntry(
 
   const ruleIds = thresholdEvaluation?.ruleIds?.length
     ? thresholdEvaluation.ruleIds
-    : getFallbackRuleIds(input.marker, assessment);
+    : getFallbackRuleIds(input.marker, assessment, input);
 
   const notes = [
     ...(thresholdEvaluation?.notes ?? []),
@@ -355,6 +370,7 @@ function buildEntry(
     marker: input.marker,
     displayName: biomarker.displayName,
     value: input.value,
+    ...(input.field_state !== undefined ? { fieldState: input.field_state } : {}),
     unit: input.unit,
     interpretableState: assessment.state,
     freshness: assessment.freshness,

--- a/packages/domain/minimumSliceFunctionContract.assertions.ts
+++ b/packages/domain/minimumSliceFunctionContract.assertions.ts
@@ -25,7 +25,7 @@ export function runMinimumSliceFunctionContractAssertions(): void {
       collectedAt: '2026-04-10T08:00:00.000Z',
       source: 'manual',
       entries: [
-        { marker: 'apob', value: 118, unit: 'mg/dL' },
+        { marker: 'apob', value: 118, unit: 'mg/dL', field_state: 'provided', value_source: 'manual' },
         { marker: 'glucose', value: 104, unit: 'mg/dL', fastingContext: true },
       ],
     },
@@ -45,6 +45,8 @@ export function runMinimumSliceFunctionContractAssertions(): void {
 
   assert(parsed.panel.panelId === 'panel_demo_1', 'Parsed contract should keep panel ids.');
   assert(parsed.panel.entries.length === 2, 'Parsed contract should keep entry count.');
+  assert(parsed.panel.entries[0]?.field_state === 'provided', 'Parsed contract should keep field_state when provided.');
+  assert(parsed.panel.entries[0]?.value_source === 'manual', 'Parsed contract should keep value_source when provided.');
   assert(parsed.persistence?.interpretedEntryLabResultEntryIds?.apob === 'entry_apob_1', 'Parsed contract should keep entry linkage maps.');
   assert(parseOptionalDateFromIso(parsed.execution?.now, 'execution.now')?.toISOString() === '2026-04-13T02:50:00.000Z', 'ISO execution timestamps should convert into Date values.');
 
@@ -61,6 +63,14 @@ export function runMinimumSliceFunctionContractAssertions(): void {
   assertThrows(
     () => parseMinimumSliceFunctionRequestBody({ panel: { panelId: 'x', collectedAt: '2026-04-10T08:00:00.000Z', entries: [{ marker: 'apob', value: '118' }] } }),
     'panel.entries[0].value must be a number or null.',
+  );
+  assertThrows(
+    () => parseMinimumSliceFunctionRequestBody({ panel: { panelId: 'x', collectedAt: '2026-04-10T08:00:00.000Z', entries: [{ marker: 'apob', field_state: 'disabled', value: 118 }] } }),
+    'panel.entries[0].value must be null when field_state is disabled.',
+  );
+  assertThrows(
+    () => parseMinimumSliceFunctionRequestBody({ panel: { panelId: 'x', collectedAt: '2026-04-10T08:00:00.000Z', entries: [{ marker: 'apob', state_reason: 'user_disabled' }] } }),
+    'panel.entries[0].state_reason requires field_state.',
   );
   assertThrows(
     () => parseMinimumSliceFunctionRequestBody({ panel: { panelId: 'x', collectedAt: '2026-04-10T08:00:00.000Z', entries: [{ marker: 'apob', fastingContext: 'yes' }] } }),

--- a/packages/domain/minimumSliceFunctionContract.ts
+++ b/packages/domain/minimumSliceFunctionContract.ts
@@ -1,14 +1,32 @@
+import { FieldState, FieldStateReason, FieldValueSource, requiresNullValueForFieldState } from './fieldValueState.ts';
 import { BiomarkerKey } from './v1.ts';
 
 export interface MinimumSliceFunctionRequestEntry {
   marker: BiomarkerKey;
   value?: number | null;
+  field_state?: FieldState;
+  value_source?: FieldValueSource;
+  state_reason?: FieldStateReason | null;
   unit?: string | null;
   assayType?: string | null;
   collectedAt?: string | null;
   fastingContext?: boolean | null;
   acuteContext?: boolean | null;
 }
+
+const VALID_FIELD_STATES: FieldState[] = ['provided', 'synced', 'manual_override', 'missing', 'disabled'];
+const VALID_FIELD_VALUE_SOURCES: FieldValueSource[] = ['manual', 'wearable_sync', 'vendor_import', 'lab', 'derived', 'unknown'];
+const VALID_FIELD_STATE_REASONS: FieldStateReason[] = [
+  'not_available',
+  'not_known',
+  'prefer_not_to_answer',
+  'sync_failed',
+  'sync_partial',
+  'sync_suspect',
+  'user_corrected',
+  'user_disabled',
+  'out_of_scope',
+];
 
 export interface MinimumSliceFunctionRequestBody {
   panel: {
@@ -97,6 +115,67 @@ function parseOptionalNullableIsoString(value: unknown, field: string): string |
   return parseOptionalIsoString(value, field);
 }
 
+function parseOptionalFieldState(value: unknown, field: string): FieldState | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = requireString(value, field) as FieldState;
+  if (!VALID_FIELD_STATES.includes(parsed)) {
+    throw new Error(`${field} must be one of: ${VALID_FIELD_STATES.join(', ')}.`);
+  }
+
+  return parsed;
+}
+
+function parseFieldState(value: unknown, field: string): FieldState {
+  const parsed = parseOptionalFieldState(value, field);
+  if (parsed === undefined) {
+    throw new Error(`${field} is required.`);
+  }
+
+  return parsed;
+}
+
+function parseOptionalFieldValueSource(value: unknown, field: string): FieldValueSource | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = requireString(value, field) as FieldValueSource;
+  if (!VALID_FIELD_VALUE_SOURCES.includes(parsed)) {
+    throw new Error(`${field} must be one of: ${VALID_FIELD_VALUE_SOURCES.join(', ')}.`);
+  }
+
+  return parsed;
+}
+
+function parseFieldValueSource(value: unknown, field: string): FieldValueSource {
+  const parsed = parseOptionalFieldValueSource(value, field);
+  if (parsed === undefined) {
+    throw new Error(`${field} is required.`);
+  }
+
+  return parsed;
+}
+
+function parseOptionalFieldStateReason(value: unknown, field: string): FieldStateReason | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  const parsed = requireString(value, field) as FieldStateReason;
+  if (!VALID_FIELD_STATE_REASONS.includes(parsed)) {
+    throw new Error(`${field} must be one of: ${VALID_FIELD_STATE_REASONS.join(', ')}.`);
+  }
+
+  return parsed;
+}
+
 function parseEntry(value: unknown, index: number): MinimumSliceFunctionRequestEntry {
   if (!isRecord(value)) {
     throw new Error(`panel.entries[${index}] must be an object.`);
@@ -111,6 +190,22 @@ function parseEntry(value: unknown, index: number): MinimumSliceFunctionRequestE
     }
 
     output.value = value.value;
+  }
+
+  if (value.field_state !== undefined) {
+    output.field_state = parseFieldState(value.field_state, `panel.entries[${index}].field_state`);
+  }
+
+  if (value.value_source !== undefined) {
+    output.value_source = parseFieldValueSource(value.value_source, `panel.entries[${index}].value_source`);
+  }
+
+  if (value.state_reason !== undefined) {
+    const stateReason = parseOptionalFieldStateReason(value.state_reason, `panel.entries[${index}].state_reason`);
+
+    if (stateReason !== undefined) {
+      output.state_reason = stateReason;
+    }
   }
 
   if (value.unit !== undefined) {
@@ -151,6 +246,14 @@ function parseEntry(value: unknown, index: number): MinimumSliceFunctionRequestE
     }
 
     output.acuteContext = value.acuteContext;
+  }
+
+  if (output.field_state && requiresNullValueForFieldState(output.field_state) && output.value !== undefined && output.value !== null) {
+    throw new Error(`panel.entries[${index}].value must be null when field_state is ${output.field_state}.`);
+  }
+
+  if (output.state_reason && !output.field_state) {
+    throw new Error(`panel.entries[${index}].state_reason requires field_state.`);
   }
 
   return output;

--- a/packages/domain/minimumSliceMobileForm.assertions.ts
+++ b/packages/domain/minimumSliceMobileForm.assertions.ts
@@ -26,6 +26,8 @@ export function runMinimumSliceMobileFormAssertions(): void {
   assert(emptyDraft.panelId === '', 'Mobile form draft factory should start with empty panel id.');
   assert(emptyDraft.source === 'mobile-manual-entry', 'Mobile form draft factory should default the source.');
   assert(emptyDraft.fastingContext === true, 'Mobile form draft factory should default fastingContext to true.');
+  assert(emptyDraft.lpaMeta?.fieldState === 'missing', 'Mobile form draft factory should mark optional Lp(a) as missing by default.');
+  assert(emptyDraft.crpMeta?.fieldState === 'missing', 'Mobile form draft factory should mark optional CRP as missing by default.');
 
   const input = buildMinimumSlicePanelInputFromMobileDraft(
     {
@@ -39,6 +41,8 @@ export function runMinimumSliceMobileFormAssertions(): void {
       crp: '2.4',
       fastingContext: true,
       source: 'manual-mobile-test',
+      lpaMeta: { fieldState: 'provided', valueSource: 'manual' },
+      crpMeta: { fieldState: 'provided', valueSource: 'manual' },
     },
     {
       profileId: 'profile_mobile_1',
@@ -52,6 +56,8 @@ export function runMinimumSliceMobileFormAssertions(): void {
   assert(input.entries.length === 6, 'Mobile form builder should include optional markers when present.');
   assert(input.entries[0]?.marker === 'apob' && input.entries[0]?.unit === 'mg/dL', 'Mobile form builder should create ApoB entry with fixed unit.');
   assert(input.entries[3]?.marker === 'glucose' && input.entries[3]?.fastingContext === true, 'Mobile form builder should preserve glucose fasting context.');
+  assert(input.entries[4]?.field_state === 'provided', 'Mobile form builder should preserve Lp(a) field_state metadata.');
+  assert(input.entries[5]?.value_source === 'manual', 'Mobile form builder should preserve CRP value_source metadata.');
 
   const fallbackSourceInput = buildMinimumSlicePanelInputFromMobileDraft(
     {
@@ -73,6 +79,29 @@ export function runMinimumSliceMobileFormAssertions(): void {
 
   assert(fallbackSourceInput.source === 'mobile-screen', 'Mobile form builder should use the default source when the draft source is blank.');
   assert(fallbackSourceInput.entries.length === 4, 'Mobile form builder should skip optional blank markers.');
+
+  const disabledOptionalInput = buildMinimumSlicePanelInputFromMobileDraft(
+    {
+      panelId: 'panel_mobile_2b',
+      collectedAt: '2026-04-13T09:00:00.000Z',
+      apob: '90',
+      ldl: '120',
+      hba1c: '5.4',
+      glucose: '95',
+      lpa: '',
+      crp: '',
+      lpaMeta: { fieldState: 'disabled', valueSource: 'manual', stateReason: 'user_disabled' },
+      crpMeta: { fieldState: 'missing', valueSource: 'unknown', stateReason: 'not_available' },
+    },
+    {
+      profileId: 'profile_mobile_2b',
+    },
+  );
+
+  assert(disabledOptionalInput.entries.length === 6, 'Mobile form builder should preserve optional entries when field metadata is explicit.');
+  assert(disabledOptionalInput.entries[4]?.value === null, 'Disabled optional entry should map to null value.');
+  assert(disabledOptionalInput.entries[4]?.field_state === 'disabled', 'Disabled optional entry should keep disabled field_state.');
+  assert(disabledOptionalInput.entries[5]?.field_state === 'missing', 'Missing optional entry should keep missing field_state.');
 
   assertThrows(
     () =>

--- a/packages/domain/minimumSliceMobileForm.ts
+++ b/packages/domain/minimumSliceMobileForm.ts
@@ -1,4 +1,38 @@
+import { FieldState, FieldStateReason, FieldValueSource } from './fieldValueState.ts';
 import { MinimumSlicePanelInput } from './minimumSlice.ts';
+
+export interface MinimumSliceMobileFieldMetadata {
+  fieldState?: FieldState;
+  valueSource?: FieldValueSource;
+  stateReason?: FieldStateReason | null;
+}
+
+export type OptionalMinimumSliceMarkerKey = 'lpa' | 'crp';
+
+export interface OptionalMinimumSliceMarkerConfig {
+  marker: OptionalMinimumSliceMarkerKey;
+  fieldKey: OptionalMinimumSliceMarkerKey;
+  metadataKey: 'lpaMeta' | 'crpMeta';
+  label: string;
+  unit: string;
+}
+
+export const OPTIONAL_MINIMUM_SLICE_MARKERS: readonly OptionalMinimumSliceMarkerConfig[] = [
+  {
+    marker: 'lpa',
+    fieldKey: 'lpa',
+    metadataKey: 'lpaMeta',
+    label: 'Lp(a)',
+    unit: 'mg/dL',
+  },
+  {
+    marker: 'crp',
+    fieldKey: 'crp',
+    metadataKey: 'crpMeta',
+    label: 'CRP',
+    unit: 'mg/L',
+  },
+] as const;
 
 export interface MinimumSliceMobileFormDraft {
   panelId: string;
@@ -8,9 +42,42 @@ export interface MinimumSliceMobileFormDraft {
   hba1c: string;
   glucose: string;
   lpa?: string;
+  lpaMeta?: MinimumSliceMobileFieldMetadata;
   crp?: string;
+  crpMeta?: MinimumSliceMobileFieldMetadata;
   fastingContext?: boolean;
   source?: string;
+}
+
+export function createOptionalFieldMetadata(
+  fieldState: Extract<FieldState, 'provided' | 'missing' | 'disabled'>,
+): MinimumSliceMobileFieldMetadata {
+  if (fieldState === 'provided') {
+    return { fieldState: 'provided', valueSource: 'manual', stateReason: null };
+  }
+
+  if (fieldState === 'disabled') {
+    return { fieldState: 'disabled', valueSource: 'manual', stateReason: 'user_disabled' };
+  }
+
+  return { fieldState: 'missing', valueSource: 'unknown', stateReason: 'not_available' };
+}
+
+export function getOptionalMarkerConfig(marker: OptionalMinimumSliceMarkerKey): OptionalMinimumSliceMarkerConfig {
+  const config = OPTIONAL_MINIMUM_SLICE_MARKERS.find((candidate) => candidate.marker === marker);
+  if (!config) {
+    throw new Error(`Unsupported optional minimum-slice marker: ${marker}`);
+  }
+
+  return config;
+}
+
+export function getOptionalFieldMetadata(
+  draft: MinimumSliceMobileFormDraft,
+  marker: OptionalMinimumSliceMarkerKey,
+): MinimumSliceMobileFieldMetadata | undefined {
+  const config = getOptionalMarkerConfig(marker);
+  return draft[config.metadataKey];
 }
 
 export interface BuildMinimumSlicePanelFromDraftOptions {
@@ -61,6 +128,33 @@ function parseOptionalNumber(value: string | undefined, field: string): number |
   return parsed;
 }
 
+function hasFieldMetadata(metadata: MinimumSliceMobileFieldMetadata | undefined): boolean {
+  return metadata?.fieldState !== undefined || metadata?.valueSource !== undefined || metadata?.stateReason !== undefined;
+}
+
+function buildOptionalEntry(
+  marker: MinimumSlicePanelInput['entries'][number]['marker'],
+  rawValue: string | undefined,
+  field: string,
+  unit: string,
+  metadata: MinimumSliceMobileFieldMetadata | undefined,
+): MinimumSlicePanelInput['entries'][number] | undefined {
+  const value = parseOptionalNumber(rawValue, field);
+
+  if (value === undefined && !hasFieldMetadata(metadata)) {
+    return undefined;
+  }
+
+  return {
+    marker,
+    value: value ?? null,
+    unit,
+    ...(metadata?.fieldState !== undefined ? { field_state: metadata.fieldState } : {}),
+    ...(metadata?.valueSource !== undefined ? { value_source: metadata.valueSource } : {}),
+    ...(metadata?.stateReason !== undefined ? { state_reason: metadata.stateReason } : {}),
+  };
+}
+
 export function createMinimumSliceMobileFormDraft(): MinimumSliceMobileFormDraft {
   return {
     panelId: '',
@@ -70,7 +164,9 @@ export function createMinimumSliceMobileFormDraft(): MinimumSliceMobileFormDraft
     hba1c: '',
     glucose: '',
     lpa: '',
+    lpaMeta: createOptionalFieldMetadata('missing'),
     crp: '',
+    crpMeta: createOptionalFieldMetadata('missing'),
     fastingContext: true,
     source: 'mobile-manual-entry',
   };
@@ -107,14 +203,18 @@ export function buildMinimumSlicePanelInputFromMobileDraft(
     ],
   };
 
-  const lpa = parseOptionalNumber(draft.lpa, 'lpa');
-  if (lpa !== undefined) {
-    input.entries.push({ marker: 'lpa', value: lpa, unit: 'mg/dL' });
-  }
+  for (const config of OPTIONAL_MINIMUM_SLICE_MARKERS) {
+    const entry = buildOptionalEntry(
+      config.marker,
+      draft[config.fieldKey],
+      config.fieldKey,
+      config.unit,
+      draft[config.metadataKey],
+    );
 
-  const crp = parseOptionalNumber(draft.crp, 'crp');
-  if (crp !== undefined) {
-    input.entries.push({ marker: 'crp', value: crp, unit: 'mg/L' });
+    if (entry !== undefined) {
+      input.entries.push(entry);
+    }
   }
 
   return input;

--- a/packages/domain/runMinimumSliceAssertions.ts
+++ b/packages/domain/runMinimumSliceAssertions.ts
@@ -1,5 +1,6 @@
 import { runContractAssertions } from './contracts.assertions.ts';
 import { runEvidenceRegistrySeedAssertions } from './evidenceSupabaseSeed.assertions.ts';
+import { runFieldValueStateAssertions } from './fieldValueState.assertions.ts';
 import { runMinimumSliceAppClientAssertions } from './minimumSliceAppClient.assertions.ts';
 import { runMinimumSliceAppHttpClientAssertions } from './minimumSliceAppHttpClient.assertions.ts';
 import { runMinimumSliceMobileFormAssertions } from './minimumSliceMobileForm.assertions.ts';
@@ -12,6 +13,7 @@ import { runSupabasePersistenceAssertions } from './supabasePersistence.assertio
 import { runSupabaseRepositoryAssertions } from './supabaseRepository.assertions.ts';
 
 async function main(): Promise<void> {
+  runFieldValueStateAssertions();
   runMinimumSliceAssertions();
   runMinimumSliceFunctionContractAssertions();
   await runMinimumSliceAppClientAssertions();

--- a/packages/domain/v1.ts
+++ b/packages/domain/v1.ts
@@ -1,3 +1,4 @@
+import { FieldState, FieldStateReason, FieldValueSource, requiresNullValueForFieldState } from './fieldValueState.ts';
 import { BiomarkerDefinition, biomarkers, CanonicalStatus, getBiomarkerDefinition } from './biomarkers.ts';
 
 // Literal union type derived from the biomarkers array — gives compile-time
@@ -40,6 +41,8 @@ export enum RecommendationEligibilityClass {
   Blocked = 'blocked',
 }
 
+export { FieldState } from './fieldValueState.ts';
+
 export interface MarkerRuntimeConfig {
   key: BiomarkerKey;
   markerRole: MarkerRole;
@@ -53,6 +56,9 @@ export interface MarkerRuntimeConfig {
 export interface InterpretationInput {
   marker: BiomarkerKey;
   value?: number | null;
+  field_state?: FieldState;
+  value_source?: FieldValueSource;
+  state_reason?: FieldStateReason | null;
   unit?: string | null;
   assayType?: string | null;
   collectedAt?: string | Date | null;
@@ -223,6 +229,26 @@ export function assessInterpretability(
 ): InterpretabilityAssessment {
   const config = getMarkerRuntimeConfig(input.marker);
   const freshness = getFreshnessState(input.collectedAt, now);
+
+  if (input.field_state === 'disabled') {
+    return {
+      marker: input.marker,
+      state: InterpretabilityState.Missing,
+      freshness,
+      blockingReason: input.state_reason ?? 'disabled',
+      scoreBlocked: true,
+    };
+  }
+
+  if (input.field_state && requiresNullValueForFieldState(input.field_state) && input.value != null) {
+    return {
+      marker: input.marker,
+      state: InterpretabilityState.InterpretationLimited,
+      freshness,
+      blockingReason: 'invalid_field_state_value_pair',
+      scoreBlocked: true,
+    };
+  }
 
   if (input.value == null || Number.isNaN(input.value)) {
     return {


### PR DESCRIPTION
## Merge order
Merge after PR A (`pr-a-provisioning-seam`).
If reviewers want the ingest protections in place first, merge after PR B as well.
This PR contains the field-state core and the currently committed mobile integration files that wire it into the app flow.

## What this PR does
- adds the shared `fieldValueState` domain contract and assertions
- extends minimum-slice contract, parsing, and mobile form behavior for explicit field-state metadata
- integrates the first `lpa` and `crp` state flow through the mobile model, controller, and screen
- updates recommendation logic so intentionally disabled fields are not treated like generic missing data

## Why
This turns field-state handling from a planning concept into a reusable implementation pattern while staying honest about the current committed mobile integration scope.

## Reviewer focus
Please verify:
- the shared field-state contract is coherent and reusable
- `lpa` and `crp` state behavior matches the intended UX and function contract
- the PR description matches the actual commit contents, including UI/model/controller files
- recommendation behavior now distinguishes intentional disablement from ordinary missingness
