### PR TITLE
docs: align checkpoint, field-state docs, and QA follow-up

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -2,7 +2,7 @@
 status: current
 canonical_for: current execution state
 owner: repo
-last_verified: 2026-04-13
+last_verified: 2026-04-17
 supersedes: []
 superseded_by: null
 scope: repo
@@ -12,45 +12,83 @@ scope: repo
 
 ## Verdict
 
-Mobile auth scaffolding is now in a cleaner shape, backend hardening is already on `main`, and the main remaining product blocker is unchanged: the first real authenticated Expo submit against the hosted edge function still has not been verified live.
+The minimum-slice mobile seam is now proven live end to end in the real app: login, authenticated submit, wrong-password handling, hosted-function error handling, and sign-out were all verified on device, and the next active seam is now **wearable ingestion proof** with `wearable_source_id` ownership and provisioning as the first real design and implementation question.
 
 ## Current state
 
-- Branch: `main`
-- Active seam: hosted minimum-slice backend live, Expo mobile seam with real Supabase auth wired
+- Branch: `main`, currently aligned with `origin/main` as the clean base for the next cycle
+- Active seam: minimum-slice proof complete, wearable ingestion proof opened as the only active next seam
 - Source of truth repo: `gzug/One-L1fe`
 - Current blockers:
-  - first real authenticated Expo submit against hosted endpoint not yet verified live
+  - no product blocker remains on the minimum-slice seam
+  - PR #47 (`checkpoint: minimum-slice proof complete, wearable ingestion next`) was opened to close the previous cycle, but should only be merged if it is clearly non-regressive against the current local checkpoint state; otherwise carry its intent forward into new focused PRs
+  - hosted verification for the new wearable provisioning + `wearables-sync` sequence is still pending (current proof is local code/test level)
+  - no physical wearable/device/app is available locally yet, so the current Garmin-first workstream should stay device-free: schema, auth, functions, mobile seams, mocks, and docs first
 - Key confirmed facts:
   - hosted migrations match repo
   - RLS and policies are live
-  - `save-minimum-slice-interpretation` is deployed with JWT enforcement
-  - one authenticated hosted smoke call returned HTTP 200 with writes succeeding end to end
-  - backend hardening migration `20260413093000_phase0_backend_hardening.sql` is now on `main`
-  - PR #1 (phase0 backend hardening) merged to `main` on 2026-04-13
-  - Supabase CI now runs linked-project lint plus local `supabase start` and `supabase db reset`
-  - the repo now includes `memory/`, `docs/ops/`, a data-handling policy, and lightweight metadata files
-  - `mobileSupabaseAuth.ts` is the thin Supabase client adapter using `auth.getSession()`
-  - `LoginScreen.tsx` is the minimal email/password UI and delegates to the Supabase client
-  - placeholder env vars (`EXPO_PUBLIC_ONE_L1FE_ACCESS_TOKEN`, `EXPO_PUBLIC_ONE_L1FE_PROFILE_ID`) were removed
-  - `apps/mobile/.env.example` now matches the real auth seam (`EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL` + `EXPO_PUBLIC_ONE_L1FE_SUPABASE_ANON_KEY`)
-  - Expo env access was normalized to direct `process.env.VAR_NAME` dot notation, removing the earlier `readEnv` helper (PR #14, #15)
-  - Supabase test user exists for smoke testing: `test@one-l1fe.dev` (UID `3aa48a6f-0f7b-47d3-9875-7353064dd359`)
-  - `useAuthSession.ts` now owns the thin React auth-state wrapper (`loading -> signed-out -> signed-in`) and was merged in PR #17 on 2026-04-13
-  - `MinimumSliceScreen.tsx` is now the standalone minimum-slice form component and was merged in PR #19 on 2026-04-13
-  - `App.tsx` is now a ~55-line pure auth-gate shell consuming `useAuthSession`, `LoginScreen.tsx`, and `MinimumSliceScreen.tsx`, merged in PR #20 on 2026-04-13
-  - missing mobile Supabase env no longer hard-crashes the auth seam; the login surface stays visible with a clear config error
-  - the signed-in mobile shell now includes a thin session bar with user identity and explicit sign-out, making signed-out transition testing a first-class path
+  - `save-minimum-slice-interpretation` works for real authenticated mobile submit after disabling gateway JWT verification and relying on explicit in-function auth via `supabase.auth.getUser()`
+  - the minimum-slice proof now includes all four smoke checks as live-confirmed behavior: wrong password, hosted function error path, successful sign-out, and successful authenticated submit
+  - Expo Go login via QR was confirmed live on iPhone for `g.zugang@hotmail.com`
+  - the current controllable confirmed smoke-test user is `g.zugang@hotmail.com` (UID `523b48a4-2aa2-4e4c-97f2-8fa95141ac8b`) and a matching `public.profiles` row exists
+  - `mobileSupabaseAuth.ts` uses AsyncStorage-backed Supabase session persistence for Expo/RN and now normalizes true signed-out cases distinctly from operational auth errors
+  - `react-native-url-polyfill/auto` must load before `@supabase/supabase-js` in the mobile auth seam
+  - mobile auth assertions now cover no-session, `user === null`, `getUser` error, `getSession` error, and valid-session cases
+  - minimum-slice HTTP transport assertions now cover both `apikey` inclusion when provided and omission when no anon key is provided
+  - current mobile diagnostics surface hosted function URL plus Supabase gateway error codes on failure instead of only a generic 401
+  - `apps/mobile/.gitignore` now protects `.env` and `.env.*`
+  - `apps/mobile/metro.config.js` is present to make the Expo app resolve the workspace layout cleanly under the monorepo
+  - for the wearable seam, mobile auth must continue to flow through `apps/mobile/mobileSupabaseAuth.ts`; do not introduce a parallel mobile Supabase client
+  - thin wearable provisioning work is in progress at local-prep level:
+    - the chosen provisioning path is now `supabase/functions/wearable-source-resolve/`; the parallel `provision-wearable-source/` draft should stay removed
+    - local mobile helpers exist at `apps/mobile/wearableSourceProvisioning.ts` and `apps/mobile/src/hooks/useWearableSource.ts`, and wearable calls must continue to reuse `apps/mobile/mobileSupabaseAuth.ts`
+    - provisioning identity should be anchored to instance-level identifiers only: `app_install_id` first for device-free prep, `device_hardware_id` later when real Garmin hardware exists
+    - `source_app_id` should be treated as connector metadata, not as a sole ownership key
+    - local migration prep should keep only the identity-guard path (`20260417093000_wearable_source_identity_guards.sql`); the earlier composite uniqueness draft should stay discarded because it collapses multiple legitimate sources too aggressively
+    - Garmin smartwatch is the first intended wearable target for the seam, but only at planning/preparation level for now because no physical device or Garmin app access is available yet
+    - current Garmin-first field priority should be `resting_heart_rate`, `sleep_duration`, `steps_total`, and `hrv` with explicit method tagging
+    - HRV V1 policy should stay strict: always store/display method metadata, never compare or aggregate SDNN and RMSSD together, and keep `unknown` method out of engine input
+    - `wearable_metric_definitions` is already seeded for the first real device metrics, so the first slice does not need new metric-definition rows for `resting_heart_rate`, `sleep_duration`, `steps_total`, or `hrv`
+    - `subjective_energy` is worth treating as an early self-report calibrator, but should not be forced into wearable ingest just for symmetry; it fits better in `weekly_checkins` or a later adjacent self-report surface
+    - Garmin-first example payloads now exist under `supabase/functions/wearables-sync/examples/` in the current contract shape, using `platform = health_connect` as the temporary near-term path instead of inventing a premature `platform = garmin` contract
+    - `wearables-sync` now rejects inactive `wearable_sources`; ownership alone is not sufficient
+  - field-state work has moved from pure planning into implementation at local code/test level:
+    - a shared field-state contract now exists in `packages/domain/fieldValueState.ts`
+    - minimum-slice function parsing now accepts field-state metadata (`field_state`, `value_source`, `state_reason`) with early guardrails
+    - minimum-slice mobile draft/model/UI now support the first explicit optional-field states for `lpa` and `crp`
+    - minimum-slice recommendation logic now distinguishes `disabled` from generic `missing`, so intentionally excluded fields do not trigger false collect-more-data prompts
+    - current V1 simplification is to treat `provided` as a display-layer umbrella concept rather than a required persisted canonical state
+    - app UX should not block on smartwatch sync readiness: wearable-backed fields need a manual fallback so empty, partial, or clearly wrong smartwatch values can be corrected in-app before the real integration is fully live and trustworthy
+    - fields across the app should support an explicit disabled/not-provided state when a user does not have, does not know, or does not want to enter a value; calculation paths must treat that as intentional missingness, not as an error
+    - `declined` should stay out of V1 unless a real settings/preferences flow exists
+    - "reset to device value" should stay later unless the product explicitly retains parallel synced + manual candidate values
+  - verification status for this seam:
+    - field-state and Garmin-first prep are now verified at local code/typecheck/assertion/documentation level
+    - no real Garmin/device proof exists yet
+    - hosted/device: still pending for the wearable provisioning flow
 - Deployment note: domain files are vendored into `_lib/domain` at deploy time via `scripts/prepare-supabase-function-domain.sh`, while source of truth stays in `packages/domain/`
+- Local cleanup on 2026-04-16 removed disposable AI-generated repo/project clutter, deleted the stale local sandbox, removed the generated local `_lib/` copy under the function tree, and stashed the pre-cleanup local working tree as `local-sync-before-cleanup-2026-04-16`
 
 ## Current next step
 
 The next best steps are, in order:
-1. **Run first live authenticated Expo submit**: set `EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL` and `EXPO_PUBLIC_ONE_L1FE_SUPABASE_ANON_KEY` in `.env`, start the app, sign in with a real user, submit the minimum-slice form, verify HTTP 200 plus DB write under the correct `profileId`,
-2. smoke-test the remaining main auth failure modes once in Expo: wrong credentials and hosted function error,
-3. verify the explicit sign-out path once in Expo and confirm the app returns cleanly to Login without stale signed-in access,
-4. only then choose the next thin app seam, likely a second signed-in screen around the same controller surface,
-4. add schema drift detection CI only after the current lint plus replay path has stayed stable across a couple of clean cycles.
+1. **Cut the current local diff into focused PRs instead of reviving stale broad PRs**: prefer four slices, A = provisioning seam, B = ingest guardrails/examples, C = field-state contract plus first implementation, D = checkpoint/docs/QA,
+2. **Keep the single provisioning seam clean**: stay on `wearable-source-resolve` only, with mobile helpers and docs aligned to that path,
+3. **Keep field-state implementation coherent**: continue centralizing state rendering/behavior so the current `lpa`/`crp` slice becomes a reusable pattern instead of one-off UI logic,
+4. **Prepare Garmin-first, device-free inputs**: use `source_kind = vendor_api`, `vendor_name = garmin`, and an instance-level identifier (`app_install_id` now, `device_hardware_id` later) while treating `source_app_id` as metadata only,
+5. **Design the manual fallback path before trusting sync UX**: wearable-backed app fields must remain manually editable when sync is unavailable, partial, delayed, or obviously wrong,
+6. **Design explicit field disable semantics**: wearable and non-wearable fields must support a user-chosen disabled/not-provided state that is visible in the app and handled safely in scoring, recommendations, and validation,
+7. **Refine next-layer field semantics**: add `stale` only as a derived display/recommendation-layer freshness state backed by one shared typed domain policy, preferably from metric-level observation freshness rather than a coarse source timestamp, and keep `declined` out of V1 unless a real preference flow exists,
+8. **Keep the first wearable field slice tight**: target `resting_heart_rate`, `sleep_duration`, `steps_total`, and `hrv` first, while treating `subjective_energy` as self-report instead of device ingest,
+9. **Run hosted provisioning proof when credentials/runtime are ready**: call `wearable-source-resolve` with real auth and verify returned `wearable_source_id` ownership for the signed-in profile,
+10. **Then run one immediate ingest proof**: pass that id into one minimal `wearables-sync` request and verify `wearable_sync_runs` + `wearable_observations` writes,
+11. **Verify negative paths explicitly**: inactive source on `wearables-sync`, unknown source id on `wearables-sync`, missing/invalid auth on `wearable-source-resolve`, and missing instance-level identity on provisioning must return clear failures.
+
+Near-term simplifications to keep:
+- keep `declined` out of V1 unless a real settings/preferences flow exists
+- keep "reset to device value" as later work unless the product starts retaining parallel synced + manual candidate values explicitly
+- treat `provided` as a display-layer umbrella, not a required persisted state
+- keep the HRV render guard explicit in the reusable component contract as a WARN-level impossible-state fallback, not as a normal product path
 
 ## Startup rule
 
@@ -63,9 +101,13 @@ Only read deeper docs when the task actually touches them.
 - `docs/compliance/intended-use.md` only for health-adjacent copy, recommendation wording, or compliance boundaries.
 - `docs/architecture/evidence-registry-and-rule-governance-v1.md` only for provenance / evidence logic work.
 - `docs/roadmap/v1-checkpoint-and-next-agent-brief.md` only when planning the next implementation seam.
+- `docs/architecture/wearables-and-context-schema-draft.md` only when the task is specifically about the new wearable seam.
+- `docs/architecture/field-value-state-and-missingness-v1.md` when the task touches manual overrides, disabled/not-provided fields, or calculation behavior under missingness.
+- `docs/architecture/field-status-qa-checklist-v1.md` when the task is about test coverage, QA priorities, or release-blocking field-state failures.
 - `GLOSSARY.md` only when abbreviations or term meanings are unclear.
 - `README.md` only for broad repo orientation.
 - `supabase/README.md` for Supabase workflow, CI commands, secrets, and deploy procedure.
+- `supabase/functions/wearable-source-resolve/README.md` only when working directly on wearable source resolution/provisioning.
 
 ## Guardrails
 
@@ -75,3 +117,4 @@ Only read deeper docs when the task actually touches them.
 - Keep Notion out of hidden runtime logic.
 - Do not treat the Priority Score as a clinical risk score.
 - Keep raw personal health data, direct identifiers, and unsafe artifacts out of the repo. Use `docs/compliance/data-handling-and-redaction.md` as the canonical operational policy.
+- For wearable work, route mobile auth through `apps/mobile/mobileSupabaseAuth.ts` and do not create a second mobile Supabase client.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -2,7 +2,7 @@
 status: current
 canonical_for: durable project assumptions
 owner: repo
-last_verified: 2026-04-13
+last_verified: 2026-04-17
 supersedes: []
 superseded_by: null
 scope: repo
@@ -32,8 +32,26 @@ Important: this file stores project memory, not personal health records. Do not 
 - Keep the Priority Score framed as a bounded prioritization aid, not a clinical risk score.
 - Keep shared domain imports cross-runtime safe when the same files must run under both Node-based tests and Supabase Edge Functions.
 - For the first real mobile app seam, use Expo scaffolding first and avoid `expo-router` until there is a concrete navigation need.
-- The Expo scaffold under `apps/mobile/` uses a real Supabase auth session through `mobileSupabaseAuth.ts` (`auth.getSession()`), with real Expo env keys for Supabase URL and anon key instead of auth placeholders.
+- The Expo scaffold under `apps/mobile/` uses a real Supabase auth session through `mobileSupabaseAuth.ts`, with real Expo env keys for Supabase URL and anon key instead of auth placeholders.
 - Keep the mobile auth/session architecture thin and explicit: `useAuthSession.ts` owns auth-state subscription, `LoginScreen.tsx` owns sign-in UI, `MinimumSliceScreen.tsx` owns the signed-in minimum-slice form, and `App.tsx` stays a small auth-gate shell that wires those pieces together.
+- In the mobile auth seam, load `react-native-url-polyfill/auto` before `@supabase/supabase-js`.
+- Treat true signed-out auth states separately from operational auth errors in `getFreshAccessToken()` and adjacent mobile flows.
+- For wearable work, reuse `apps/mobile/mobileSupabaseAuth.ts` and do not introduce a second mobile Supabase client.
+- Early wearable seams should be prepared in a device-free, mockable way when no physical device/app access is available yet.
+- Garmin smartwatch is the current first planning target for wearable source provisioning.
+- The first tight Garmin-first field slice should prioritize `resting_heart_rate`, `sleep_duration`, `steps_total`, and `hrv` with explicit method metadata.
+- `subjective_energy` is useful as an early calibrator, but should stay self-report-first rather than being forced into wearable ingest.
+- The chosen pre-ingest provisioning seam is `supabase/functions/wearable-source-resolve/`.
+- Wearable source ownership should be anchored to instance-level identifiers (`app_install_id` now, `device_hardware_id` when real hardware exists), while `source_app_id` stays metadata and not the sole identity key.
+- `wearables-sync` must reject inactive `wearable_sources`; ownership alone is not sufficient.
+- Wearable-backed app fields must keep a manual-entry or manual-correction fallback so the product remains usable when smartwatch sync is unavailable, partial, delayed, or wrong.
+- App fields should support explicit intentional-missingness states when a user does not have, does not know, or does not want to provide a value. That state must be visible to the product logic and must not trigger calculation or validation errors.
+- In V1, treat `provided` as a display-layer umbrella concept rather than a required persisted canonical state.
+- Keep `declined` out of V1 unless a real settings/preferences flow exists.
+- If `stale` is added, derive it from one shared typed domain policy, preferably from metric-level freshness/observation timestamps rather than a coarse source timestamp.
+- Keep the HRV no-method render guard explicit in the reusable component contract as an impossible-state WARN path, not as a normal product path.
+- The canonical architecture note for this is `docs/architecture/field-value-state-and-missingness-v1.md`.
+- Field-state QA priorities and release blockers live in `docs/architecture/field-status-qa-checklist-v1.md`.
 - For wearables, keep daily summaries explicit about source scope (`single_source` vs `merged`) and timezone semantics, and keep context notes minimally structured with tags instead of free text only.
 
 ## Durable repo operations posture
@@ -43,12 +61,14 @@ Important: this file stores project memory, not personal health records. Do not 
 - `MEMORY.md` stores only durable assumptions and decisions.
 - `memory/` stores short-term working notes and daily continuity, not durable truth.
 - `main` should stay the stable branch, with short-lived branches for focused changes.
+- When the local baseline has moved materially, prefer fresh focused PR slices over reviving stale broad/meta PRs unchanged.
 - Keep lightweight GitHub hygiene in place: templates, CODEOWNERS, and CI for typecheck plus domain tests.
 - Do not let generated docs or AI-assisted code drift away from the actual implemented path.
 - Treat local Supabase replay plus authenticated smoke-test success as the required backend baseline before claiming the edge-function seam works.
 - Treat hosted Supabase security-advisor clean status plus ordered migration confirmation as sufficient evidence that the hardening baseline is live, even if GitHub-side enforcement still needs separate verification.
 - Do not treat a local-only Supabase function as a hosted-ready backend seam. Hosted deployment and one authenticated hosted smoke call are required before claiming the mobile path is production-ready.
 - The minimum-slice hosted backend seam is green only when all are true: hosted migrations match repo, RLS/policies are live, the function is deployed, and an authenticated hosted smoke call returns 200 with writes succeeding.
+- The minimum-slice mobile seam should be treated as proven only when login, authenticated submit, wrong-password handling, hosted-function error handling, and sign-out have all been verified in the real app.
 - Use `docs/compliance/data-handling-and-redaction.md` as the canonical operational policy for fixtures, screenshots, logs, smoke tests, and copied examples.
 - Use `docs/ops/openclaw.md` as the canonical OpenClaw operating guide for startup order, promotion rules, and short-term memory usage.
 

--- a/docs/architecture/field-status-qa-checklist-v1.md
+++ b/docs/architecture/field-status-qa-checklist-v1.md
@@ -1,0 +1,166 @@
+---
+status: draft
+canonical_for: field-status QA targets for minimum-slice and early wearable seams
+owner: repo
+last_verified: 2026-04-17
+supersedes: []
+superseded_by: null
+scope: qa
+---
+
+# Field status QA checklist v1
+
+## Verdict
+
+Before any serious app-facing rollout of field-state logic, the repo should explicitly test:
+- core state behavior,
+- HRV method safety,
+- calculation/recommendation suppression rules,
+- and wearable ingest safety rails.
+
+The highest-risk failures are:
+1. HRV reaching storage without a usable method,
+2. cross-user `wearable_source_id` access,
+3. treating `disabled` like generic `missing`,
+4. and silent state conflicts between synced and manual values.
+
+## P0 release blockers
+
+### Core field-state behavior
+
+1. `synced` with value present
+- Expected UI: value + source label
+- Expected calculation: value is eligible input
+- Expected recommendation behavior: normal path when prerequisites are met
+
+2. `manual_override` with value present
+- Expected UI: user-owned value label
+- Expected calculation: manual value wins over synced candidate
+- Expected recommendation behavior: based on manual value only
+
+3. `missing`
+- Expected UI: not-yet-recorded placeholder
+- Expected calculation: blocked
+- Expected recommendation behavior: no false positive recommendation from that field
+
+4. `disabled`
+- Expected UI: disconnected / intentionally excluded posture
+- Expected calculation: blocked
+- Expected recommendation behavior: suppress collect-more-data style prompts for that field
+
+5. synced + manual value both available
+- Expected UI: manual value stays primary
+- Expected calculation: manual value wins
+- Expected recommendation behavior: recomputed from manual value
+
+6. edit transition from `synced` -> `manual_override`
+- Expected UI: state updates immediately
+- Expected calculation: recalculates immediately from manual value
+
+### HRV-specific blockers
+
+7. HRV with `rmssd`
+- Expected UI: method label visible
+- Expected calculation: allowed
+
+8. HRV with `sdnn`
+- Expected UI: method label visible
+- Expected calculation: allowed, but never mixed with RMSSD
+
+9. HRV without method
+- Expected ingest behavior: rejected before storage
+- Expected downstream behavior: unavailable, not partially accepted
+
+10. HRV method changes between syncs
+- Expected UI: method-change warning
+- Expected calculation: no cross-method trend or merge
+
+11. two active HRV sources with different methods
+- Expected UI: per-source display only
+- Expected calculation: no merged trend
+
+### Wearable ingest blockers
+
+12. duplicate `source_record_id`
+- Expected behavior: upsert, no duplicate row creation
+
+13. unknown `metric_key`
+- Expected behavior: reject request item / fail validation path clearly
+
+14. чужой `wearable_source_id`
+- Expected behavior: reject, no writes
+
+15. empty observations array
+- Expected behavior: accepted only if the contract deliberately allows it; otherwise reject clearly.
+- Current repo note: current `validate.ts` requires `observations` to be an array but does not enforce non-empty, so this should be verified intentionally rather than assumed.
+
+## P1 next-layer tests
+
+1. `stale` display-layer state
+- Value shown with explicit freshness label
+- never silently treated as current
+
+2. `declined` state, if later adopted
+- blocked like missing for engine purposes
+- UX-distinct from ordinary missingness
+
+3. reset from `manual_override` back to synced
+- only visible when a synced candidate still exists
+- recomputes from synced value
+
+4. manual HRV entry requires method selection
+- no method, no submit
+
+5. lab-field stale handling (`lpa`, `crp`)
+- date labeled
+- interpretation bounded by age
+
+6. source deactivated mid-session
+- later syncs rejected until reactivation path is explicit
+
+7. timezone/day-boundary handling for sleep-derived metrics
+- `source_timezone` must be preserved and used in day assignment logic
+
+## P2 capacity-allowing tests
+
+1. rapid state transitions in one session
+- final state wins
+- no stale intermediate UI state persists
+
+2. oversized payload behavior
+- confirm practical failure mode and whether partial success semantics are ever introduced
+- Current repo note: current implementation chunks by 500 but validation caps requests at 5000; true 10k handling is not a current contract guarantee.
+
+3. future timestamps / clock skew
+- current behavior should be made explicit before relying on it
+
+4. multiple same-field lab results on different dates
+- most recent should win in UI unless a historical comparison surface is explicitly built
+
+## Repo-specific highest-risk targets to keep explicit
+
+### 1. HRV method enforcement
+
+Current repo posture already rejects `unknown` for new HRV observations in:
+- `supabase/functions/wearables-sync/_lib/validate.ts`
+
+That should remain explicitly asserted before broadening any wearable work.
+
+### 2. Cross-user wearable source access
+
+Ownership check currently lives in:
+- `supabase/functions/wearables-sync/_lib/sync.ts`
+
+That path should keep explicit tests because it is a true security boundary, not just UX logic.
+
+### 3. Disabled vs missing semantics
+
+Current repo posture now distinguishes `disabled` from generic `missing` in the minimum-slice domain flow.
+That distinction should remain covered so later refactors do not reintroduce false collect-more-data prompts.
+
+## Recommended next assertion additions
+
+1. add explicit assertion coverage for cross-user `wearable_source_id` rejection
+2. add explicit assertion coverage for HRV-without-method rejection at the wearable validate layer
+3. add assertion coverage for disabled-vs-missing recommendation suppression beyond the current minimum-slice slice
+4. add a small UI/model-level test matrix once field-state rendering is centralized further

--- a/docs/architecture/field-value-state-and-missingness-v1.md
+++ b/docs/architecture/field-value-state-and-missingness-v1.md
@@ -1,0 +1,318 @@
+---
+status: draft
+canonical_for: field state, manual override, and intentional missingness handling
+owner: repo
+last_verified: 2026-04-17
+supersedes: []
+superseded_by: null
+scope: architecture
+---
+
+# Field value state and missingness policy v1
+
+## Verdict
+
+App fields that influence calculations, recommendations, summaries, or validation must not be modeled as a raw value alone.
+They need an explicit field state that distinguishes:
+1. present values,
+2. synced values,
+3. manual overrides,
+4. temporarily missing values,
+5. intentionally disabled values.
+
+This applies to wearable-backed fields and to other relevant app fields.
+
+## Why
+
+A blank field is ambiguous.
+It can mean:
+- the integration failed,
+- the user has not entered the value yet,
+- the value is not available,
+- the user does not know it,
+- the user does not want to provide it,
+- or the app intentionally should not use it.
+
+Those are not the same product or calculation state.
+If they are collapsed into `null`, the app will eventually produce:
+- broken validation,
+- misleading coverage,
+- accidental zero-like behavior,
+- incorrect scoring,
+- or dishonest result confidence.
+
+## Core rule
+
+Every calculation-relevant field should be represented by:
+- `value`
+- `field_state`
+- `value_source`
+- optional `state_reason`
+- optional provenance metadata
+
+The system must reason on `field_state`, not just on `value`.
+
+## Recommended state model
+
+### `field_state`
+
+Use one of these canonical states in the current implementation baseline:
+- `synced`
+- `manual_override`
+- `missing`
+- `disabled`
+
+Implementation simplification for V1:
+- treat `provided` as a display-layer umbrella concept, not as a separately stored canonical state
+- store concrete active states like `synced` and `manual_override` instead of maintaining a second redundant `provided` value in persistence
+
+Likely next additions after the first slice stabilizes:
+- `stale` as a display/recommendation-layer state derived from timestamps and per-metric freshness windows
+- `declined` as a UX-distinct form of intentional non-provision, if the product needs to distinguish "not available" from "prefer not to share"
+
+Current V1.5 direction for `stale`:
+- derive it, do not store it as a DB column
+- compute it from one shared typed domain-layer policy instead of scattering thresholds per feature
+- never silently present a stale value as current
+- never silently collapse `stale` into `missing`
+
+### Meaning of each state
+
+#### `provided`
+Meaning:
+- a user-entered or app-entered value is present and currently active.
+
+Use when:
+- the field is filled manually and there is no competing synced source.
+
+V1 note:
+- in current repo language this remains useful as a UI/app-facing concept, but it should not force a redundant persisted state if `manual_override` or another concrete active state already explains the value.
+
+#### `synced`
+Meaning:
+- the active value currently comes from an external source such as Apple Health, Health Connect, or Garmin.
+
+Use when:
+- the value was imported and is being used as the current app value.
+
+#### `manual_override`
+Meaning:
+- a synced or defaulted value exists, but the user intentionally replaced or corrected it.
+
+Use when:
+- sync is wrong,
+- sync is partial,
+- sync is stale,
+- or the user wants to trust a manually known value instead.
+
+#### `missing`
+Meaning:
+- no usable value is currently present, but the field is still conceptually applicable.
+
+Use when:
+- sync has not completed,
+- the user has not entered anything yet,
+- or the source is temporarily unavailable.
+
+Important:
+- `missing` is not an error by itself.
+- `missing` is not the same as `disabled`.
+
+#### `disabled`
+Meaning:
+- the field should be intentionally excluded from normal use and from calculations that depend on it.
+
+Use when:
+- the source was deactivated,
+- permissions were revoked,
+- the product flow intentionally excludes it,
+- or the user chose not to keep that source active.
+
+Important:
+- `disabled` must never be interpreted as zero.
+- `disabled` must never silently fall back to a guessed value.
+- `disabled` should reduce coverage or confidence when relevant, but must not throw validation/runtime errors.
+- `disabled` should invalidate reuse of the last known value unless a later product rule explicitly says otherwise.
+
+## `value_source`
+
+Recommended canonical values:
+- `manual`
+- `wearable_sync`
+- `vendor_import`
+- `lab`
+- `derived`
+- `unknown`
+
+Notes:
+- `field_state` and `value_source` are not interchangeable.
+- Example: a field can have `field_state = manual_override` and `value_source = manual`.
+- Example: a field can have `field_state = synced` and `value_source = wearable_sync`.
+
+## Optional `state_reason`
+
+Use small explicit reasons instead of freeform text where possible.
+
+Suggested values:
+- `not_available`
+- `not_known`
+- `prefer_not_to_answer`
+- `sync_failed`
+- `sync_partial`
+- `sync_suspect`
+- `user_corrected`
+- `user_disabled`
+- `out_of_scope`
+
+If the product later promotes `declined` into its own explicit state, prefer using that for UX semantics rather than overloading `state_reason` alone.
+
+## Product behavior rules
+
+## 1. Validation
+
+Validation must distinguish between:
+- invalid value shape,
+- missing active value,
+- intentionally disabled field.
+
+Required behavior:
+- `disabled` should not trigger required-field errors.
+- `missing` may trigger completeness warnings when the field matters.
+- malformed provided values should still fail validation.
+
+## 2. Calculations and scoring
+
+Calculation paths must never use naive truthiness checks.
+They must branch on field state.
+
+Required behavior:
+- `provided`, `synced`, and `manual_override` are eligible active inputs.
+- `missing` is excluded from direct calculation input.
+- `disabled` is excluded from direct calculation input.
+- if `stale` is introduced later, it should be handled as conditionally usable with explicit freshness labeling rather than silently collapsing into `missing`.
+- stale windows should live in one typed domain-layer policy shared by display and recommendation paths.
+- if a result depends materially on a `missing` or `disabled` field, coverage/confidence must reflect that.
+- no path should crash because a field is `disabled`.
+
+## 3. Recommendations
+
+Recommendations must treat unavailable inputs honestly.
+
+Required behavior:
+- do not invent certainty when a prerequisite field is `missing` or `disabled`.
+- when a recommendation depends on a disabled field, either:
+  - omit that recommendation path, or
+  - surface reduced confidence / insufficient data explicitly.
+
+## 4. UI behavior
+
+The UI should make source and state visible without becoming noisy.
+
+Each relevant field should support:
+- enter manually,
+- sync/import when available,
+- edit/correct manually,
+- disable / mark as not provided.
+
+Suggested UI labels:
+- `From your device`
+- `Your value`
+- `Adjusted by you`
+- `Not yet recorded`
+- `Source disconnected`
+- `Not provided`
+
+Suggested field-level action posture:
+- `synced`: view detail, manual edit
+- `manual_override`: edit, optionally reset to device value when a synced candidate still exists
+- `missing`: enter manually, connect device
+- `disabled`: reconnect source, enter manually
+- later `stale`: edit, reconnect source
+- later `declined`: change preference
+
+Copy guidance:
+- keep labels short,
+- avoid apologetic wording,
+- show longer help text on demand instead of permanently,
+- prefer relative freshness text like `2 days ago` if a stale state is surfaced,
+- keep state rendering centralized in a reusable field component instead of duplicating it per metric.
+
+## 5. Sync conflict behavior
+
+When a synced value and a user correction conflict:
+- do not silently overwrite the manual correction.
+- keep the user-selected active state explicit.
+- later syncs may refresh the underlying synced candidate, but should not automatically replace `manual_override`.
+
+## Wearable-first application
+
+For wearable-backed fields, the UI and state model should assume sync can be:
+- absent,
+- delayed,
+- partially populated,
+- stale,
+- or wrong.
+
+So the product should support this progression cleanly:
+1. field starts as `missing`
+2. user enters a temporary manual value, state becomes `provided`
+3. Garmin sync later arrives, state can become `synced`
+4. user distrusts synced value and corrects it, state becomes `manual_override`
+5. user does not want this field considered at all, state becomes `disabled`
+
+## Recommended app-facing shape
+
+A minimal generic shape:
+
+```ts
+export type FieldState =
+  | 'provided'
+  | 'synced'
+  | 'manual_override'
+  | 'missing'
+  | 'disabled';
+
+export type FieldValueSource =
+  | 'manual'
+  | 'wearable_sync'
+  | 'vendor_import'
+  | 'lab'
+  | 'derived'
+  | 'unknown';
+
+export type FieldStateReason =
+  | 'not_available'
+  | 'not_known'
+  | 'prefer_not_to_answer'
+  | 'sync_failed'
+  | 'sync_partial'
+  | 'sync_suspect'
+  | 'user_corrected'
+  | 'user_disabled'
+  | 'out_of_scope';
+
+export interface AppFieldValue<T> {
+  value: T | null;
+  field_state: FieldState;
+  value_source: FieldValueSource;
+  state_reason?: FieldStateReason | null;
+  updated_at?: string | null;
+  source_updated_at?: string | null;
+}
+```
+
+## Guardrails
+
+- Do not conflate `missing` with `disabled`.
+- Do not use `0`, empty string, or `false` as a proxy for disabled.
+- Do not hide provenance after manual override.
+- Do not silently downgrade manual corrections on the next sync.
+- Do not let disabled fields throw runtime or calculation errors.
+
+## Recommended next implementation steps
+
+1. define a shared TypeScript field-state contract in app/domain code,
+2. decide which current app fields need the full state model first,
+3. add UI affordances for manual edit and disable/not-provided,
+4. thread field-state awareness into calculation and summary paths,
+5. add tests for `missing` vs `disabled` vs `manual_override`.

--- a/docs/architecture/wearables-and-context-schema-draft.md
+++ b/docs/architecture/wearables-and-context-schema-draft.md
@@ -363,7 +363,7 @@ If ingested at all, store them with:
 
 ## Recommended first V1 metric keys
 
-Best first candidates:
+Best first candidates already present in seeded `wearable_metric_definitions`:
 - `steps_total`
 - `active_minutes`
 - `workout_session`
@@ -378,14 +378,101 @@ Best first candidates:
 - `temperature_deviation`
 
 Not all need to be supported on day one.
-The best first cut is:
-- steps
-- workouts
-- heart rate
-- resting heart rate
-- HRV with stored method metadata
-- sleep session timing
-- sleep duration
+The best first Garmin-first cut is:
+- `resting_heart_rate`
+- `sleep_duration`
+- `steps_total`
+- `hrv` with explicit stored method metadata
+- `subjective_energy` as a parallel self-report anchor, not as a Garmin metric
+
+### V1 must-have field priority
+
+1. `resting_heart_rate`
+   - strong cardiovascular baseline
+   - low error risk because trends matter more than one absolute reading
+   - manually estimable if sync is absent
+   - native Garmin fit
+
+2. `sleep_duration`
+   - core recovery signal and directly actionable
+   - medium risk if wrong because recovery logic can drift
+   - manually estimable
+   - reliable Garmin fit
+
+3. `steps_total`
+   - stable activity baseline and strong engagement anchor
+   - low error risk because directional value still helps
+   - easy manual fallback
+   - reliable Garmin fit
+
+4. `hrv`
+   - recovery-critical but method-sensitive
+   - high misuse risk if SDNN / RMSSD are conflated
+   - poor manual fallback
+   - usable from Garmin only when method stays explicit
+
+5. `subjective_energy`
+   - valuable calibrator for device data and user trust
+   - should be modeled as self-report first, not as wearable ingest
+   - no Garmin dependency
+
+### V1.5 candidates
+
+- `active_minutes`
+- `sleep_session` / sleep onset timing
+- `weight` (better manual-first unless a scale integration exists)
+- vendor `stress score` only with clear black-box posture and no early hard-engine dependence
+
+### Later / cautious metrics
+
+Keep these later unless there is a strong reason and an explicit confidence downgrade:
+- `spo2`
+- `temperature_deviation`
+- `respiratory_rate`
+
+These are useful context signals, but early over-trust would be risky.
+
+### HRV method policy for V1
+
+Verdict:
+- store HRV with explicit method metadata,
+- never merge or trend RMSSD and SDNN together,
+- always display the method label,
+- keep `unknown` method out of engine input.
+
+Working rules:
+- `measurement_method` is application-required for `metric_key = 'hrv'`
+- allowed methods remain `sdnn` and `rmssd` for active use
+- `unknown` may be retained only as a reference-only bucket if a later ingest path explicitly decides to keep it, but it must not feed engine logic or cross-method trend views
+- same method + same source: normal trend path allowed
+- same method + different source: only with explicit source labeling
+- different methods: store separately, display separately, never aggregate together
+
+Implementation posture:
+- `wearable_observations.measurement_method` already exists and should be treated as mandatory in application validation for HRV even though the column itself is nullable
+- nightly Garmin HRV should not be assumed to be raw-sample equivalent until the real payload shape is verified
+- if Garmin or another source only yields nightly derived HRV, preserve that provenance via `vendor_signal_class`
+- UI should always render the HRV method label when a value is shown
+- if the active HRV source/method changes, trend comparison should pause rather than silently stitching lines together
+- if multiple HRV sources are active, show them per source and never merged
+
+Important repo-specific note:
+- current `wearables-sync` validation already rejects `unknown` for new HRV observations. That is stricter than a "store but engine-exclude" fallback and is the safer current default until a deliberate exception path is designed.
+- because of that current repo posture, UI should not offer an `unknown` HRV method path for active V1 entry flows unless backend policy is deliberately loosened later.
+
+### Modeling note: subjective energy
+
+`subjective_energy` should not be introduced as a fake Garmin-style metric just to keep one table shape.
+Prefer one of these paths:
+- add it to `weekly_checkins` / adjacent self-report surfaces first, or
+- add a later dedicated self-report field if product cadence needs it more often than weekly.
+
+Do not pretend it is device-observed.
+
+Recommended rollout:
+- V1: extend `weekly_checkins` with an `energy_score`-style self-report field if/when the weekly check-in flow is activated
+- V1.5: add a daily or on-demand self-report surface only if finer recovery/context resolution becomes product-critical
+- Never derive `subjective_energy` from HRV, steps, or sleep and then present it as if the user reported it
 
 ## RLS posture
 


### PR DESCRIPTION
## Merge order
Merge last, after PRs A, B, and C.
This PR captures docs, checkpointing, and QA follow-up once the implementation PRs are in place.

## What this PR does
- updates `CHECKPOINT.md` to reflect the wearable provisioning seam and field-state implementation status
- updates durable memory for the current seam decisions
- adds architecture documentation for field-value state and missingness
- adds a QA checklist for field-status behavior
- updates the wearables schema draft to match the current direction

## Why
This keeps the durable project layer aligned with the implementation split and makes the remaining verification work explicit.

## Reviewer focus
Please verify:
- docs match the committed implementation and current branch split
- checkpoint and memory updates are accurate and non-regressive
- QA and architecture guidance are actionable for the next execution step
