### PR TITLE
checkpoint: post PR-E/F — field-state stale policy + validate guardrails live

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -12,83 +12,73 @@ scope: repo
 
 ## Verdict
 
-The minimum-slice mobile seam is now proven live end to end in the real app: login, authenticated submit, wrong-password handling, hosted-function error handling, and sign-out were all verified on device, and the next active seam is now **wearable ingestion proof** with `wearable_source_id` ownership and provisioning as the first real design and implementation question.
+The minimum-slice mobile seam is proven live end to end. Field-state contract is now complete through the `stale` derived-policy layer. Wearable ingestion proof (provisioning + first ingest) is the only remaining active seam — all local code, migration, and doc prep is done; hosted function deployment and smoke-test are the remaining blockers.
 
 ## Current state
 
 - Branch: `main`, currently aligned with `origin/main` as the clean base for the next cycle
-- Active seam: minimum-slice proof complete, wearable ingestion proof opened as the only active next seam
+- Active seam: wearable ingestion proof — local prep complete, hosted deployment + smoke-test still pending
 - Source of truth repo: `gzug/One-L1fe`
 - Current blockers:
+  - **PR #52** (`pr-e-field-state-stale-and-validate-guardrails`) — open, awaiting CI + review
+  - **PR #53** (`pr-f-memory-stale-policy-live`) — open, merge after #52
+  - **PR #54** (`pr-g-checkpoint-post-ef`) — this PR, merge after #53
+  - hosted deployment of `wearable-source-resolve` and `wearables-sync` still pending — no physical device/Garmin app available yet
   - no product blocker remains on the minimum-slice seam
-  - PR #47 (`checkpoint: minimum-slice proof complete, wearable ingestion next`) was opened to close the previous cycle, but should only be merged if it is clearly non-regressive against the current local checkpoint state; otherwise carry its intent forward into new focused PRs
-  - hosted verification for the new wearable provisioning + `wearables-sync` sequence is still pending (current proof is local code/test level)
-  - no physical wearable/device/app is available locally yet, so the current Garmin-first workstream should stay device-free: schema, auth, functions, mobile seams, mocks, and docs first
 - Key confirmed facts:
-  - hosted migrations match repo
+  - hosted migrations match repo (all 8 migrations including `20260417093000_wearable_source_identity_guards.sql`)
   - RLS and policies are live
-  - `save-minimum-slice-interpretation` works for real authenticated mobile submit after disabling gateway JWT verification and relying on explicit in-function auth via `supabase.auth.getUser()`
-  - the minimum-slice proof now includes all four smoke checks as live-confirmed behavior: wrong password, hosted function error path, successful sign-out, and successful authenticated submit
-  - Expo Go login via QR was confirmed live on iPhone for `g.zugang@hotmail.com`
-  - the current controllable confirmed smoke-test user is `g.zugang@hotmail.com` (UID `523b48a4-2aa2-4e4c-97f2-8fa95141ac8b`) and a matching `public.profiles` row exists
-  - `mobileSupabaseAuth.ts` uses AsyncStorage-backed Supabase session persistence for Expo/RN and now normalizes true signed-out cases distinctly from operational auth errors
+  - `save-minimum-slice-interpretation` works for real authenticated mobile submit
+  - Expo Go login via QR confirmed live on iPhone for `g.zugang@hotmail.com`
+  - the current controllable confirmed smoke-test user is `g.zugang@hotmail.com` (UID `523b48a4-2aa2-4e4c-97f2-8fa95141ac8b`)
+  - `mobileSupabaseAuth.ts` uses AsyncStorage-backed Supabase session persistence, normalizes true signed-out cases distinctly from operational auth errors
   - `react-native-url-polyfill/auto` must load before `@supabase/supabase-js` in the mobile auth seam
-  - mobile auth assertions now cover no-session, `user === null`, `getUser` error, `getSession` error, and valid-session cases
-  - minimum-slice HTTP transport assertions now cover both `apikey` inclusion when provided and omission when no anon key is provided
-  - current mobile diagnostics surface hosted function URL plus Supabase gateway error codes on failure instead of only a generic 401
-  - `apps/mobile/.gitignore` now protects `.env` and `.env.*`
-  - `apps/mobile/metro.config.js` is present to make the Expo app resolve the workspace layout cleanly under the monorepo
-  - for the wearable seam, mobile auth must continue to flow through `apps/mobile/mobileSupabaseAuth.ts`; do not introduce a parallel mobile Supabase client
-  - thin wearable provisioning work is in progress at local-prep level:
-    - the chosen provisioning path is now `supabase/functions/wearable-source-resolve/`; the parallel `provision-wearable-source/` draft should stay removed
-    - local mobile helpers exist at `apps/mobile/wearableSourceProvisioning.ts` and `apps/mobile/src/hooks/useWearableSource.ts`, and wearable calls must continue to reuse `apps/mobile/mobileSupabaseAuth.ts`
-    - provisioning identity should be anchored to instance-level identifiers only: `app_install_id` first for device-free prep, `device_hardware_id` later when real Garmin hardware exists
-    - `source_app_id` should be treated as connector metadata, not as a sole ownership key
-    - local migration prep should keep only the identity-guard path (`20260417093000_wearable_source_identity_guards.sql`); the earlier composite uniqueness draft should stay discarded because it collapses multiple legitimate sources too aggressively
-    - Garmin smartwatch is the first intended wearable target for the seam, but only at planning/preparation level for now because no physical device or Garmin app access is available yet
-    - current Garmin-first field priority should be `resting_heart_rate`, `sleep_duration`, `steps_total`, and `hrv` with explicit method tagging
-    - HRV V1 policy should stay strict: always store/display method metadata, never compare or aggregate SDNN and RMSSD together, and keep `unknown` method out of engine input
-    - `wearable_metric_definitions` is already seeded for the first real device metrics, so the first slice does not need new metric-definition rows for `resting_heart_rate`, `sleep_duration`, `steps_total`, or `hrv`
-    - `subjective_energy` is worth treating as an early self-report calibrator, but should not be forced into wearable ingest just for symmetry; it fits better in `weekly_checkins` or a later adjacent self-report surface
-    - Garmin-first example payloads now exist under `supabase/functions/wearables-sync/examples/` in the current contract shape, using `platform = health_connect` as the temporary near-term path instead of inventing a premature `platform = garmin` contract
-    - `wearables-sync` now rejects inactive `wearable_sources`; ownership alone is not sufficient
-  - field-state work has moved from pure planning into implementation at local code/test level:
-    - a shared field-state contract now exists in `packages/domain/fieldValueState.ts`
-    - minimum-slice function parsing now accepts field-state metadata (`field_state`, `value_source`, `state_reason`) with early guardrails
-    - minimum-slice mobile draft/model/UI now support the first explicit optional-field states for `lpa` and `crp`
-    - minimum-slice recommendation logic now distinguishes `disabled` from generic `missing`, so intentionally excluded fields do not trigger false collect-more-data prompts
-    - current V1 simplification is to treat `provided` as a display-layer umbrella concept rather than a required persisted canonical state
-    - app UX should not block on smartwatch sync readiness: wearable-backed fields need a manual fallback so empty, partial, or clearly wrong smartwatch values can be corrected in-app before the real integration is fully live and trustworthy
-    - fields across the app should support an explicit disabled/not-provided state when a user does not have, does not know, or does not want to enter a value; calculation paths must treat that as intentional missingness, not as an error
-    - `declined` should stay out of V1 unless a real settings/preferences flow exists
-    - "reset to device value" should stay later unless the product explicitly retains parallel synced + manual candidate values
-  - verification status for this seam:
-    - field-state and Garmin-first prep are now verified at local code/typecheck/assertion/documentation level
-    - no real Garmin/device proof exists yet
-    - hosted/device: still pending for the wearable provisioning flow
-- Deployment note: domain files are vendored into `_lib/domain` at deploy time via `scripts/prepare-supabase-function-domain.sh`, while source of truth stays in `packages/domain/`
-- Local cleanup on 2026-04-16 removed disposable AI-generated repo/project clutter, deleted the stale local sandbox, removed the generated local `_lib/` copy under the function tree, and stashed the pre-cleanup local working tree as `local-sync-before-cleanup-2026-04-16`
+  - `apps/mobile/.gitignore` protects `.env` and `.env.*`
+  - `apps/mobile/metro.config.js` present for monorepo layout resolution
+  - for the wearable seam, mobile auth must continue to flow through `apps/mobile/mobileSupabaseAuth.ts`
+  - wearable provisioning path is `supabase/functions/wearable-source-resolve/` only; the parallel `provision-wearable-source/` draft is removed
+  - local mobile helpers exist at `apps/mobile/wearableSourceProvisioning.ts` and `apps/mobile/src/hooks/useWearableSource.ts`
+  - provisioning identity anchored to instance-level identifiers: `app_install_id` first, `device_hardware_id` later
+  - `source_app_id` is connector metadata, not a sole ownership key
+  - identity-guard migration (`20260417093000_wearable_source_identity_guards.sql`) is on `main` and applies unique index guards for `(profile_id, source_kind, app_install_id)` and `(profile_id, source_kind, device_hardware_id)`
+  - `wearables-sync` rejects inactive `wearable_sources` and now also rejects empty observations arrays (enforced in `validate.ts` as of PR #52)
+  - Garmin smartwatch is the first intended wearable target, but only at planning/preparation level; no physical device or Garmin app access yet
+  - Garmin-first field priority: `resting_heart_rate`, `sleep_duration`, `steps_total`, `hrv` with explicit method tagging
+  - HRV V1 policy: always store/display method metadata, never compare or aggregate SDNN and RMSSD together, `unknown` method rejected at `validate.ts` layer
+  - `wearable_metric_definitions` already seeded for first real device metrics
+  - `subjective_energy` stays self-report-first, not forced into wearable ingest
+  - Garmin-first example payloads exist under `supabase/functions/wearables-sync/examples/` using `platform = health_connect` as the near-term path
+  - field-state contract is now complete:
+    - `packages/domain/fieldValueState.ts` defines `FieldState`, `FieldValueSource`, `FieldStateReason`, `AppFieldValue<T>`, `ACTIVE_FIELD_STATES`, `isActiveFieldState()`, `requiresNullValueForFieldState()`, `DerivedDisplayState`, `isDerivedStale()`, `getDerivedDisplayState()`
+    - `stale` is a derived display/recommendation concept only — never persisted as a `field_state` column value; derived at read/render time via `isDerivedStale()` (default 30-day window, configurable)
+    - minimum-slice function parsing accepts field-state metadata (`field_state`, `value_source`, `state_reason`) with early guardrails
+    - minimum-slice mobile draft/model/UI support explicit optional-field states for `lpa` and `crp`
+    - minimum-slice recommendation logic distinguishes `disabled` from generic `missing` — intentionally excluded fields do not trigger false collect-more-data prompts
+    - `declined` stays out of V1 unless a real settings/preferences flow exists
+    - `provided` is a display-layer umbrella concept, not a required persisted canonical state
+    - "reset to device value" stays later unless the product starts retaining parallel synced + manual candidate values explicitly
+  - field-state QA checklist (`docs/architecture/field-status-qa-checklist-v1.md`) is now `status: current`:
+    - P0 #9 (HRV-without-method) marked enforced
+    - P0 #15 (empty observations) marked enforced
+    - P1 #1 (stale) updated with implementation pointer
+  - deployment note: domain files are vendored into `_lib/domain` at deploy time via `scripts/prepare-supabase-function-domain.sh`; source of truth stays in `packages/domain/`
+  - local cleanup on 2026-04-16 removed disposable AI-generated repo/project clutter
 
 ## Current next step
 
-The next best steps are, in order:
-1. **Cut the current local diff into focused PRs instead of reviving stale broad PRs**: prefer four slices, A = provisioning seam, B = ingest guardrails/examples, C = field-state contract plus first implementation, D = checkpoint/docs/QA,
-2. **Keep the single provisioning seam clean**: stay on `wearable-source-resolve` only, with mobile helpers and docs aligned to that path,
-3. **Keep field-state implementation coherent**: continue centralizing state rendering/behavior so the current `lpa`/`crp` slice becomes a reusable pattern instead of one-off UI logic,
-4. **Prepare Garmin-first, device-free inputs**: use `source_kind = vendor_api`, `vendor_name = garmin`, and an instance-level identifier (`app_install_id` now, `device_hardware_id` later) while treating `source_app_id` as metadata only,
-5. **Design the manual fallback path before trusting sync UX**: wearable-backed app fields must remain manually editable when sync is unavailable, partial, delayed, or obviously wrong,
-6. **Design explicit field disable semantics**: wearable and non-wearable fields must support a user-chosen disabled/not-provided state that is visible in the app and handled safely in scoring, recommendations, and validation,
-7. **Refine next-layer field semantics**: add `stale` only as a derived display/recommendation-layer freshness state backed by one shared typed domain policy, preferably from metric-level observation freshness rather than a coarse source timestamp, and keep `declined` out of V1 unless a real preference flow exists,
-8. **Keep the first wearable field slice tight**: target `resting_heart_rate`, `sleep_duration`, `steps_total`, and `hrv` first, while treating `subjective_energy` as self-report instead of device ingest,
-9. **Run hosted provisioning proof when credentials/runtime are ready**: call `wearable-source-resolve` with real auth and verify returned `wearable_source_id` ownership for the signed-in profile,
-10. **Then run one immediate ingest proof**: pass that id into one minimal `wearables-sync` request and verify `wearable_sync_runs` + `wearable_observations` writes,
-11. **Verify negative paths explicitly**: inactive source on `wearables-sync`, unknown source id on `wearables-sync`, missing/invalid auth on `wearable-source-resolve`, and missing instance-level identity on provisioning must return clear failures.
+In order:
+1. **Merge open PRs in order**: #52 (field-state+validate) → #53 (memory) → #54 (this checkpoint)
+2. **Deploy `wearable-source-resolve` to hosted Supabase** and run one authenticated smoke call to verify `wearable_source_id` ownership for `g.zugang@hotmail.com`
+3. **Deploy `wearables-sync` to hosted Supabase** and run one minimal ingest request using the resolved `wearable_source_id`; verify `wearable_sync_runs` + `wearable_observations` writes
+4. **Verify negative paths explicitly**: inactive source on `wearables-sync`, unknown source id, missing/invalid auth on `wearable-source-resolve`, missing instance-level identity on provisioning
+5. **Then open CHECKPOINT for wearable seam proven** — once steps 2–4 are green
 
 Near-term simplifications to keep:
 - keep `declined` out of V1 unless a real settings/preferences flow exists
-- keep "reset to device value" as later work unless the product starts retaining parallel synced + manual candidate values explicitly
+- keep "reset to device value" as later work
 - treat `provided` as a display-layer umbrella, not a required persisted state
-- keep the HRV render guard explicit in the reusable component contract as a WARN-level impossible-state fallback, not as a normal product path
+- keep the HRV render guard explicit in the reusable component contract as a WARN-level impossible-state fallback
+- keep `isDerivedStale()` default 30-day window as the lab-field starting policy; tighten for wearable-freshness at callsite when real sync data exists
 
 ## Startup rule
 


### PR DESCRIPTION
## Merge order
Merge after PR #53 (`pr-f-memory-stale-policy-live`). Chain: #52 → #53 → #54 (this).

## What this PR does

Updates `CHECKPOINT.md` to reflect the current repo state after PRs E and F:

- Removes the stale "four focused PR slices" next-step framing (A–D are merged, E+F open)
- Records PRs #52 and #53 as open blockers with merge order
- Documents the field-state contract as **complete** through the `stale` derived-policy layer:
  - `isDerivedStale()` + `getDerivedDisplayState()` live in `fieldValueState.ts`
  - `stale` is explicitly derived-only, never persisted
  - `wearables-sync` empty observations now enforced
  - QA checklist now `status: current` with P0 #9 and #15 marked enforced
- Tightens the next-step list to the concrete remaining blocker: hosted deployment + smoke-test for `wearable-source-resolve` and `wearables-sync`
- Cleans up forward-looking language that was already delivered

## Why
CHECKPOINT was still describing the field-state work as a future task even though it is now fully implemented and assertion-covered. Keeping it accurate prevents the next agent session from re-doing work that is already done.
