### PR TITLE
feat(mobile): add useWearableSource hook

### DIFF
--- a/apps/mobile/useWearableSource.ts
+++ b/apps/mobile/useWearableSource.ts
@@ -1,0 +1,46 @@
+import { useState, useCallback } from 'react';
+import {
+  resolveWearableSourceForCurrentUser,
+  ResolveWearableSourceRequest,
+  ResolveWearableSourceResponse,
+} from './wearableSourceProvisioning';
+
+export type WearableSourceState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ready'; wearableSourceId: string; response: ResolveWearableSourceResponse }
+  | { status: 'error'; message: string };
+
+export interface UseWearableSourceOptions {
+  // Reserved for future use: pass auto: true to trigger provision on mount.
+  // Not implemented in v1 — provision must be called explicitly.
+  auto?: false;
+}
+
+export function useWearableSource(_options: UseWearableSourceOptions = {}) {
+  const [state, setState] = useState<WearableSourceState>({ status: 'idle' });
+
+  const provision = useCallback(async (request: ResolveWearableSourceRequest) => {
+    setState({ status: 'loading' });
+    try {
+      const response = await resolveWearableSourceForCurrentUser(request);
+      setState({
+        status: 'ready',
+        wearableSourceId: response.wearable_source_id,
+        response,
+      });
+    } catch (err) {
+      setState({
+        status: 'error',
+        message:
+          err instanceof Error
+            ? err.message
+            : 'Unknown error during wearable source provisioning.',
+      });
+    }
+  }, []);
+
+  const reset = useCallback(() => setState({ status: 'idle' }), []);
+
+  return { state, provision, reset };
+}


### PR DESCRIPTION
## What

Adds `useWearableSource.ts` — a React hook wrapping `resolveWearableSourceForCurrentUser` from `wearableSourceProvisioning.ts`.

## Behaviour

- `provision(request)` — manual trigger only, no auto-mount
- `state: idle | loading | ready | error`
- `wearableSourceId` exposed directly on `ready` state
- `reset()` for retry flows
- `UseWearableSourceOptions.auto` reserved as `false`-only in v1 — explicit opt-in for future auto-provision

## Why manual trigger

Keeps auth, retry, error visibility and future device/consent flows controllable. Auto-mount on first render is hard to cancel and leaks into edge cases.

## Next

`useWearableSync.ts` consumes `wearableSourceId` from this hook to trigger the sync pipeline.