### PR TITLE
feat(mobile): add HealthConnect permission gate — platform adapter, hook, UI gate

### DIFF
--- a/apps/mobile/HealthConnectPermissionGate.tsx
+++ b/apps/mobile/HealthConnectPermissionGate.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useWearablePermissions } from './useWearablePermissions';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function HealthConnectPermissionGate({
+  children,
+}: Props): React.JSX.Element {
+  const { status, request } = useWearablePermissions();
+
+  if (status === 'unknown') {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator color="#4263eb" />
+      </View>
+    );
+  }
+
+  if (status === 'unavailable') {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.title}>Health Connect not available</Text>
+        <Text style={styles.subtitle}>
+          This feature requires Health Connect on Android. iOS support coming soon.
+        </Text>
+      </View>
+    );
+  }
+
+  if (status === 'denied') {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.title}>Health data access needed</Text>
+        <Text style={styles.subtitle}>
+          Grant access to Steps, Heart Rate, Calories, Distance and Sleep to enable Garmin sync.
+        </Text>
+        <Pressable onPress={request} style={styles.button}>
+          <Text style={styles.buttonText}>Grant access</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return <>{children}</>;
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    gap: 16,
+  },
+  title: {
+    color: '#152033',
+    fontSize: 20,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  subtitle: {
+    color: '#52607a',
+    fontSize: 15,
+    lineHeight: 22,
+    textAlign: 'center',
+  },
+  button: {
+    alignItems: 'center',
+    backgroundColor: '#4263eb',
+    borderRadius: 12,
+    minHeight: 52,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    width: '100%',
+  },
+  buttonText: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+});

--- a/apps/mobile/docs/health-connect-native-setup.md
+++ b/apps/mobile/docs/health-connect-native-setup.md
@@ -1,0 +1,65 @@
+# Health Connect Native Setup
+
+## Required: MainActivity.kt change (Android only)
+
+After installing `react-native-health-connect`, the following change is required in
+`android/app/src/main/java/.../MainActivity.kt`.
+
+Add the import:
+```kotlin
+import com.healthconnect.reactnative.permission.HealthConnectPermissionDelegate
+```
+
+Add inside `MainActivity` class:
+```kotlin
+override fun onCreate(savedInstanceState: Bundle?) {
+  super.onCreate(savedInstanceState)
+  HealthConnectPermissionDelegate.setPermissionDelegate(this)
+}
+```
+
+Without this change, `requestPermission()` will silently fail on Android.
+
+## Required: AndroidManifest.xml
+
+Add inside `<manifest>`:
+```xml
+<uses-permission android:name="android.permission.health.READ_STEPS" />
+<uses-permission android:name="android.permission.health.READ_HEART_RATE" />
+<uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />
+<uses-permission android:name="android.permission.health.READ_DISTANCE" />
+<uses-permission android:name="android.permission.health.READ_SLEEP" />
+```
+
+Add inside `<application>`:
+```xml
+<activity
+  android:name="androidx.health.connect.client.permission.HealthPermissionActivity"
+  android:exported="true" />
+```
+
+## npm install
+
+```bash
+cd apps/mobile
+npm install react-native-health-connect
+```
+
+## iOS
+
+No action needed yet. iOS stub returns `unavailable` until HealthKit adapter slice is built.
+When iOS support is added: install `@kingstinct/react-native-healthkit` and implement
+`createIOSAdapter()` in `wearablePermissions.ts`.
+
+## WearableSyncScreen wiring
+
+Wrap `WearableSyncScreen` in `App.tsx`:
+
+```tsx
+import HealthConnectPermissionGate from './HealthConnectPermissionGate.tsx';
+
+// In the wearable-sync tab:
+<HealthConnectPermissionGate>
+  <WearableSyncScreen />
+</HealthConnectPermissionGate>
+```

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -16,6 +16,7 @@
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.6",
+        "react-native-health-connect": "^3.5.0",
         "react-native-web": "^0.20.0"
       },
       "devDependencies": {
@@ -6774,6 +6775,27 @@
       "integrity": "sha512-2WCNdE3Qd6Fwg9+4BpbATUxCLcouF6YRY7K+J36KJ4l3y+tWN6XCqAC4DuoGblAAbb2sLkhEDp4FOlbOIot2Og==",
       "license": "MIT",
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-health-connect": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-health-connect/-/react-native-health-connect-3.5.0.tgz",
+      "integrity": "sha512-lIfiRps+jjDs83SApQ3AzBzU2cITwn8nPRl3v+52imWJPVw7qltAXkduioOfqFqOQJuEOwd1Wei3qtMTYbTaag==",
+      "license": "MIT",
+      "workspaces": [
+        "example",
+        "docs"
+      ],
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/matinzd/react-native-health-connect?sponsor=1"
+      },
+      "peerDependencies": {
+        "@expo/config-plugins": ">= 6.0.2",
         "react": "*",
         "react-native": "*"
       }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -20,6 +20,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.6",
+    "react-native-health-connect": "^3.5.0",
     "react-native-web": "^0.20.0"
   },
   "devDependencies": {

--- a/apps/mobile/useWearablePermissions.ts
+++ b/apps/mobile/useWearablePermissions.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  getWearablePermissionsAdapter,
+  WearablePermissionStatus,
+} from './wearablePermissions';
+
+export interface UseWearablePermissionsResult {
+  status: WearablePermissionStatus;
+  request: () => Promise<void>;
+}
+
+export function useWearablePermissions(): UseWearablePermissionsResult {
+  const [status, setStatus] = useState<WearablePermissionStatus>('unknown');
+
+  useEffect(() => {
+    getWearablePermissionsAdapter()
+      .then((adapter) => adapter.check())
+      .then(setStatus)
+      .catch(() => setStatus('denied'));
+  }, []);
+
+  const request = useCallback(async () => {
+    try {
+      const adapter = await getWearablePermissionsAdapter();
+      const result = await adapter.request();
+      setStatus(result);
+    } catch {
+      setStatus('denied');
+    }
+  }, []);
+
+  return { status, request };
+}

--- a/apps/mobile/wearablePermissions.ts
+++ b/apps/mobile/wearablePermissions.ts
@@ -1,0 +1,56 @@
+import { Platform } from 'react-native';
+
+// react-native-health-connect is Android-only.
+// iOS adapter (HealthKit) will be added as a separate slice when iOS support is introduced.
+// Import is dynamic to avoid breaking iOS builds before the library is conditionally linked.
+export type WearablePermissionStatus = 'unknown' | 'granted' | 'denied' | 'unavailable';
+
+export interface WearablePermissionsAdapter {
+  check: () => Promise<WearablePermissionStatus>;
+  request: () => Promise<WearablePermissionStatus>;
+}
+
+export const GARMIN_READ_PERMISSIONS = [
+  { accessType: 'read' as const, recordType: 'Steps' as const },
+  { accessType: 'read' as const, recordType: 'HeartRate' as const },
+  { accessType: 'read' as const, recordType: 'ActiveCaloriesBurned' as const },
+  { accessType: 'read' as const, recordType: 'Distance' as const },
+  { accessType: 'read' as const, recordType: 'SleepSession' as const },
+];
+
+async function createAndroidAdapter(): Promise<WearablePermissionsAdapter> {
+  // Dynamic import keeps iOS builds from failing before HealthKit adapter is added.
+  const hc = await import('react-native-health-connect');
+
+  return {
+    check: async (): Promise<WearablePermissionStatus> => {
+      const isInitialized = await hc.initialize();
+      if (!isInitialized) return 'unavailable';
+      const granted = await hc.getGrantedPermissions();
+      const grantedKeys = new Set(granted.map((p: { recordType: string }) => p.recordType));
+      const allGranted = GARMIN_READ_PERMISSIONS.every((p) => grantedKeys.has(p.recordType));
+      return allGranted ? 'granted' : 'denied';
+    },
+    request: async (): Promise<WearablePermissionStatus> => {
+      const isInitialized = await hc.initialize();
+      if (!isInitialized) return 'unavailable';
+      const granted = await hc.requestPermission(GARMIN_READ_PERMISSIONS);
+      const grantedKeys = new Set(granted.map((p: { recordType: string }) => p.recordType));
+      const allGranted = GARMIN_READ_PERMISSIONS.every((p) => grantedKeys.has(p.recordType));
+      return allGranted ? 'granted' : 'denied';
+    },
+  };
+}
+
+// iOS stub — replace with HealthKit adapter when iOS support slice is built.
+function createIOSAdapter(): WearablePermissionsAdapter {
+  return {
+    check: async () => 'unavailable',
+    request: async () => 'unavailable',
+  };
+}
+
+export async function getWearablePermissionsAdapter(): Promise<WearablePermissionsAdapter> {
+  if (Platform.OS === 'android') return createAndroidAdapter();
+  return createIOSAdapter();
+}


### PR DESCRIPTION
## What

- `wearablePermissions.ts` — platform adapter interface, Android implementation via `react-native-health-connect`, iOS stub
- `useWearablePermissions.ts` — hook exposing `status` + `request()`
- `HealthConnectPermissionGate.tsx` — UI gate wrapping `WearableSyncScreen`
- `docs/health-connect-native-setup.md` — native setup instructions for OpenClaw

## Platform strategy

- Android: dynamic import of `react-native-health-connect` (avoids iOS build failure)
- iOS: returns `unavailable` until HealthKit adapter slice is built
- Interface is iOS-ready — `createIOSAdapter()` is a drop-in when the time comes

## Native setup required (OpenClaw)

See `apps/mobile/docs/health-connect-native-setup.md` for:
- `MainActivity.kt` change (required for `requestPermission` to work)
- `AndroidManifest.xml` permissions
- `App.tsx` wiring of `HealthConnectPermissionGate`

## npm install required

```bash
cd apps/mobile && npm install react-native-health-connect
```

## Permissions requested

- Steps, HeartRate, ActiveCaloriesBurned, Distance, SleepSession