### PR TITLE
feat(mobile): wrap WearableSyncScreen in HealthConnectPermissionGate

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -10,6 +10,7 @@ import { createMobileSupabaseAuthSessionProvider } from './mobileSupabaseAuth.ts
 import LoginScreen from './LoginScreen.tsx';
 import MinimumSliceScreen from './MinimumSliceScreen.tsx';
 import WearableSyncScreen from './WearableSyncScreen.tsx';
+import HealthConnectPermissionGate from './HealthConnectPermissionGate.tsx';
 import SessionBar from './SessionBar.tsx';
 import { useAuthSession } from './useAuthSession.ts';
 
@@ -60,7 +61,9 @@ export default function App(): React.JSX.Element {
         {activeScreen === 'minimum-slice' ? (
           <MinimumSliceScreen controller={controller} />
         ) : (
-          <WearableSyncScreen />
+          <HealthConnectPermissionGate>
+            <WearableSyncScreen />
+          </HealthConnectPermissionGate>
         )}
       </View>
     </SafeAreaView>


### PR DESCRIPTION
## What

Wires `HealthConnectPermissionGate` around `WearableSyncScreen` in `App.tsx`.

## Behaviour

- On Android: shows permission request UI before `WearableSyncScreen` is accessible
- On iOS: shows "Health Connect not available" message (stub until HealthKit slice)
- Blood Panel tab unaffected

## Completes

This is the final wiring step for the wearable sync stack. All hooks, clients, screens and gates are now connected end-to-end.

## Still pending (requires device)

- `MainActivity.kt` + `AndroidManifest.xml` native changes (see OpenClaw handoff)
- `MOCK_APP_INSTALL_ID` replacement with real device install ID