### PR TITLE
fix(mobile): remove dead onSignedIn callback (#31)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -28,14 +28,12 @@ export default function App(): React.JSX.Element {
   const { authState, error, user, signOut } = useAuthSession();
   const [activeScreen, setActiveScreen] = useState<ActiveScreen>('minimum-slice');
 
-  const handleSignedIn = React.useCallback(() => {}, []);
-
   if (authState === 'loading') {
     return <SafeAreaView style={styles.centered} />;
   }
 
   if (authState === 'signed-out' || authState === 'config-error') {
-    return <LoginScreen onSignedIn={handleSignedIn} initialError={error} />;
+    return <LoginScreen initialError={error} />;
   }
 
   return (

--- a/apps/mobile/LoginScreen.tsx
+++ b/apps/mobile/LoginScreen.tsx
@@ -13,12 +13,10 @@ import {
 import { getMobileSupabaseClient } from './mobileSupabaseAuth.ts';
 
 interface LoginScreenProps {
-  onSignedIn: () => void;
   initialError?: string;
 }
 
 export default function LoginScreen({
-  onSignedIn,
   initialError,
 }: LoginScreenProps): React.JSX.Element {
   const [email, setEmail] = useState('');
@@ -51,7 +49,7 @@ export default function LoginScreen({
         return;
       }
 
-      onSignedIn();
+      // Navigation is handled automatically by useAuthSession's onAuthStateChange listener.
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Sign in failed.');
     } finally {


### PR DESCRIPTION
Closes #31

## What
Removes the `onSignedIn` prop and callback from `LoginScreen` and `App`.

## Why
After `signInWithPassword()` succeeds, the `onAuthStateChange` listener in `useAuthSession` handles the auth state transition automatically. The manual `onSignedIn()` call was a dead contract — firing redundantly and coupling two systems that should be decoupled.

## Changes
- `LoginScreen.tsx`: removes `onSignedIn` from `LoginScreenProps` and the call site; adds a clarifying comment in its place
- `App.tsx`: removes the `onSignedIn` prop passed to `<LoginScreen />`

## No behavioural change
Auth flow is identical — state transitions via `onAuthStateChange` as before.