### PR TITLE
feat: auto-compute daily summaries after wearable sync (Front 3)

### DIFF
--- a/apps/mobile/WearableSyncScreen.tsx
+++ b/apps/mobile/WearableSyncScreen.tsx
@@ -9,13 +9,24 @@ import {
 } from 'react-native';
 import { useWearableSource } from './useWearableSource';
 import { useWearableSync } from './useWearableSync';
+import { useComputeDailySummaries } from './useComputeDailySummaries';
 import { createGarminProvisioningRequest } from './wearableSourceProvisioning';
 
 const MOCK_APP_INSTALL_ID = 'dev-install-001';
 
+// Returns today and yesterday as ISO date strings (YYYY-MM-DD)
+function getSyncDateRange(): { date_from: string; date_to: string } {
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  const fmt = (d: Date) => d.toISOString().split('T')[0];
+  return { date_from: fmt(yesterday), date_to: fmt(today) };
+}
+
 export default function WearableSyncScreen(): React.JSX.Element {
   const { state: sourceState, provision, reset: resetSource } = useWearableSource();
-  const { state: syncState, result, error: syncError, submitSync, reset: resetSync } = useWearableSync();
+  const { state: syncState, result: syncResult, error: syncError, submitSync, reset: resetSync } = useWearableSync();
+  const { state: computeState, result: computeResult, error: computeError, submitCompute, reset: resetCompute } = useComputeDailySummaries();
 
   const handleProvision = useCallback(async () => {
     const request = createGarminProvisioningRequest({
@@ -26,20 +37,36 @@ export default function WearableSyncScreen(): React.JSX.Element {
 
   const handleSync = useCallback(async () => {
     if (sourceState.status !== 'ready') return;
-    await submitSync({
+
+    const syncPayload = {
       wearable_source_id: sourceState.wearableSourceId,
-      platform: 'android',
-      sync_mode: 'incremental',
+      platform: 'android' as const,
+      sync_mode: 'incremental' as const,
       started_at: new Date().toISOString(),
       source_cursor: null,
       observations: [],
-    });
-  }, [sourceState, submitSync]);
+    };
+
+    const syncRes = await submitSync(syncPayload);
+
+    // Auto-compute daily summaries immediately after a successful sync
+    if (syncRes !== null) {
+      const { date_from, date_to } = getSyncDateRange();
+      await submitCompute({
+        wearable_source_id: sourceState.wearableSourceId,
+        date_from,
+        date_to,
+      });
+    }
+  }, [sourceState, submitSync, submitCompute]);
 
   const handleReset = useCallback(() => {
     resetSource();
     resetSync();
-  }, [resetSource, resetSync]);
+    resetCompute();
+  }, [resetSource, resetSync, resetCompute]);
+
+  const isSyncing = syncState === 'submitting' || computeState === 'submitting';
 
   return (
     <ScrollView style={styles.scrollView} contentContainerStyle={styles.container}>
@@ -51,6 +78,7 @@ export default function WearableSyncScreen(): React.JSX.Element {
         </Text>
       </View>
 
+      {/* Step 1 — Provision */}
       <View style={styles.card}>
         <Text style={styles.sectionTitle}>Step 1 — Provision source</Text>
         <Text style={styles.statusText}>
@@ -79,15 +107,20 @@ export default function WearableSyncScreen(): React.JSX.Element {
         </Pressable>
       </View>
 
+      {/* Step 2 — Sync */}
       <View style={styles.card}>
         <Text style={styles.sectionTitle}>Step 2 — Trigger sync</Text>
         <Text style={styles.statusText}>
           Status: <Text style={styles.mono}>{syncState}</Text>
         </Text>
-        {syncState === 'success' && result && (
+        {syncState === 'success' && syncResult && (
           <>
-            <Text style={styles.statusText}>Run ID: <Text style={styles.mono}>{result.sync_run_id}</Text></Text>
-            <Text style={styles.statusText}>Inserted: <Text style={styles.mono}>{result.records_inserted}</Text></Text>
+            <Text style={styles.statusText}>
+              Run ID: <Text style={styles.mono}>{syncResult.sync_run_id}</Text>
+            </Text>
+            <Text style={styles.statusText}>
+              Inserted: <Text style={styles.mono}>{syncResult.records_inserted}</Text>
+            </Text>
           </>
         )}
         {syncError && <Text style={styles.errorText}>{syncError}</Text>}
@@ -95,9 +128,9 @@ export default function WearableSyncScreen(): React.JSX.Element {
           onPress={handleSync}
           style={[
             styles.primaryButton,
-            (sourceState.status !== 'ready' || syncState === 'submitting') && styles.buttonDisabled,
+            (sourceState.status !== 'ready' || isSyncing) && styles.buttonDisabled,
           ]}
-          disabled={sourceState.status !== 'ready' || syncState === 'submitting'}
+          disabled={sourceState.status !== 'ready' || isSyncing}
         >
           {syncState === 'submitting' ? (
             <ActivityIndicator color="#ffffff" />
@@ -106,6 +139,35 @@ export default function WearableSyncScreen(): React.JSX.Element {
           )}
         </Pressable>
       </View>
+
+      {/* Step 3 — Compute (auto-triggered, shown after sync succeeds) */}
+      {(syncState === 'success' || computeState !== 'idle') && (
+        <View style={[styles.card, computeState === 'error' && styles.cardError]}>
+          <Text style={styles.sectionTitle}>Step 3 — Compute summaries</Text>
+          <Text style={styles.statusText}>
+            Status: <Text style={styles.mono}>{computeState}</Text>
+          </Text>
+          {computeState === 'submitting' && (
+            <ActivityIndicator color="#4263eb" style={styles.spinner} />
+          )}
+          {computeState === 'success' && computeResult && (
+            <>
+              <Text style={styles.statusText}>
+                Summaries written:{' '}
+                <Text style={styles.mono}>{computeResult.summaries_written}</Text>
+              </Text>
+              <Text style={styles.statusText}>
+                Version:{' '}
+                <Text style={styles.mono}>{computeResult.computation_version}</Text>
+              </Text>
+              {computeResult.error_summary && (
+                <Text style={styles.errorText}>{computeResult.error_summary}</Text>
+              )}
+            </>
+          )}
+          {computeError && <Text style={styles.errorText}>{computeError}</Text>}
+        </View>
+      )}
 
       <View style={styles.actions}>
         <Pressable onPress={handleReset} style={styles.secondaryButton}>
@@ -123,15 +185,41 @@ const styles = StyleSheet.create({
   eyebrow: { color: '#4263eb', fontSize: 13, fontWeight: '700', textTransform: 'uppercase' },
   title: { color: '#152033', fontSize: 28, fontWeight: '700' },
   subtitle: { color: '#52607a', fontSize: 15, lineHeight: 21 },
-  card: { backgroundColor: '#ffffff', borderColor: '#d9e2f2', borderRadius: 16, borderWidth: 1, gap: 12, padding: 16 },
+  card: {
+    backgroundColor: '#ffffff',
+    borderColor: '#d9e2f2',
+    borderRadius: 16,
+    borderWidth: 1,
+    gap: 12,
+    padding: 16,
+  },
+  cardError: {
+    borderColor: '#f5b8b8',
+    backgroundColor: '#fff8f8',
+  },
   sectionTitle: { color: '#152033', fontSize: 18, fontWeight: '700' },
   statusText: { color: '#24324a', fontSize: 14, lineHeight: 21 },
   mono: { fontFamily: 'monospace', color: '#4263eb' },
   errorText: { color: '#b42318', fontSize: 14, lineHeight: 20 },
+  spinner: { alignSelf: 'flex-start' },
   actions: { gap: 12, marginBottom: 32 },
-  primaryButton: { alignItems: 'center', backgroundColor: '#4263eb', borderRadius: 12, minHeight: 52, justifyContent: 'center' },
+  primaryButton: {
+    alignItems: 'center',
+    backgroundColor: '#4263eb',
+    borderRadius: 12,
+    minHeight: 52,
+    justifyContent: 'center',
+  },
   buttonDisabled: { opacity: 0.4 },
   primaryButtonText: { color: '#ffffff', fontSize: 16, fontWeight: '700' },
-  secondaryButton: { alignItems: 'center', backgroundColor: '#ffffff', borderColor: '#c8d3e1', borderRadius: 12, borderWidth: 1, minHeight: 52, justifyContent: 'center' },
+  secondaryButton: {
+    alignItems: 'center',
+    backgroundColor: '#ffffff',
+    borderColor: '#c8d3e1',
+    borderRadius: 12,
+    borderWidth: 1,
+    minHeight: 52,
+    justifyContent: 'center',
+  },
   secondaryButtonText: { color: '#24324a', fontSize: 16, fontWeight: '600' },
 });

--- a/apps/mobile/useComputeDailySummaries.ts
+++ b/apps/mobile/useComputeDailySummaries.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { supabase } from './supabaseClient';
+import { getMobileSupabaseClient } from './mobileSupabaseAuth';
 
 export type ComputeState = 'idle' | 'submitting' | 'success' | 'error';
 
@@ -35,6 +35,7 @@ export function useComputeDailySummaries(): UseComputeDailySummariesReturn {
       setResult(null);
 
       try {
+        const supabase = getMobileSupabaseClient();
         const { data, error: fnError } = await supabase.functions.invoke(
           'compute-daily-summaries',
           { body: params },

--- a/apps/mobile/useComputeDailySummaries.ts
+++ b/apps/mobile/useComputeDailySummaries.ts
@@ -1,0 +1,75 @@
+import { useCallback, useState } from 'react';
+import { supabase } from './supabaseClient';
+
+export type ComputeState = 'idle' | 'submitting' | 'success' | 'error';
+
+export interface ComputeResult {
+  summaries_written: number;
+  computation_version: string;
+  error_summary: string | null;
+}
+
+export interface ComputeDailySummariesParams {
+  wearable_source_id: string;
+  date_from: string;
+  date_to?: string;
+}
+
+export interface UseComputeDailySummariesReturn {
+  state: ComputeState;
+  result: ComputeResult | null;
+  error: string | null;
+  submitCompute: (params: ComputeDailySummariesParams) => Promise<ComputeResult | null>;
+  reset: () => void;
+}
+
+export function useComputeDailySummaries(): UseComputeDailySummariesReturn {
+  const [state, setState] = useState<ComputeState>('idle');
+  const [result, setResult] = useState<ComputeResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const submitCompute = useCallback(
+    async (params: ComputeDailySummariesParams): Promise<ComputeResult | null> => {
+      setState('submitting');
+      setError(null);
+      setResult(null);
+
+      try {
+        const { data, error: fnError } = await supabase.functions.invoke(
+          'compute-daily-summaries',
+          { body: params },
+        );
+
+        if (fnError) {
+          setState('error');
+          setError(fnError.message ?? 'compute-daily-summaries failed');
+          return null;
+        }
+
+        const computeResult: ComputeResult = {
+          summaries_written: data.summaries_written ?? 0,
+          computation_version: data.computation_version ?? 'v1',
+          error_summary: data.error_summary ?? null,
+        };
+
+        setState('success');
+        setResult(computeResult);
+        return computeResult;
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        setState('error');
+        setError(message);
+        return null;
+      }
+    },
+    [],
+  );
+
+  const reset = useCallback(() => {
+    setState('idle');
+    setResult(null);
+    setError(null);
+  }, []);
+
+  return { state, result, error, submitCompute, reset };
+}


### PR DESCRIPTION
## What

Chains `compute-daily-summaries` automatically after a successful `wearables-sync` call — the "separate async job" referenced in `sync.ts` comments is now wired up in the mobile UI.

## Changes

### New: `useComputeDailySummaries.ts`
- Hook analog zu `useWearableSync`
- State: `idle | submitting | success | error`
- Calls `supabase.functions.invoke('compute-daily-summaries')`
- Returns `summaries_written`, `computation_version`, `error_summary`

### Updated: `WearableSyncScreen.tsx`
- `handleSync` chains: `submitSync` → on success → `submitCompute` (yesterday + today)
- `isSyncing` flag blockt den Button während sync **oder** compute läuft
- Step 3 Card erscheint automatisch sobald sync succeeded
- `cardError` style für compute error state
- `handleReset` resettet alle drei hooks

## Flow

```
User: Trigger sync
  → Step 2: submitting
  → sync success
  → Step 3 erscheint: submitting
  → compute success: summaries_written + version
```

## Scope

- Foreground-only (v1) — kein Background Fetch
- `date_from` = gestern, `date_to` = heute (deckt den typischen Sync-Window ab)
- `MOCK_APP_INSTALL_ID` bleibt — blocked on real Garmin device

## Out of scope

- Background auto-sync (`expo-background-task`) — v2, nach iOS-Disclaimer-Evaluierung
- Android Health Connect wiring
- `MOCK_APP_INSTALL_ID` replacement