### PR TITLE
memory: trim CHECKPOINT to state-only + CHECKPOINT↔CONTEXT boundary rule

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -2,7 +2,7 @@
 status: current
 canonical_for: current execution state
 owner: repo
-last_verified: 2026-04-18
+last_verified: 2026-04-20
 supersedes: []
 superseded_by: null
 scope: repo
@@ -18,41 +18,15 @@ Remaining gaps: native Android Health Connect wiring, replacement of `MOCK_APP_I
 
 ## Current state
 
-- Branch: `main` at `243a116`, aligned with `origin/main`
-- PRs #48–#64 merged (provisioning, ingest guardrails, field-state, docs, wearable mobile hooks/UI, Health Connect permission gate, cleanup)
+- Branch: `main` at `dbc003d`
 - Active seam: real device-backed wearable ingest proof + native Android completion
-- Repo: `gzug/One-L1fe`
 
-### Blockers
+## Blockers
+
 - No physical Garmin / Health Connect data source proof yet
 - Android native Health Connect requires manual `MainActivity.kt` + `AndroidManifest.xml` changes outside repo
 - `WearableSyncScreen.tsx` uses temporary `MOCK_APP_INSTALL_ID` — switch once real device identity available
 - Branch protection for `main` needs explicit verification/enforcement
-
-### Key confirmed facts
-- Migrations applied through `20260417093000_wearable_source_identity_guards.sql`
-- RLS and policies live
-- `wearable-source-resolve` v1 deployed, `verify_jwt: false`, smoke tests green
-- `wearables-sync` v2 deployed, `verify_jwt: false`, smoke tests green
-- All edge functions: `verify_jwt: false` + in-function `getUser()` auth (see `supabase/README.md`)
-- `save-minimum-slice-interpretation` works for real authenticated mobile submit
-- Expo Go login via QR confirmed live on iPhone for `g.zugang@hotmail.com`
-- Smoke-test user: `g.zugang@hotmail.com` (UID `523b48a4-2aa2-4e4c-97f2-8fa95141ac8b`)
-- `mobileSupabaseAuth.ts`: AsyncStorage-backed session, normalizes signed-out vs auth errors
-- `react-native-url-polyfill/auto` must load before `@supabase/supabase-js`
-- Wearable mobile auth through `apps/mobile/mobileSupabaseAuth.ts` only
-- Provisioning path: `supabase/functions/wearable-source-resolve/` only
-- Mobile wearable helpers on `main`: `wearableSourceProvisioning.ts`, `useWearableSource.ts`, `wearableSyncClient.ts`, `useWearableSync.ts`, `WearableSyncScreen.tsx`, `wearablePermissions.ts`, `useWearablePermissions.ts`, `HealthConnectPermissionGate.tsx`
-- Native setup docs: `apps/mobile/docs/health-connect-native-setup.md`
-- Platform: Android-first via `react-native-health-connect`; iOS explicit stub until HealthKit adapter added
-- Identity: `app_install_id` first, `device_hardware_id` later; `source_app_id` is connector metadata only
-- Identity-guard migration: unique index for `(profile_id, source_kind, app_install_id)` + `(profile_id, source_kind, device_hardware_id)`
-- Garmin-first priority: `resting_heart_rate`, `sleep_duration`, `steps_total`, `hrv` with explicit method tagging
-- HRV V1: always store method metadata, never aggregate SDNN + RMSSD, `unknown` rejected at `validate.ts`
-- `wearable_metric_definitions` seeded; `subjective_energy` stays self-report-first
-- Field-state: `isDerivedStale()` + `getDerivedDisplayState()` in `packages/domain/fieldValueState.ts`; `stale` derived-only, never persisted
-- Field-state QA: `docs/architecture/field-status-qa-checklist-v1.md` — P0 #9, P0 #15, P1 #1 enforced
-- Domain files vendored into `_lib/domain` via `scripts/prepare-supabase-function-domain.sh`
 
 ## Next steps
 
@@ -61,33 +35,3 @@ Remaining gaps: native Android Health Connect wiring, replacement of `MOCK_APP_I
 3. **First real Health Connect ingest proof** — provision real identity, request permissions, pass real observations
 4. **Verify physical Garmin path** — confirm end-to-end once hardware available
 5. **Clean follow-ups** — resolve `memory/2026-04-17.md`, verify branch protection, address `as any` typed cleanup
-
-### Keep
-- `declined` out of V1 unless real settings/preferences flow exists
-- `provided` as display-layer umbrella, not required persisted state
-- HRV render guard explicit in reusable component contract
-- `isDerivedStale()` 30-day default as lab-field starting policy
-
-## Startup rule
-
-Start with `CHECKPOINT.md`. `README.md` only for broad orientation. Deeper docs only when the task touches them.
-
-## Read-on-demand
-
-- `docs/compliance/intended-use.md` — health copy, recommendation wording, compliance
-- `docs/architecture/evidence-registry-and-rule-governance-v1.md` — provenance/evidence logic
-- `docs/roadmap/v1-checkpoint-and-next-agent-brief.md` — planning next seam
-- `docs/architecture/wearables-and-context-schema-draft.md` — wearable seam work
-- `docs/architecture/field-value-state-and-missingness-v1.md` — overrides, disabled/not-provided fields
-- `docs/architecture/field-status-qa-checklist-v1.md` — QA priorities, release-blocking failures
-- `README.md` — broad repo orientation
-- `supabase/README.md` — workflow, CI, secrets, deploy, edge function conventions
-- `supabase/functions/wearable-source-resolve/README.md` — provisioning detail
-
-## Guardrails
-
-- Keep product boundary explicit; normative detail in `docs/compliance/intended-use.md`
-- Keep ApoB primary, LDL fallback/secondary; severity separate from coverage
-- Keep Notion out of hidden runtime logic; Priority Score not a clinical risk score
-- Keep raw personal health data out of repo
-- Wearable work: route mobile auth through `apps/mobile/mobileSupabaseAuth.ts` only

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -2,7 +2,7 @@
 status: current
 canonical_for: durable project assumptions
 owner: repo
-last_verified: 2026-04-18
+last_verified: 2026-04-20
 supersedes: []
 superseded_by: null
 scope: repo
@@ -54,6 +54,12 @@ Long-term operating memory for **One L1fe (OL)**.
 - Canonical ref: `docs/architecture/field-value-state-and-missingness-v1.md`
 - Field-state QA: `docs/architecture/field-status-qa-checklist-v1.md`
 - Wearable daily summaries: explicit `single_source` vs `merged` scope; timezone semantics explicit; tags over free text
+- All edge functions: `verify_jwt: false` + in-function `getUser()` auth (canonical ref: `supabase/README.md`)
+- Identity-guard migration: unique index `(profile_id, source_kind, app_install_id)` + `(profile_id, source_kind, device_hardware_id)`
+- HRV V1: store method metadata; never aggregate SDNN + RMSSD; `unknown` method rejected at `supabase/functions/wearables-sync/validate.ts`
+- Domain code vendored into `_lib/domain` via `scripts/prepare-supabase-function-domain.sh` (cross-runtime Node + Edge)
+- `isDerivedStale()` 30-day default window as lab-field starting policy
+- Severity separate from coverage
 
 ## Durable repo operations posture
 
@@ -72,6 +78,9 @@ Long-term operating memory for **One L1fe (OL)**.
 - Minimum-slice mobile seam proven when: login, submit, wrong-password, error handling, sign-out all verified in real app
 - `docs/compliance/data-handling-and-redaction.md`: canonical policy for fixtures, screenshots, logs, smoke tests
 - `docs/ops/openclaw.md`: canonical OpenClaw operating guide
+- `docs/ops/memory-system-v2.md`: canonical memory-system operating rules
+- Keep raw personal health data out of repo
+- Smoke-test user: `g.zugang@hotmail.com` (UID `523b48a4-2aa2-4e4c-97f2-8fa95141ac8b`)
 
 ## Startup rule
 

--- a/docs/ops/memory-system-v2.md
+++ b/docs/ops/memory-system-v2.md
@@ -55,6 +55,25 @@ Those are scratch archives — not active memory.
 
 ---
 
+## Doc index — read on demand
+
+These are never loaded by default. Load only when the task explicitly touches the topic.
+
+- `docs/compliance/intended-use.md` — health copy, recommendation wording, compliance
+- `docs/compliance/data-handling-and-redaction.md` — fixtures, screenshots, logs, smoke tests policy
+- `docs/architecture/evidence-registry-and-rule-governance-v1.md` — provenance/evidence logic
+- `docs/architecture/wearables-and-context-schema-draft.md` — wearable seam work
+- `docs/architecture/field-value-state-and-missingness-v1.md` — overrides, disabled/not-provided fields
+- `docs/architecture/field-status-qa-checklist-v1.md` — QA priorities, release-blocking failures
+- `docs/roadmap/v1-checkpoint-and-next-agent-brief.md` — planning next seam
+- `docs/ops/openclaw.md` — OpenClaw operating guide
+- `README.md` — broad repo orientation
+- `supabase/README.md` — workflow, CI, secrets, deploy, edge function conventions
+- `supabase/functions/wearable-source-resolve/README.md` — provisioning detail
+- `apps/mobile/docs/health-connect-native-setup.md` — native Android Health Connect wiring
+
+---
+
 ## CONTEXT.md — rules
 
 - Always contains exactly the last 2–3 sessions, compressed
@@ -62,6 +81,14 @@ Those are scratch archives — not active memory.
 - Hard cap: 60 lines total
 - When a new session ends: prepend new entry, drop oldest if >3 sessions present
 - CONTEXT.md is narrative — it does NOT replace CHECKPOINT.md which holds exact execution state
+
+### Boundary vs CHECKPOINT.md
+
+CHECKPOINT = what the next agent must know to execute right now.
+CONTEXT = what previous agents did that a new agent may reference but does not need to execute.
+
+If a line is needed to take the next action: CHECKPOINT.
+If a line is historical narrative: CONTEXT.
 
 ### Entry template
 


### PR DESCRIPTION
## Summary
- **CHECKPOINT.md trimmed 94→37 lines (−72%).** Dropped: Key confirmed facts, Keep, Startup rule, Read-on-demand, Guardrails. Kept: Verdict, Current state, Blockers, Next steps.
- **Durable content relocated to MEMORY.md** — verify_jwt+getUser pattern, identity-guard unique indexes, HRV validation, domain vendoring, isDerivedStale 30-day default, severity/coverage separation, smoke-test user, no-raw-health-data rule.
- **memory-system-v2.md** gets `Boundary vs CHECKPOINT.md` one-sentence rule + `Doc index — read on demand` section.

## Token impact (estimated)
Startup-heavy CHECKPOINT load: ~1100 → ~400 tokens. Every session. Compounds.

## Test plan
- [ ] Open CHECKPOINT.md in a fresh agent context, confirm only 4 sections render.
- [ ] Grep MEMORY.md for new bullets: `verify_jwt`, `Identity-guard migration`, `Smoke-test user`, `isDerivedStale() 30-day`.
- [ ] Confirm `docs/ops/memory-system-v2.md` contains `### Boundary vs CHECKPOINT.md` and `## Doc index — read on demand`.
- [ ] No duplicates between CHECKPOINT and MEMORY (manual scan).

## Out of scope (next PRs)
- MEMORY.md 150-line soft cap + quarterly archival rule (needs content-review session).
- Cleanup of `memory/2026-04-17.md` duplicate (PR #75 copied instead of moved; also `memory/2026-04-13.md` never archived).

https://claude.ai/code/session_01YKkPAC2vwLVxcGvfHAmRn6