### PR TITLE
feat(mobile): HealthConnect plugin config + EAS preview APK profile

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -11,9 +11,32 @@
     "ios": {
       "supportsTablet": true
     },
-    "android": {},
+    "android": {
+      "package": "com.onel1fe.mobile",
+      "permissions": [
+        "android.permission.health.READ_STEPS",
+        "android.permission.health.READ_HEART_RATE",
+        "android.permission.health.READ_ACTIVE_CALORIES_BURNED",
+        "android.permission.health.READ_DISTANCE",
+        "android.permission.health.READ_SLEEP"
+      ]
+    },
     "web": {
       "bundler": "metro"
-    }
+    },
+    "plugins": [
+      [
+        "react-native-health-connect",
+        {
+          "permissions": [
+            "Steps",
+            "HeartRate",
+            "ActiveCaloriesBurned",
+            "Distance",
+            "SleepSession"
+          ]
+        }
+      ]
+    ]
   }
 }

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,0 +1,30 @@
+{
+  "cli": {
+    "version": ">= 16.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      },
+      "ios": {
+        "simulator": true
+      }
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}


### PR DESCRIPTION
## What

### U-2 — Android HealthConnect wiring (repo side)
- `app.json`: adds `react-native-health-connect` plugin with permissions (Steps, HeartRate, ActiveCaloriesBurned, Distance, SleepSession)
- `app.json`: adds `android.package` + `android.permissions` array with all 5 Health Connect permission strings
- After merging: run `npx expo prebuild --platform android` locally to generate `MainActivity.kt` + `AndroidManifest.xml` changes automatically from this config

### U-5 — EAS build config for APK
- New `eas.json` with 3 profiles:
  - `development` — internal APK with dev client
  - `preview` — internal APK (for Bruder distribution), iOS simulator build
  - `production` — standard store build with autoIncrement

## What still needs to happen manually
- `npx expo prebuild --platform android` (generates native android/ folder)
- `eas build --profile preview --platform android` (triggers APK build on EAS)
- Install APK on Bruder's Android device

## Not in scope
- U-3 (branch protection) — GitHub Settings UI only
- U-4 (real Garmin ingest proof) — requires physical device