### PR TITLE
docs(ops): EAS build script + Android sideload guide

### DIFF
--- a/docs/ops/sideload-guide.md
+++ b/docs/ops/sideload-guide.md
@@ -1,0 +1,68 @@
+---
+status: current
+owner: repo
+last_verified: 2026-04-20
+audience: trusted-user (brother)
+---
+
+# Sideload Guide — One L1fe Android APK
+
+This guide lets a trusted user install the One L1fe app directly from an APK
+without going through the Play Store.
+
+---
+
+## Step 1 — Enable Unknown Sources (Android)
+
+1. Open **Settings** on your Android phone
+2. Go to **Apps** → **Special app access** → **Install unknown apps**
+3. Find your browser (e.g. Chrome) or Files app
+4. Enable **Allow from this source**
+
+> On some devices this is under **Settings → Security → Install unknown apps**.
+
+---
+
+## Step 2 — Get the APK link
+
+The builder (Max) will send you a direct download link from EAS.
+It looks like:
+```
+https://expo.dev/artifacts/eas/...
+```
+
+Open the link on your phone and tap **Download**.
+
+---
+
+## Step 3 — Install
+
+1. Open your **Downloads** folder (Files app)
+2. Tap the `.apk` file
+3. Tap **Install**
+4. If prompted "Play Protect" — tap **Install anyway**
+
+---
+
+## Step 4 — Login
+
+Use the credentials Max sent you.
+The app connects to the shared Supabase backend.
+
+---
+
+## Updates
+
+When a new version is ready, Max will send a new APK link.
+Install it over the existing app — your data is stored in the cloud, nothing is lost.
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| "App not installed" | Uninstall old version first, then re-install |
+| "Parse error" | Download the APK again — file may be corrupted |
+| Can't log in | Ask Max to check your user account in Supabase |
+| Blank screen on launch | Force-close and reopen the app |

--- a/scripts/build-android-preview.sh
+++ b/scripts/build-android-preview.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# build-android-preview.sh
+# Builds an Android APK using the EAS 'preview' profile.
+# Output: downloadable APK link printed by EAS on completion (~10 min).
+#
+# Prerequisites:
+#   - eas-cli installed: npm install -g eas-cli
+#   - Logged in to EAS: eas login
+#   - EAS secrets set (SUPABASE_URL, SUPABASE_ANON_KEY): see docs/ops/sideload-guide.md
+#
+# Usage:
+#   bash scripts/build-android-preview.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+MOBILE_DIR="$REPO_ROOT/apps/mobile"
+
+echo "→ One L1fe — EAS Android Preview Build"
+echo "  Mobile dir: $MOBILE_DIR"
+echo ""
+
+cd "$MOBILE_DIR"
+
+echo "→ Installing dependencies..."
+npm install
+
+echo "→ Submitting build to EAS (preview profile, Android)..."
+eas build \
+  --profile preview \
+  --platform android \
+  --non-interactive
+
+echo ""
+echo "✓ Build submitted. The APK download link will appear above when complete."
+echo "  Typical build time: 8-12 minutes."
+echo "  Send the link to the tester once the build status shows 'Finished'."


### PR DESCRIPTION
## What

Adds two files for Android APK distribution to a trusted user (brother):

- **`docs/ops/sideload-guide.md`** — step-by-step install guide written for a non-technical user (enable unknown sources → download APK → install → login)
- **`scripts/build-android-preview.sh`** — one-command EAS build trigger for the `preview` profile

## Secret handling

Keys are stored as EAS secrets (`eas secret:create`) — never in the repo. The build script reads them from the EAS environment at build time.

## Usage

```bash
bash scripts/build-android-preview.sh
# → EAS prints APK download link when build finishes (~10 min)
# → Send link to tester
```

Tester follows `docs/ops/sideload-guide.md`.