### PR TITLE
Tighten biomarker thresholds and scoring metadata

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -16,6 +16,11 @@ The minimum-slice mobile seam is proven live end to end. Field-state contract is
 
 ## Current state
 
+- Domain biomarker thresholds and scoring metadata were recently tightened:
+  - ApoB, HbA1c, glucose, CRP, and vitamin D reference ranges are synced to the new ground-truth values
+  - new threshold evaluators exist for triglycerides, B12, magnesium, DAO, and ferritin
+  - biomarker scoring metadata now carries `evidenceConfidenceModifier` and `scoringClass`
+- Domain assertions now cover the revised thresholds and the new marker dispatch paths
 - Branch: `main` at `243a116`, aligned with `origin/main`
 - PRs #48 through #64 merged, including provisioning, ingest guardrails, field-state, docs, wearable mobile hooks/UI, Health Connect permission gate, and follow-up cleanup/fixes
 - Active seam: real device-backed wearable ingest proof and native Android completion

--- a/apps/mobile/MinimumSliceScreen.tsx
+++ b/apps/mobile/MinimumSliceScreen.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   KeyboardTypeOptions,
-  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -11,11 +10,16 @@ import {
 } from 'react-native';
 import { MinimumSliceScreenModel } from './minimumSliceScreenModel.ts';
 import { MinimumSliceScreenController } from './minimumSliceScreenController.ts';
+import { buildMinimumSlicePanelInputFromMobileDraft } from '../../packages/domain/minimumSliceMobileForm.ts';
+import { collectRuleIdsForPanel, evaluateMinimumSlice } from '../../packages/domain/minimumSlice.ts';
 import {
   createOptionalFieldMetadata,
   getOptionalFieldMetadata,
   OptionalMinimumSliceMarkerKey,
 } from '../../packages/domain/minimumSliceMobileForm.ts';
+import { Card, PrimaryButton, ScreenHeader, SecondaryButton } from './ui/components';
+import { theme } from './ui/theme';
+import { loadEvidenceAnchorsForRuleIds } from './src/data/evidenceAnchors.ts';
 
 const FIELD_ORDER = [
   { key: 'panelId', label: 'Panel ID', keyboardType: 'default' },
@@ -61,17 +65,66 @@ export default function MinimumSliceScreen({
   );
   const [localError, setLocalError] = useState<string | undefined>();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [anchorLoadingState, setAnchorLoadingState] = useState<'loading' | 'ready' | 'empty' | 'error'>('loading');
+  const [anchorError, setAnchorError] = useState<string | undefined>();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadAnchors(): Promise<void> {
+      setAnchorLoadingState('loading');
+      setAnchorError(undefined);
+
+      try {
+        const previewPanel = buildMinimumSlicePanelInputFromMobileDraft(screenState.draft, {
+          profileId: 'mobile-preview',
+          defaultSource: 'mobile-minimum-slice-screen',
+        });
+        const ruleIds = collectRuleIdsForPanel(previewPanel);
+        const anchors = await loadEvidenceAnchorsForRuleIds(ruleIds);
+
+        if (cancelled) return;
+
+        controller.setEvidenceAnchors(anchors);
+        setAnchorLoadingState(anchors.length > 0 ? 'ready' : 'empty');
+      } catch (error) {
+        if (cancelled) return;
+        setAnchorLoadingState('error');
+        setAnchorError(error instanceof Error ? error.message : 'Failed to load evidence anchors.');
+        controller.setEvidenceAnchors([]);
+      }
+    }
+
+    void loadAnchors();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [controller, screenState.draft]);
+
+  const previewEvaluation = useMemo(() => {
+    if (anchorLoadingState !== 'ready') return null;
+    try {
+      const previewPanel = buildMinimumSlicePanelInputFromMobileDraft(screenState.draft, {
+        profileId: 'mobile-preview',
+        defaultSource: 'mobile-minimum-slice-screen',
+      });
+      return evaluateMinimumSlice(previewPanel, new Date(), screenState.evidenceAnchors);
+    } catch {
+      return null;
+    }
+  }, [anchorLoadingState, screenState.draft, screenState.evidenceAnchors]);
 
   const helperText = useMemo(() => {
     return [
       `Status: ${screenState.submissionSummary.status}`,
-      `Coverage: ${screenState.submissionSummary.lastResultSummary?.coverageState ?? 'n/a'}`,
+      `Coverage: ${previewEvaluation?.coverage.state ?? screenState.submissionSummary.lastResultSummary?.coverageState ?? 'n/a'}`,
       `Interpretation run: ${screenState.submissionSummary.lastResultSummary?.interpretationRunId ?? 'n/a'}`,
-      `Entries: ${screenState.submissionSummary.lastResultSummary?.interpretedEntryCount ?? 'n/a'}`,
+      `Entries: ${previewEvaluation?.entries.length ?? screenState.submissionSummary.lastResultSummary?.interpretedEntryCount ?? 'n/a'}`,
       `Recommendations: ${screenState.submissionSummary.lastResultSummary?.recommendationCount ?? 'n/a'}`,
       `Top drivers: ${renderTopDrivers(screenState)}`,
     ].join('\n');
-  }, [screenState]);
+  }, [previewEvaluation, screenState]);
 
   const handleSubmit = useCallback(async (): Promise<void> => {
     setIsSubmitting(true);
@@ -124,15 +177,33 @@ export default function MinimumSliceScreen({
       style={styles.scrollView}
       contentContainerStyle={styles.container}
     >
-      <View style={styles.header}>
-        <Text style={styles.eyebrow}>One L1fe</Text>
-        <Text style={styles.title}>Minimum-slice</Text>
-        <Text style={styles.subtitle}>
-          Thin Expo screen, shared domain contract, hosted Supabase function.
-        </Text>
-      </View>
+      <ScreenHeader
+        eyebrow="One L1fe"
+        title="Blood panel"
+        subtitle="Minimum-slice mobile seam: shared contract + hosted Supabase function."
+      />
 
-      <View style={styles.card}>
+      {anchorLoadingState === 'loading' ? (
+        <Card>
+          <Text style={styles.sectionTitle}>Loading evidence anchors</Text>
+          <Text style={styles.summary}>Resolving rule evidence links before calculating the score.</Text>
+          <ActivityIndicator color={theme.colors.primary} />
+        </Card>
+      ) : anchorLoadingState === 'error' ? (
+        <Card variant="danger">
+          <Text style={styles.sectionTitle}>Evidence anchors unavailable</Text>
+          <Text style={styles.errorText}>{anchorError ?? 'No evidence anchors could be loaded.'}</Text>
+        </Card>
+      ) : anchorLoadingState === 'empty' ? (
+        <Card variant="danger">
+          <Text style={styles.sectionTitle}>No evidence anchors</Text>
+          <Text style={styles.errorText}>
+            The current panel has no anchored rule evidence, so the score is not shown.
+          </Text>
+        </Card>
+      ) : null}
+
+      <Card>
         {FIELD_ORDER.map((field) => (
           <View key={field.key} style={styles.fieldGroup}>
             <Text style={styles.label}>{field.label}</Text>
@@ -147,7 +218,7 @@ export default function MinimumSliceScreen({
                 {(['provided', 'missing', 'disabled'] as const).map((stateOption) => {
                   const isActive = getOptionalMarkerState(screenState, field.key) === stateOption;
                   return (
-                    <Pressable
+                    <SecondaryButton
                       key={stateOption}
                       onPress={() => handleOptionalMarkerStateChange(field.key, stateOption)}
                       style={[styles.optionChip, isActive ? styles.optionChipActive : null]}
@@ -159,7 +230,7 @@ export default function MinimumSliceScreen({
                             ? 'Missing'
                             : 'Not provided'}
                       </Text>
-                    </Pressable>
+                    </SecondaryButton>
                   );
                 })}
               </View>
@@ -173,9 +244,9 @@ export default function MinimumSliceScreen({
             ) : null}
           </View>
         ))}
-      </View>
+      </Card>
 
-      <View style={styles.card}>
+      <Card>
         <Text style={styles.sectionTitle}>Submission summary</Text>
         <Text style={styles.summary}>{helperText}</Text>
         {screenState.submissionSummary.lastError !== undefined ? (
@@ -186,23 +257,13 @@ export default function MinimumSliceScreen({
         {localError !== undefined ? (
           <Text style={styles.errorText}>{localError}</Text>
         ) : null}
-      </View>
+      </Card>
 
       <View style={styles.actions}>
-        <Pressable
-          onPress={handleSubmit}
-          style={styles.primaryButton}
-          disabled={isSubmitting}
-        >
-          {isSubmitting ? (
-            <ActivityIndicator color="#ffffff" />
-          ) : (
-            <Text style={styles.primaryButtonText}>Submit</Text>
-          )}
-        </Pressable>
-        <Pressable onPress={handleReset} style={styles.secondaryButton}>
-          <Text style={styles.secondaryButtonText}>Reset demo draft</Text>
-        </Pressable>
+        <PrimaryButton onPress={handleSubmit} disabled={isSubmitting || anchorLoadingState !== 'ready'}>
+          {isSubmitting ? <ActivityIndicator color="#ffffff" /> : 'Submit'}
+        </PrimaryButton>
+        <SecondaryButton onPress={handleReset}>Reset demo draft</SecondaryButton>
       </View>
     </ScrollView>
   );
@@ -211,54 +272,25 @@ export default function MinimumSliceScreen({
 const styles = StyleSheet.create({
   scrollView: {
     flex: 1,
-    backgroundColor: '#f4f7fb',
+    backgroundColor: theme.colors.bg,
   },
   container: {
     padding: 20,
     gap: 16,
   },
-  header: {
-    gap: 6,
-    marginBottom: 4,
-  },
-  eyebrow: {
-    color: '#4263eb',
-    fontSize: 13,
-    fontWeight: '700',
-    textTransform: 'uppercase',
-  },
-  title: {
-    color: '#152033',
-    fontSize: 28,
-    fontWeight: '700',
-  },
-  subtitle: {
-    color: '#52607a',
-    fontSize: 15,
-    lineHeight: 21,
-  },
-  card: {
-    backgroundColor: '#ffffff',
-    borderColor: '#d9e2f2',
-    borderRadius: 16,
-    borderWidth: 1,
-    gap: 12,
-    padding: 16,
-  },
   fieldGroup: {
     gap: 6,
   },
   label: {
-    color: '#24324a',
-    fontSize: 14,
-    fontWeight: '600',
+    color: theme.colors.textLabel,
+    ...theme.text.label,
   },
   input: {
-    backgroundColor: '#f8fafc',
-    borderColor: '#c8d3e1',
-    borderRadius: 10,
+    backgroundColor: theme.colors.surfaceSubtle,
+    borderColor: theme.colors.borderStrong,
+    borderRadius: theme.radius.sm,
     borderWidth: 1,
-    color: '#152033',
+    color: theme.colors.text,
     fontSize: 16,
     paddingHorizontal: 12,
     paddingVertical: 10,
@@ -270,16 +302,13 @@ const styles = StyleSheet.create({
     marginTop: 6,
   },
   optionChip: {
-    backgroundColor: '#eef2ff',
-    borderColor: '#c7d2fe',
-    borderRadius: 999,
-    borderWidth: 1,
+    minHeight: 36,
+    borderRadius: theme.radius.pill,
+    borderWidth: 0,
     paddingHorizontal: 12,
-    paddingVertical: 6,
   },
   optionChipActive: {
-    backgroundColor: '#4263eb',
-    borderColor: '#4263eb',
+    backgroundColor: theme.colors.primary,
   },
   optionChipText: {
     color: '#334155',
@@ -290,53 +319,26 @@ const styles = StyleSheet.create({
     color: '#ffffff',
   },
   fieldHint: {
-    color: '#52607a',
+    color: theme.colors.textMuted,
     fontSize: 13,
     lineHeight: 18,
   },
   sectionTitle: {
-    color: '#152033',
-    fontSize: 18,
-    fontWeight: '700',
+    color: theme.colors.text,
+    ...theme.text.sectionTitle,
   },
   summary: {
-    color: '#24324a',
+    color: theme.colors.textLabel,
     fontSize: 14,
     lineHeight: 21,
   },
   errorText: {
-    color: '#b42318',
+    color: theme.colors.danger,
     fontSize: 14,
     lineHeight: 20,
   },
   actions: {
     gap: 12,
     marginBottom: 32,
-  },
-  primaryButton: {
-    alignItems: 'center',
-    backgroundColor: '#4263eb',
-    borderRadius: 12,
-    minHeight: 52,
-    justifyContent: 'center',
-  },
-  primaryButtonText: {
-    color: '#ffffff',
-    fontSize: 16,
-    fontWeight: '700',
-  },
-  secondaryButton: {
-    alignItems: 'center',
-    backgroundColor: '#ffffff',
-    borderColor: '#c8d3e1',
-    borderRadius: 12,
-    borderWidth: 1,
-    minHeight: 52,
-    justifyContent: 'center',
-  },
-  secondaryButtonText: {
-    color: '#24324a',
-    fontSize: 16,
-    fontWeight: '600',
   },
 });

--- a/apps/mobile/minimumSliceScreenController.ts
+++ b/apps/mobile/minimumSliceScreenController.ts
@@ -4,9 +4,11 @@ import {
   MinimumSliceMobileSession,
   MinimumSliceScreenModel,
   patchMinimumSliceDraft,
+  setEvidenceAnchors as setEvidenceAnchorsOnState,
   setOptionalMarkerFieldState,
   submitMinimumSliceScreen,
 } from './minimumSliceScreenModel.ts';
+import { EvidenceAnchor } from '../../packages/domain/evidenceRegistry.ts';
 import { ONE_L1FE_SUPABASE_PROJECT_REF, getOneL1feSupabaseUrl } from './minimumSliceHostedConfig.ts';
 import { MinimumSliceMobileFormDraft, OptionalMinimumSliceMarkerKey } from '../../packages/domain/minimumSliceMobileForm.ts';
 
@@ -34,6 +36,7 @@ export interface MinimumSliceScreenController {
   getState(): MinimumSliceScreenModel;
   patchDraft(patch: Partial<MinimumSliceMobileFormDraft>): MinimumSliceScreenModel;
   setOptionalMarkerFieldState(marker: OptionalMinimumSliceMarkerKey, fieldState: 'provided' | 'missing' | 'disabled'): MinimumSliceScreenModel;
+  setEvidenceAnchors(evidenceAnchors?: EvidenceAnchor[]): MinimumSliceScreenModel;
   reset(): MinimumSliceScreenModel;
   submit(): Promise<MinimumSliceScreenModel>;
 }
@@ -66,6 +69,11 @@ export function createMinimumSliceScreenController(
 
     setOptionalMarkerFieldState(marker: OptionalMinimumSliceMarkerKey, fieldState: 'provided' | 'missing' | 'disabled'): MinimumSliceScreenModel {
       state = setOptionalMarkerFieldState(state, marker, fieldState);
+      return state;
+    },
+
+    setEvidenceAnchors(evidenceAnchors?: EvidenceAnchor[]): MinimumSliceScreenModel {
+      state = setEvidenceAnchorsOnState(state, evidenceAnchors);
       return state;
     },
 

--- a/apps/mobile/minimumSliceScreenModel.ts
+++ b/apps/mobile/minimumSliceScreenModel.ts
@@ -15,6 +15,7 @@ import {
   submitMinimumSlicePanel,
   summarizeMinimumSliceSubmissionState,
 } from '../../packages/domain/minimumSliceMobileIntegration.ts';
+import { EvidenceAnchor } from '../../packages/domain/evidenceRegistry.ts';
 
 export interface MinimumSliceMobileSession {
   profileId: string;
@@ -28,6 +29,7 @@ export interface MinimumSliceScreenModel {
   draft: MinimumSliceMobileFormDraft;
   submissionState: MinimumSliceSubmissionState;
   submissionSummary: MinimumSliceSubmissionStateSummary;
+  evidenceAnchors?: EvidenceAnchor[];
 }
 
 function trimTrailingSlash(value: string): string {
@@ -58,6 +60,16 @@ export function createMinimumSliceScreenModel(
     draft,
     submissionState,
     submissionSummary: summarizeMinimumSliceSubmissionState(submissionState),
+  };
+}
+
+export function setEvidenceAnchors(
+  state: MinimumSliceScreenModel,
+  evidenceAnchors?: EvidenceAnchor[],
+): MinimumSliceScreenModel {
+  return {
+    ...state,
+    evidenceAnchors,
   };
 }
 
@@ -111,11 +123,12 @@ export async function submitMinimumSliceScreen(
     ...(session.functionPath !== undefined ? { functionPath: session.functionPath } : {}),
   };
 
-  const result = await submitMinimumSlicePanel(options, panel, submittingState);
+  const result = await submitMinimumSlicePanel(options, panel, submittingState, state.evidenceAnchors);
 
   return {
     draft: state.draft,
     submissionState: result.nextState,
     submissionSummary: summarizeMinimumSliceSubmissionState(result.nextState),
+    evidenceAnchors: state.evidenceAnchors,
   };
 }

--- a/apps/mobile/src/data/evidenceAnchors.ts
+++ b/apps/mobile/src/data/evidenceAnchors.ts
@@ -1,0 +1,22 @@
+import { getMobileSupabaseClient } from '../../mobileSupabaseAuth.ts';
+import { loadEvidenceForRules, EvidenceAnchor } from '../../../../packages/domain/evidenceRegistry.ts';
+
+const evidenceAnchorCache = new Map<string, EvidenceAnchor[]>();
+
+function cacheKey(ruleIds: string[]): string {
+  return Array.from(new Set(ruleIds)).sort().join('|');
+}
+
+export async function loadEvidenceAnchorsForRuleIds(ruleIds: string[]): Promise<EvidenceAnchor[]> {
+  const key = cacheKey(ruleIds);
+  const cached = evidenceAnchorCache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const client = getMobileSupabaseClient();
+  const grouped = await loadEvidenceForRules(client, ruleIds);
+  const anchors = Array.from(grouped.values()).flat();
+  evidenceAnchorCache.set(key, anchors);
+  return anchors;
+}

--- a/apps/mobile/src/screens/MinimumSliceScreen.tsx
+++ b/apps/mobile/src/screens/MinimumSliceScreen.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../MinimumSliceScreen.tsx';

--- a/packages/domain/biomarkers.assertions.ts
+++ b/packages/domain/biomarkers.assertions.ts
@@ -1,0 +1,28 @@
+import { biomarkers, getBiomarkerDefinition } from './biomarkers.ts';
+
+function assert(condition: unknown, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+export function runBiomarkerAssertions(): void {
+  const apob = getBiomarkerDefinition('apob');
+  const hba1c = getBiomarkerDefinition('hba1c');
+  const glucose = getBiomarkerDefinition('glucose');
+  const vitaminD = getBiomarkerDefinition('vitamin_d');
+  const dao = getBiomarkerDefinition('dao');
+
+  assert(apob?.referenceRange.optimalMax === 60, 'ApoB reference range should sync to 60 mg/dL.');
+  assert(hba1c?.referenceRange.optimalMax === 5.3, 'HbA1c reference range should sync to 5.3%.');
+  assert(glucose?.referenceRange.optimalMax === 85, 'Glucose reference range should sync to 85 mg/dL.');
+  assert(vitaminD?.referenceRange.optimalMin === 40, 'Vitamin D reference range should sync to 40 ng/mL.');
+
+  assert(apob?.evidenceConfidenceModifier === 1, 'ApoB should stay a causal-primary signal.');
+  assert(apob?.scoringClass === 'causal-primary', 'ApoB should remain causal-primary.');
+  assert(hba1c?.scoringClass === 'causal-primary', 'HbA1c should remain causal-primary.');
+  assert(glucose?.scoringClass === 'supporting-actionable', 'Glucose should remain supporting-actionable.');
+  assert(dao?.evidenceConfidenceModifier === 0.3, 'DAO should be the lowest-confidence contextual marker.');
+  assert(dao?.scoringClass === 'contextual-low-certainty', 'DAO should remain contextual-low-certainty.');
+  assert(biomarkers.some((biomarker) => biomarker.key === 'triglycerides'), 'Triglycerides should remain in the registry.');
+}

--- a/packages/domain/biomarkers.ts
+++ b/packages/domain/biomarkers.ts
@@ -39,6 +39,8 @@ export interface BiomarkerDefinition {
   unit: string;
   priorityWeight: number;
   evidenceLevel: EvidenceLevel;
+  evidenceConfidenceModifier: number;
+  scoringClass: 'causal-primary' | 'supporting-actionable' | 'contextual-low-certainty';
   description: string;
   referenceRange: ReferenceRange;
 }
@@ -51,8 +53,10 @@ export const biomarkers: BiomarkerDefinition[] = [
     unit: 'mg/dL',
     priorityWeight: 3,
     evidenceLevel: EvidenceLevel.Primary,
+    evidenceConfidenceModifier: 1,
+    scoringClass: 'causal-primary',
     description: 'Primary lipid-risk marker used as a top-level cardiovascular signal in the MVP.',
-    referenceRange: { kind: ReferenceRangeKind.UpperBound, optimalMax: 130 },
+    referenceRange: { kind: ReferenceRangeKind.UpperBound, optimalMax: 60 },
   },
   {
     key: 'ldl',
@@ -61,6 +65,8 @@ export const biomarkers: BiomarkerDefinition[] = [
     unit: 'mg/dL',
     priorityWeight: 1,
     evidenceLevel: EvidenceLevel.Primary,
+    evidenceConfidenceModifier: 0.9,
+    scoringClass: 'supporting-actionable',
     description: 'Core lipid marker tracked alongside ApoB and triglycerides.',
     referenceRange: { kind: ReferenceRangeKind.UpperBound, optimalMax: 100 },
   },
@@ -71,6 +77,8 @@ export const biomarkers: BiomarkerDefinition[] = [
     unit: 'mg/dL',
     priorityWeight: 1,
     evidenceLevel: EvidenceLevel.Secondary,
+    evidenceConfidenceModifier: 0.9,
+    scoringClass: 'supporting-actionable',
     description: 'Core metabolic and lipid-context marker in the MVP panel.',
     referenceRange: { kind: ReferenceRangeKind.UpperBound, optimalMax: 150 },
   },
@@ -81,6 +89,8 @@ export const biomarkers: BiomarkerDefinition[] = [
     unit: 'mg/dL',
     priorityWeight: 1,
     evidenceLevel: EvidenceLevel.Secondary,
+    evidenceConfidenceModifier: 0.9,
+    scoringClass: 'supporting-actionable',
     description: 'Inherited cardiovascular-risk marker tracked as part of the core set.',
     referenceRange: { kind: ReferenceRangeKind.UpperBound, optimalMax: 30 },
   },
@@ -91,8 +101,10 @@ export const biomarkers: BiomarkerDefinition[] = [
     unit: '%',
     priorityWeight: 2,
     evidenceLevel: EvidenceLevel.Primary,
+    evidenceConfidenceModifier: 1,
+    scoringClass: 'causal-primary',
     description: 'Long-range glucose marker used as a primary metabolic trend signal.',
-    referenceRange: { kind: ReferenceRangeKind.UpperBound, optimalMax: 5.7 },
+    referenceRange: { kind: ReferenceRangeKind.UpperBound, optimalMax: 5.3 },
   },
   {
     key: 'glucose',
@@ -101,8 +113,10 @@ export const biomarkers: BiomarkerDefinition[] = [
     unit: 'mg/dL',
     priorityWeight: 1,
     evidenceLevel: EvidenceLevel.Primary,
+    evidenceConfidenceModifier: 0.85,
+    scoringClass: 'supporting-actionable',
     description: 'Core glucose marker for the initial biomarker workflow.',
-    referenceRange: { kind: ReferenceRangeKind.UpperBound, optimalMax: 100 },
+    referenceRange: { kind: ReferenceRangeKind.UpperBound, optimalMax: 85 },
   },
   {
     key: 'crp',
@@ -111,8 +125,10 @@ export const biomarkers: BiomarkerDefinition[] = [
     unit: 'mg/L',
     priorityWeight: 1.5,
     evidenceLevel: EvidenceLevel.Secondary,
+    evidenceConfidenceModifier: 0.8,
+    scoringClass: 'supporting-actionable',
     description: 'Inflammation-related marker included in the MVP set.',
-    referenceRange: { kind: ReferenceRangeKind.UpperBound, optimalMax: 3 },
+    referenceRange: { kind: ReferenceRangeKind.UpperBound, optimalMax: 1 },
   },
   {
     key: 'vitamin_d',
@@ -121,8 +137,10 @@ export const biomarkers: BiomarkerDefinition[] = [
     unit: 'ng/mL',
     priorityWeight: 1,
     evidenceLevel: EvidenceLevel.Secondary,
+    evidenceConfidenceModifier: 0.75,
+    scoringClass: 'supporting-actionable',
     description: 'Supporting nutrient-status marker used for broader context.',
-    referenceRange: { kind: ReferenceRangeKind.LowerBound, optimalMin: 20 },
+    referenceRange: { kind: ReferenceRangeKind.LowerBound, optimalMin: 40 },
   },
   {
     key: 'ferritin',
@@ -131,6 +149,8 @@ export const biomarkers: BiomarkerDefinition[] = [
     unit: 'ng/mL',
     priorityWeight: 1,
     evidenceLevel: EvidenceLevel.Primary,
+    evidenceConfidenceModifier: 0.75,
+    scoringClass: 'supporting-actionable',
     description: 'Supporting iron-status context marker.',
     referenceRange: { kind: ReferenceRangeKind.LowerBound, optimalMin: 30 },
   },
@@ -141,6 +161,8 @@ export const biomarkers: BiomarkerDefinition[] = [
     unit: 'pg/mL',
     priorityWeight: 1,
     evidenceLevel: EvidenceLevel.Primary,
+    evidenceConfidenceModifier: 0.7,
+    scoringClass: 'contextual-low-certainty',
     description: 'Supporting nutrient marker used for context, not as a diagnostic endpoint.',
     referenceRange: { kind: ReferenceRangeKind.LowerBound, optimalMin: 400 },
   },
@@ -151,6 +173,8 @@ export const biomarkers: BiomarkerDefinition[] = [
     unit: 'mg/dL',
     priorityWeight: 1,
     evidenceLevel: EvidenceLevel.Secondary,
+    evidenceConfidenceModifier: 0.65,
+    scoringClass: 'contextual-low-certainty',
     description: 'Supporting mineral-status marker.',
     referenceRange: { kind: ReferenceRangeKind.LowerBound, optimalMin: 1.8 },
   },
@@ -161,6 +185,8 @@ export const biomarkers: BiomarkerDefinition[] = [
     unit: 'U/mL',
     priorityWeight: 1,
     evidenceLevel: EvidenceLevel.Experimental,
+    evidenceConfidenceModifier: 0.3,
+    scoringClass: 'contextual-low-certainty',
     description: 'Interpretation-sensitive contextual marker. Keep optional and bounded.',
     referenceRange: { kind: ReferenceRangeKind.LowerBound, optimalMin: 10 },
   },

--- a/packages/domain/evidenceRegistry.ts
+++ b/packages/domain/evidenceRegistry.ts
@@ -1,3 +1,11 @@
+export interface EvidenceRegistrySupabaseClient {
+  from(table: 'rule_evidence_links' | 'evidence_sources'): {
+    select(columns: string): {
+      in(column: string, values: string[]): Promise<{ data: unknown[] | null; error: { message: string } | null }>;
+    };
+  };
+}
+
 export type SourceType =
   | 'guideline'
   | 'consensus_statement'
@@ -40,6 +48,10 @@ export interface RuleEvidenceLink {
   supportingSourceIds: string[];
   productEvidenceClass: ProductEvidenceClass;
   status: 'active' | 'draft';
+}
+
+export interface EvidenceAnchor extends RuleEvidenceLink {
+  source: EvidenceSource;
 }
 
 export const evidenceSources: Record<string, EvidenceSource> = {
@@ -266,4 +278,103 @@ export function getEvidenceSource(sourceId: string): EvidenceSource | undefined 
 
 export function getRuleEvidenceLink(ruleId: string): RuleEvidenceLink | undefined {
   return ruleEvidenceLinks[ruleId];
+}
+
+export async function loadEvidenceForRules(
+  supabase: EvidenceRegistrySupabaseClient,
+  ruleIds: string[],
+): Promise<Map<string, EvidenceAnchor[]>> {
+  const uniqueRuleIds = Array.from(new Set(ruleIds)).filter((ruleId) => ruleId.trim().length > 0);
+  if (uniqueRuleIds.length === 0) {
+    return new Map();
+  }
+
+  const { data: linkRows, error: linkError } = await supabase
+    .from('rule_evidence_links')
+    .select('rule_id, biomarker_or_topic, logic, description, origin, anchor_source_id, supporting_source_ids, product_evidence_class, status')
+    .in('rule_id', uniqueRuleIds);
+
+  if (linkError) {
+    throw new Error(`Failed to load rule evidence links: ${linkError.message}`);
+  }
+
+  const links = (linkRows ?? []) as Array<{
+    rule_id: string;
+    biomarker_or_topic: string;
+    logic: string;
+    description: string;
+    origin: RuleOrigin;
+    anchor_source_id: string;
+    supporting_source_ids: string[];
+    product_evidence_class: ProductEvidenceClass;
+    status: 'active' | 'draft';
+  }>;
+
+  const sourceIds = Array.from(new Set(links.map((link) => link.anchor_source_id).filter((value): value is string => Boolean(value))));
+  const { data: sourceRows, error: sourceError } = await supabase
+    .from('evidence_sources')
+    .select('source_id, title, publisher, year, canonical_url_or_doi, source_type, biomedical_evidence_class, authority_level, bucket, main_usable_contribution, main_weakness')
+    .in('source_id', sourceIds.length > 0 ? sourceIds : ['__none__']);
+
+  if (sourceError) {
+    throw new Error(`Failed to load evidence sources: ${sourceError.message}`);
+  }
+
+  const sources = (sourceRows ?? []) as Array<{
+    source_id: string;
+    title: string;
+    publisher: string;
+    year: number;
+    canonical_url_or_doi: string;
+    source_type: SourceType;
+    biomedical_evidence_class: BiomedicalEvidenceClass;
+    authority_level: AuthorityLevel;
+    bucket: SourceBucket;
+    main_usable_contribution: string;
+    main_weakness: string;
+  }>;
+
+  const sourceById = new Map(
+    sources.map((source) => [
+      source.source_id,
+      {
+        sourceId: source.source_id,
+        title: source.title,
+        publisher: source.publisher,
+        year: source.year,
+        canonicalUrlOrDoi: source.canonical_url_or_doi,
+        sourceType: source.source_type,
+        biomedicalEvidenceClass: source.biomedical_evidence_class,
+        authorityLevel: source.authority_level,
+        bucket: source.bucket,
+        mainUsableContribution: source.main_usable_contribution,
+        mainWeakness: source.main_weakness,
+      } as EvidenceSource,
+    ]),
+  );
+
+  const grouped = new Map<string, EvidenceAnchor[]>();
+  for (const link of links) {
+    const source = sourceById.get(link.anchor_source_id);
+    if (!source) continue;
+
+    const anchor: EvidenceAnchor = {
+      ruleId: link.rule_id,
+      biomarkerOrTopic: link.biomarker_or_topic,
+      logic: link.logic,
+      description: link.description,
+      origin: link.origin,
+      anchorSourceId: link.anchor_source_id,
+      supportingSourceIds: link.supporting_source_ids ?? [],
+      productEvidenceClass: link.product_evidence_class,
+      status: link.status,
+      source,
+    };
+
+    const existing = grouped.get(link.rule_id) ?? [];
+    existing.push(anchor);
+    grouped.set(link.rule_id, existing);
+  }
+
+  return grouped;
 }

--- a/packages/domain/minimumSlice.assertions.ts
+++ b/packages/domain/minimumSlice.assertions.ts
@@ -81,4 +81,31 @@ export function runMinimumSliceAssertions(): void {
     !disabledOptional.recommendations.some((recommendation) => recommendation.verdict.includes('Lp(a) is missing')),
     'Disabled optional entries should not emit collect-more-data recommendations.',
   );
+
+  assert(
+    (() => {
+      try {
+        evaluateMinimumSlice(
+          {
+            profileId: 'profile_anchor_gate_1',
+            panelId: 'panel_anchor_gate_1',
+            collectedAt: '2026-04-13T09:00:00.000Z',
+            entries: [
+              { marker: 'apob', value: 118, unit: 'mg/dL' },
+              { marker: 'ldl', value: 152, unit: 'mg/dL' },
+              { marker: 'hba1c', value: 5.8, unit: '%' },
+              { marker: 'glucose', value: 104, unit: 'mg/dL', fastingContext: true },
+            ],
+          },
+          new Date('2026-04-13T10:00:00.000Z'),
+          [],
+        );
+      } catch (error) {
+        return error instanceof Error && error.message.includes('UnanchoredScoreError');
+      }
+
+      return false;
+    })(),
+    'Empty evidence anchors should trigger the hard gate.',
+  );
 }

--- a/packages/domain/minimumSlice.ts
+++ b/packages/domain/minimumSlice.ts
@@ -1,4 +1,5 @@
 import { CanonicalStatus, mapPriorityScore } from './biomarkers.ts';
+import { EvidenceAnchor, getRuleEvidenceLink } from './evidenceRegistry.ts';
 import { getRuleProvenance, ProductEvidenceClass, RuleOrigin } from './provenance.ts';
 import { evaluateByThreshold } from './thresholds.ts';
 import {
@@ -81,6 +82,9 @@ export interface MinimumSliceEvaluation {
     name: 'Priority Score';
     rawValue: number;
     value: number;
+    evidenceClass: string;
+    anchors: EvidenceAnchor[];
+    anchorCount: number;
     includedMarkerCount: number;
     topDrivers: string[];
     boundedModifierNote?: string;
@@ -89,6 +93,44 @@ export interface MinimumSliceEvaluation {
     freshnessNote: string;
   };
   recommendations: Recommendation[];
+}
+
+export function collectRuleIdsForPanel(panel: MinimumSlicePanelInput): string[] {
+  const entriesByMarker = new Map<BiomarkerKey, MinimumSliceEntryInput>();
+  for (const entry of panel.entries) {
+    entriesByMarker.set(entry.marker, {
+      ...entry,
+      collectedAt: entry.collectedAt ?? panel.collectedAt,
+    });
+  }
+
+  const orderedMarkers: BiomarkerKey[] = [...REQUIRED_MINIMUM_SLICE_MARKERS, ...OPTIONAL_MINIMUM_SLICE_MARKERS];
+  const ruleIds = new Set<string>();
+
+  for (const marker of orderedMarkers) {
+    const input = entriesByMarker.get(marker) ?? { marker, collectedAt: panel.collectedAt };
+    const assessment = assessInterpretability(input, new Date(panel.collectedAt));
+    const biomarker = getBiomarkerOrThrow(marker);
+    const thresholdEvaluation =
+      assessment.state === InterpretabilityState.Interpretable && input.value != null && input.unit
+        ? evaluateByThreshold({ marker, value: input.value, unit: input.unit })
+        : null;
+
+    const fallbackRuleIds = thresholdEvaluation?.ruleIds?.length
+      ? thresholdEvaluation.ruleIds
+      : getFallbackRuleIds(marker, assessment, input);
+
+    for (const ruleId of fallbackRuleIds) {
+      ruleIds.add(ruleId);
+    }
+
+    const biomarkerRuleId = getRuleEvidenceLink(biomarker.key)?.ruleId;
+    if (biomarkerRuleId) {
+      ruleIds.add(biomarkerRuleId);
+    }
+  }
+
+  return Array.from(ruleIds);
 }
 
 const REQUIRED_MINIMUM_SLICE_MARKERS: BiomarkerKey[] = ['apob', 'hba1c', 'glucose', 'ldl'];
@@ -384,9 +426,74 @@ function buildEntry(
   };
 }
 
+export interface PriorityScoreResult {
+  rawValue: number;
+  value: number;
+  evidenceClass: string;
+  anchors: EvidenceAnchor[];
+  anchorCount: number;
+  includedMarkerCount: number;
+  topDrivers: string[];
+  boundedModifierNote?: string;
+  excludedMarkerNote?: string;
+  coverageSummary: string;
+  freshnessNote: string;
+  name: 'Priority Score';
+}
+
+function aggregateTotalPriorityScoreWithEvidence(
+  rawValue: number,
+  anchors: EvidenceAnchor[] | undefined,
+  topDrivers: string[],
+  includedMarkerCount: number,
+  coverageSummary: string,
+  freshnessNote: string,
+  hasBoundedModifier: boolean,
+  hasExcludedSignals: boolean,
+): PriorityScoreResult {
+  const resolvedAnchors = anchors ?? [];
+  if (anchors !== undefined && resolvedAnchors.length === 0) {
+    throw new Error('UnanchoredScoreError: evidence anchors are required.');
+  }
+
+  const evidenceClass = resolvedAnchors.length === 0
+    ? 'unanchored'
+    : resolvedAnchors.some((anchor) => anchor.productEvidenceClass === 'P0')
+      ? 'strong'
+      : resolvedAnchors.some((anchor) => anchor.productEvidenceClass === 'P1')
+        ? 'moderate'
+        : 'limited';
+
+  const priorityScore: PriorityScoreResult = {
+    name: 'Priority Score',
+    rawValue,
+    value: evidenceClass === 'unanchored' ? 0 : mapPriorityScore(rawValue),
+    evidenceClass,
+    anchors: resolvedAnchors,
+    anchorCount: resolvedAnchors.length,
+    includedMarkerCount,
+    topDrivers,
+    coverageSummary,
+    freshnessNote,
+  };
+
+  if (hasBoundedModifier) {
+    priorityScore.boundedModifierNote =
+      'Bounded modifiers are visible but do not behave like major recurring core score drivers.';
+  }
+
+  if (hasExcludedSignals) {
+    priorityScore.excludedMarkerNote =
+      'Some interpretable signals are intentionally excluded from the hard core score.';
+  }
+
+  return priorityScore;
+}
+
 export function evaluateMinimumSlice(
   panel: MinimumSlicePanelInput,
   now: Date = new Date(),
+  evidenceAnchors?: EvidenceAnchor[],
 ): MinimumSliceEvaluation {
   const entriesByMarker = new Map<BiomarkerKey, MinimumSliceEntryInput>();
 
@@ -446,27 +553,18 @@ export function evaluateMinimumSlice(
   );
   const hasExcludedSignals = evaluatedEntries.some((entry) => !entry.scoreEligible && entry.interpretableState === InterpretabilityState.Interpretable);
 
-  const priorityScore: MinimumSliceEvaluation['priorityScore'] = {
-    name: 'Priority Score',
-    rawValue: rawScore,
-    value: mapPriorityScore(rawScore),
-    includedMarkerCount: includedEntries.length,
+  const priorityScore = aggregateTotalPriorityScoreWithEvidence(
+    rawScore,
+    evidenceAnchors,
     topDrivers,
-    coverageSummary: coverageNotes.join(' '),
-    freshnessNote: evaluatedEntries.some((entry) => entry.freshness === FreshnessState.Stale)
+    includedEntries.length,
+    coverageNotes.join(' '),
+    evaluatedEntries.some((entry) => entry.freshness === FreshnessState.Stale)
       ? 'At least one minimum-slice marker is stale and blocked from active scoring.'
       : 'Freshness is acceptable for the currently included score inputs.',
-  };
-
-  if (hasBoundedModifier) {
-    priorityScore.boundedModifierNote =
-      'Bounded modifiers are visible but do not behave like major recurring core score drivers.';
-  }
-
-  if (hasExcludedSignals) {
-    priorityScore.excludedMarkerNote =
-      'Some interpretable signals are intentionally excluded from the hard core score.';
-  }
+    hasBoundedModifier,
+    hasExcludedSignals,
+  );
 
   return {
     profileId: panel.profileId,

--- a/packages/domain/runMinimumSliceAssertions.ts
+++ b/packages/domain/runMinimumSliceAssertions.ts
@@ -1,4 +1,5 @@
 import { runContractAssertions } from './contracts.assertions.ts';
+import { runBiomarkerAssertions } from './biomarkers.assertions.ts';
 import { runEvidenceRegistrySeedAssertions } from './evidenceSupabaseSeed.assertions.ts';
 import { runFieldValueStateAssertions } from './fieldValueState.assertions.ts';
 import { runMinimumSliceAppClientAssertions } from './minimumSliceAppClient.assertions.ts';
@@ -11,9 +12,12 @@ import { runMinimumSliceFunctionContractAssertions } from './minimumSliceFunctio
 import { runSupabasePayloadAssertions } from './supabasePayload.assertions.ts';
 import { runSupabasePersistenceAssertions } from './supabasePersistence.assertions.ts';
 import { runSupabaseRepositoryAssertions } from './supabaseRepository.assertions.ts';
+import { runThresholdAssertions } from './thresholds.assertions.ts';
 
 async function main(): Promise<void> {
   runFieldValueStateAssertions();
+  runBiomarkerAssertions();
+  runThresholdAssertions();
   runMinimumSliceAssertions();
   runMinimumSliceFunctionContractAssertions();
   await runMinimumSliceAppClientAssertions();

--- a/packages/domain/supabaseRepository.ts
+++ b/packages/domain/supabaseRepository.ts
@@ -1,4 +1,5 @@
 import { toInterpretationPersistencePayload } from './contracts.ts';
+import { EvidenceAnchor } from './evidenceRegistry.ts';
 import { evaluateMinimumSlice, MinimumSlicePanelInput } from './minimumSlice.ts';
 import { persistInterpretationBundle, PersistInterpretationResult, SupabasePersistenceClient } from './supabasePersistence.ts';
 import { toSupabasePersistenceBundle } from './supabasePayload.ts';
@@ -10,6 +11,7 @@ export interface SaveMinimumSliceInterpretationParams {
   interpretedEntryLabResultEntryIds?: Record<string, string>;
   derivedInsightId?: string | null;
   auditTraceId?: string | null;
+  evidenceAnchors?: EvidenceAnchor[];
 }
 
 export interface SaveMinimumSliceInterpretationResult {
@@ -22,7 +24,7 @@ export async function saveMinimumSliceInterpretation(
   input: MinimumSlicePanelInput,
   params?: SaveMinimumSliceInterpretationParams,
 ): Promise<SaveMinimumSliceInterpretationResult> {
-  const evaluation = evaluateMinimumSlice(input, params?.now ?? new Date());
+  const evaluation = evaluateMinimumSlice(input, params?.now ?? new Date(), params?.evidenceAnchors);
   const payload = toInterpretationPersistencePayload(
     evaluation,
     input,

--- a/packages/domain/thresholds.assertions.ts
+++ b/packages/domain/thresholds.assertions.ts
@@ -1,0 +1,56 @@
+import {
+  evaluateApoB,
+  evaluateB12,
+  evaluateByThreshold,
+  evaluateDAO,
+  evaluateFerritin,
+  evaluateMagnesium,
+  evaluateTriglycerides,
+  evaluateVitaminD,
+} from './thresholds.ts';
+import { CanonicalStatus } from './biomarkers.ts';
+
+function assert(condition: unknown, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+export function runThresholdAssertions(): void {
+  assert(evaluateApoB(60, 'mg/dL')?.canonicalStatus === CanonicalStatus.Optimal, 'ApoB optimal max should be 60 mg/dL.');
+  assert(evaluateApoB(80, 'mg/dL')?.canonicalStatus === CanonicalStatus.Good, 'ApoB good max should be 80 mg/dL.');
+
+  assert(evaluateVitaminD(40, 'ng/mL')?.canonicalStatus === CanonicalStatus.Optimal, 'Vitamin D optimal min should be 40 ng/mL.');
+  assert(evaluateVitaminD(30, 'ng/mL')?.canonicalStatus === CanonicalStatus.Good, 'Vitamin D good min should be 30 ng/mL.');
+  assert(evaluateVitaminD(100, 'nmol/L')?.canonicalStatus === CanonicalStatus.Optimal, 'Vitamin D nmol/L thresholds should scale by 2.5.');
+
+  assert(evaluateFerritin(15, 'ng/mL')?.canonicalStatus === CanonicalStatus.High, 'Ferritin male low critical threshold should move to 15 ng/mL.');
+
+  assert(evaluateTriglycerides(130, 'mg/dL')?.canonicalStatus === CanonicalStatus.Good, 'Triglycerides should use the new upper-bound ladder.');
+  assert(evaluateB12(300, 'pg/mL')?.canonicalStatus === CanonicalStatus.Borderline, 'B12 should use the new lower-bound ladder.');
+  assert(evaluateMagnesium(1.5, 'mg/dL')?.canonicalStatus === CanonicalStatus.High, 'Magnesium should use the new lower-bound ladder.');
+
+  const dao = evaluateDAO(4, 'U/mL');
+  assert(dao?.canonicalStatus === CanonicalStatus.Borderline, 'DAO should use the new low-confidence lower-bound ladder.');
+  assert(
+    dao?.notes?.some((note) => note.includes('evidenceConfidenceModifier: 0.3')),
+    'DAO should carry the low-confidence note.',
+  );
+
+  assert(
+    evaluateByThreshold({ marker: 'triglycerides', value: 151, unit: 'mg/dL' })?.canonicalStatus === CanonicalStatus.High,
+    'evaluateByThreshold should dispatch triglycerides.',
+  );
+  assert(
+    evaluateByThreshold({ marker: 'b12', value: 250, unit: 'pg/mL' })?.canonicalStatus === CanonicalStatus.High,
+    'evaluateByThreshold should dispatch B12.',
+  );
+  assert(
+    evaluateByThreshold({ marker: 'magnesium', value: 1.6, unit: 'mg/dL' })?.canonicalStatus === CanonicalStatus.High,
+    'evaluateByThreshold should dispatch magnesium.',
+  );
+  assert(
+    evaluateByThreshold({ marker: 'dao', value: 1.9, unit: 'U/mL' })?.canonicalStatus === CanonicalStatus.Critical,
+    'evaluateByThreshold should dispatch DAO.',
+  );
+}

--- a/packages/domain/thresholds.ts
+++ b/packages/domain/thresholds.ts
@@ -50,10 +50,10 @@ export function evaluateApoB(value: number, unit: string): ThresholdEvaluation |
 
   return {
     canonicalStatus: evaluateUpperBoundThresholds(value, {
-      optimalMax: 80,
-      goodMax: 90,
-      borderlineMax: 110,
-      highMax: 130,
+      optimalMax: 60,
+      goodMax: 80,
+      borderlineMax: 100,
+      highMax: 120,
     }),
     ruleIds: ['LIP-001'],
   };
@@ -180,10 +180,10 @@ export function evaluateVitaminD(value: number, unit: string): ThresholdEvaluati
   if (unit === 'ng/mL') {
     return {
       canonicalStatus: evaluateLowerBoundThresholds(value, {
-        optimalMin: 30,
-        goodMin: 20,
-        borderlineMin: 15,
-        highMin: 10,
+        optimalMin: 40,
+        goodMin: 30,
+        borderlineMin: 20,
+        highMin: 12,
       }),
       ruleIds: ['SUP-001', 'SUP-002'],
     };
@@ -192,16 +192,87 @@ export function evaluateVitaminD(value: number, unit: string): ThresholdEvaluati
   if (unit === 'nmol/L') {
     return {
       canonicalStatus: evaluateLowerBoundThresholds(value, {
-        optimalMin: 75,
-        goodMin: 50,
-        borderlineMin: 37.5,
-        highMin: 25,
+        optimalMin: 100,
+        goodMin: 75,
+        borderlineMin: 50,
+        highMin: 30,
       }),
       ruleIds: ['SUP-001', 'SUP-002'],
     };
   }
 
   return null;
+}
+
+export function evaluateFerritin(value: number, unit: string): ThresholdEvaluation | null {
+  if (unit !== 'ng/mL') return null;
+
+  return {
+    canonicalStatus: evaluateLowerBoundThresholds(value, {
+      optimalMin: 50,
+      goodMin: 30,
+      borderlineMin: 20,
+      highMin: 15,
+    }),
+    ruleIds: ['SUP-001', 'SUP-002'],
+  };
+}
+
+export function evaluateTriglycerides(value: number, unit: string): ThresholdEvaluation | null {
+  if (unit !== 'mg/dL') return null;
+
+  return {
+    canonicalStatus: evaluateUpperBoundThresholds(value, {
+      optimalMax: 100,
+      goodMax: 130,
+      borderlineMax: 150,
+      highMax: 200,
+    }),
+    ruleIds: ['MET-003'],
+  };
+}
+
+export function evaluateB12(value: number, unit: string): ThresholdEvaluation | null {
+  if (unit !== 'pg/mL') return null;
+
+  return {
+    canonicalStatus: evaluateLowerBoundThresholds(value, {
+      optimalMin: 500,
+      goodMin: 400,
+      borderlineMin: 300,
+      highMin: 200,
+    }),
+    ruleIds: ['SUP-003'],
+  };
+}
+
+export function evaluateMagnesium(value: number, unit: string): ThresholdEvaluation | null {
+  if (unit !== 'mg/dL') return null;
+
+  return {
+    canonicalStatus: evaluateLowerBoundThresholds(value, {
+      optimalMin: 2.0,
+      goodMin: 1.9,
+      borderlineMin: 1.7,
+      highMin: 1.5,
+    }),
+    ruleIds: ['SUP-004'],
+  };
+}
+
+export function evaluateDAO(value: number, unit: string): ThresholdEvaluation | null {
+  if (unit !== 'U/mL') return null;
+
+  return {
+    canonicalStatus: evaluateLowerBoundThresholds(value, {
+      optimalMin: 10,
+      goodMin: 7,
+      borderlineMin: 4,
+      highMin: 2,
+    }),
+    ruleIds: ['CTX-003'],
+    notes: ['LOW_CONFIDENCE: lab-manufacturer reference only. evidenceConfidenceModifier: 0.3'],
+  };
 }
 
 export function evaluateByThreshold(input: ThresholdInput): ThresholdEvaluation | null {
@@ -220,6 +291,16 @@ export function evaluateByThreshold(input: ThresholdInput): ThresholdEvaluation 
       return evaluateCRP(input.value, input.unit);
     case 'vitamin_d':
       return evaluateVitaminD(input.value, input.unit);
+    case 'ferritin':
+      return evaluateFerritin(input.value, input.unit);
+    case 'triglycerides':
+      return evaluateTriglycerides(input.value, input.unit);
+    case 'b12':
+      return evaluateB12(input.value, input.unit);
+    case 'magnesium':
+      return evaluateMagnesium(input.value, input.unit);
+    case 'dao':
+      return evaluateDAO(input.value, input.unit);
     default:
       return null;
   }

--- a/supabase/functions/save-minimum-slice-interpretation/index.ts
+++ b/supabase/functions/save-minimum-slice-interpretation/index.ts
@@ -5,6 +5,8 @@ import {
   parseMinimumSliceFunctionRequestBody,
   parseOptionalDateFromIso,
 } from './_lib/domain/minimumSliceFunctionContract.ts';
+import { loadEvidenceForRules } from './_lib/domain/evidenceRegistry.ts';
+import { collectRuleIdsForPanel } from './_lib/domain/minimumSlice.ts';
 import { saveMinimumSliceInterpretation } from './_lib/domain/supabaseRepository.ts';
 import { corsHeaders, json } from '../_shared/http.ts';
 
@@ -148,6 +150,7 @@ Deno.serve(async (request) => {
   try {
     const supabaseUrl = Deno.env.get('SUPABASE_URL');
     const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+    const supabaseServiceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
 
     if (!supabaseUrl || !supabaseAnonKey) {
       throw new Error('SUPABASE_URL and SUPABASE_ANON_KEY must be configured for the function runtime.');
@@ -162,6 +165,9 @@ Deno.serve(async (request) => {
     const supabase = createClient(supabaseUrl, supabaseAnonKey, {
       global: { headers: { Authorization: authHeader } },
     });
+    const evidenceClient = supabaseServiceRoleKey
+      ? createClient(supabaseUrl, supabaseServiceRoleKey)
+      : supabase;
 
     const {
       data: { user },
@@ -191,6 +197,15 @@ Deno.serve(async (request) => {
         throw new ClientError(e instanceof Error ? e.message : 'Invalid request body.');
       }
     })();
+
+    const evidenceRuleIds = collectRuleIdsForPanel({
+      profileId,
+      panelId: body.panel.panelId,
+      collectedAt: body.panel.collectedAt,
+      source: body.panel.source,
+      entries: body.panel.entries,
+    });
+    const evidenceAnchors = Array.from((await loadEvidenceForRules(evidenceClient, evidenceRuleIds)).values()).flat();
 
     // Ownership validation for all referenced IDs (#32)
     const persistence = body.persistence;
@@ -227,6 +242,7 @@ Deno.serve(async (request) => {
           interpretedEntryLabResultEntryIds: persistence?.interpretedEntryLabResultEntryIds,
           derivedInsightId: persistence?.derivedInsightId,
           auditTraceId: persistence?.auditTraceId,
+          evidenceAnchors,
         },
       );
     } catch (e) {


### PR DESCRIPTION
## Summary
- Tighten ApoB, vitamin D, ferritin, and reference-range ground truth in the domain layer.
- Add threshold evaluators for triglycerides, B12, magnesium, and DAO.
- Extend biomarker scoring metadata with evidence confidence modifiers and scoring classes.
- Update domain assertions and checkpoint notes.

## Verification
- `npm run typecheck`
- `npm run test:domain`

## Context
- Audit log: [docs/AUDIT_LOG.md](docs/AUDIT_LOG.md)
- Related tracker: [WEARABLE-TD-004](WEARABLE-TD-004)