### PR TITLE
feat: user-configurable panel preferences

### DIFF
--- a/apps/mobile/src/data/userPreferences.ts
+++ b/apps/mobile/src/data/userPreferences.ts
@@ -1,0 +1,111 @@
+import {
+  DEFAULT_HC_RECORD_TYPES,
+  MANDATORY_MARKER_KEYS,
+  OPTIONAL_MARKER_KEYS,
+  type MarkerPreference,
+  type WearablePreference,
+} from '../../../../packages/domain/userPreferences.ts';
+import { getMobileSupabaseClient } from '../../mobileSupabaseAuth.ts';
+
+type MarkerRow = {
+  marker_key: string;
+  enabled: boolean;
+};
+
+type WearableRow = {
+  hc_record_type: string;
+  enabled: boolean;
+};
+
+export async function seedDefaultPreferencesIfAbsent(appInstallId: string): Promise<void> {
+  const supabase = getMobileSupabaseClient();
+  const markerRows = [...MANDATORY_MARKER_KEYS, ...OPTIONAL_MARKER_KEYS].map((markerKey) => ({
+    app_install_id: appInstallId,
+    marker_key: markerKey,
+    enabled: true,
+  }));
+
+  const wearableRows = DEFAULT_HC_RECORD_TYPES.map((hcRecordType) => ({
+    app_install_id: appInstallId,
+    hc_record_type: hcRecordType,
+    enabled: true,
+  }));
+
+  await supabase.from('user_marker_preferences').upsert(markerRows, {
+    onConflict: 'app_install_id,marker_key',
+    ignoreDuplicates: true,
+  });
+
+  await supabase.from('user_wearable_preferences').upsert(wearableRows, {
+    onConflict: 'app_install_id,hc_record_type',
+    ignoreDuplicates: true,
+  });
+}
+
+export async function fetchMarkerPreferences(appInstallId: string): Promise<MarkerPreference[]> {
+  const supabase = getMobileSupabaseClient();
+  const { data, error } = await supabase
+    .from('user_marker_preferences')
+    .select('marker_key, enabled')
+    .eq('app_install_id', appInstallId);
+
+  if (error) throw error;
+  return (data ?? []).map((row: MarkerRow) => ({ markerKey: row.marker_key, enabled: row.enabled }));
+}
+
+export async function fetchWearablePreferences(appInstallId: string): Promise<WearablePreference[]> {
+  const supabase = getMobileSupabaseClient();
+  const { data, error } = await supabase
+    .from('user_wearable_preferences')
+    .select('hc_record_type, enabled')
+    .eq('app_install_id', appInstallId);
+
+  if (error) throw error;
+  return (data ?? []).map((row: WearableRow) => ({ hcRecordType: row.hc_record_type, enabled: row.enabled }));
+}
+
+export async function setMarkerPreference(
+  appInstallId: string,
+  markerKey: string,
+  enabled: boolean,
+  onRollback: (previousValue: boolean) => void,
+): Promise<void> {
+  const supabase = getMobileSupabaseClient();
+  const { error } = await supabase.from('user_marker_preferences').upsert(
+    {
+      app_install_id: appInstallId,
+      marker_key: markerKey,
+      enabled,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'app_install_id,marker_key' },
+  );
+
+  if (error) {
+    onRollback(!enabled);
+    throw error;
+  }
+}
+
+export async function setWearablePreference(
+  appInstallId: string,
+  recordType: string,
+  enabled: boolean,
+  onRollback: (previousValue: boolean) => void,
+): Promise<void> {
+  const supabase = getMobileSupabaseClient();
+  const { error } = await supabase.from('user_wearable_preferences').upsert(
+    {
+      app_install_id: appInstallId,
+      hc_record_type: recordType,
+      enabled,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'app_install_id,hc_record_type' },
+  );
+
+  if (error) {
+    onRollback(!enabled);
+    throw error;
+  }
+}

--- a/apps/mobile/src/screens/DataSourcesSettingsScreen.tsx
+++ b/apps/mobile/src/screens/DataSourcesSettingsScreen.tsx
@@ -1,0 +1,208 @@
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { seedDefaultPreferencesIfAbsent, fetchMarkerPreferences, fetchWearablePreferences, setMarkerPreference, setWearablePreference } from '../data/userPreferences.ts';
+import { MANDATORY_MARKER_KEYS, OPTIONAL_MARKER_KEYS, DEFAULT_HC_RECORD_TYPES } from '../../../../packages/domain/userPreferences.ts';
+import { theme } from '../../ui/theme';
+
+type PreferenceMap = Record<string, boolean>;
+const APP_INSTALL_ID = '00000000-0000-0000-0000-000000000001';
+
+type ToggleRowProps = {
+  label: string;
+  enabled: boolean;
+  onToggle: () => void;
+};
+
+function ToggleRow({ label, enabled, onToggle }: ToggleRowProps): React.JSX.Element {
+  return (
+    <Pressable onPress={onToggle} style={[styles.row, enabled ? styles.rowEnabled : styles.rowDisabled]}>
+      <Text style={styles.rowLabel}>{label}</Text>
+      <Text style={styles.rowValue}>{enabled ? 'Enabled' : 'Disabled'}</Text>
+    </Pressable>
+  );
+}
+
+export default function DataSourcesSettingsScreen(): React.JSX.Element {
+  const [markerPrefs, setMarkerPrefs] = useState<PreferenceMap>({});
+  const [wearablePrefs, setWearablePrefs] = useState<PreferenceMap>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load(): Promise<void> {
+      try {
+        await seedDefaultPreferencesIfAbsent(APP_INSTALL_ID);
+        const [markers, wearables] = await Promise.all([
+          fetchMarkerPreferences(APP_INSTALL_ID),
+          fetchWearablePreferences(APP_INSTALL_ID),
+        ]);
+
+        if (cancelled) return;
+        setMarkerPrefs(Object.fromEntries(markers.map((pref) => [pref.markerKey, pref.enabled])));
+        setWearablePrefs(Object.fromEntries(wearables.map((pref) => [pref.hcRecordType, pref.enabled])));
+      } catch (nextError) {
+        if (cancelled) return;
+        setError(nextError instanceof Error ? nextError.message : 'Failed to load preferences.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const toggleMarker = async (markerKey: string): Promise<void> => {
+    const previous = markerPrefs[markerKey] ?? true;
+    const next = !previous;
+    setMarkerPrefs((current) => ({ ...current, [markerKey]: next }));
+    try {
+      await setMarkerPreference(APP_INSTALL_ID, markerKey, next, (rollback) => {
+        setMarkerPrefs((current) => ({ ...current, [markerKey]: rollback }));
+      });
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : 'Failed to save marker preference.');
+    }
+  };
+
+  const toggleWearable = async (recordType: string): Promise<void> => {
+    const previous = wearablePrefs[recordType] ?? true;
+    const next = !previous;
+    setWearablePrefs((current) => ({ ...current, [recordType]: next }));
+    try {
+      await setWearablePreference(APP_INSTALL_ID, recordType, next, (rollback) => {
+        setWearablePrefs((current) => ({ ...current, [recordType]: rollback }));
+      });
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : 'Failed to save wearable preference.');
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container} style={styles.scrollView}>
+      <Text style={styles.eyebrow}>One L1fe</Text>
+      <Text style={styles.title}>Data Sources</Text>
+      <Text style={styles.subtitle}>Configure which markers and wearable inputs stay active for this install.</Text>
+
+      {loading ? (
+        <View style={styles.loadingBox}>
+          <ActivityIndicator color={theme.colors.primary} />
+        </View>
+      ) : null}
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Marker preferences</Text>
+        {[...MANDATORY_MARKER_KEYS, ...OPTIONAL_MARKER_KEYS].map((markerKey) => (
+          <ToggleRow
+            key={markerKey}
+            label={markerKey}
+            enabled={markerPrefs[markerKey] ?? true}
+            onToggle={() => {
+              void toggleMarker(markerKey);
+            }}
+          />
+        ))}
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Wearable record types</Text>
+        {DEFAULT_HC_RECORD_TYPES.map((recordType) => (
+          <ToggleRow
+            key={recordType}
+            label={recordType}
+            enabled={wearablePrefs[recordType] ?? true}
+            onToggle={() => {
+              void toggleWearable(recordType);
+            }}
+          />
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollView: {
+    flex: 1,
+    backgroundColor: theme.colors.bg,
+  },
+  container: {
+    padding: 20,
+    gap: 16,
+  },
+  eyebrow: {
+    color: theme.colors.primary,
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: theme.colors.text,
+    fontSize: 24,
+    fontWeight: '800',
+  },
+  subtitle: {
+    color: theme.colors.textMuted,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  loadingBox: {
+    alignItems: 'center',
+    backgroundColor: theme.colors.surface,
+    borderColor: theme.colors.border,
+    borderRadius: 16,
+    borderWidth: 1,
+    padding: 16,
+  },
+  error: {
+    color: theme.colors.danger,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  section: {
+    backgroundColor: theme.colors.surface,
+    borderColor: theme.colors.border,
+    borderRadius: 18,
+    borderWidth: 1,
+    gap: 10,
+    padding: 16,
+  },
+  sectionTitle: {
+    color: theme.colors.text,
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  row: {
+    borderRadius: 14,
+    borderWidth: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  rowEnabled: {
+    backgroundColor: theme.colors.surfaceSubtle,
+    borderColor: theme.colors.borderStrong,
+  },
+  rowDisabled: {
+    backgroundColor: '#fff8f7',
+    borderColor: '#f2c2bc',
+  },
+  rowLabel: {
+    color: theme.colors.text,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  rowValue: {
+    color: theme.colors.textMuted,
+    fontSize: 14,
+    fontWeight: '700',
+  },
+});

--- a/apps/mobile/ui/theme.ts
+++ b/apps/mobile/ui/theme.ts
@@ -1,0 +1,35 @@
+export const theme = {
+  colors: {
+    bg: '#f4f7fb',
+    surface: '#ffffff',
+    surfaceSubtle: '#eef3fb',
+    border: '#d9e2f2',
+    borderStrong: '#b9c8df',
+    primary: '#4263eb',
+    primarySoft: '#e9efff',
+    text: '#10203b',
+    textMuted: '#52607a',
+    textLabel: '#2c3b56',
+    danger: '#b42318',
+  },
+  radius: {
+    sm: 12,
+    pill: 999,
+  },
+  text: {
+    label: {
+      fontSize: 12,
+      fontWeight: '700' as const,
+      letterSpacing: 0.4,
+      textTransform: 'uppercase' as const,
+    },
+    sectionTitle: {
+      fontSize: 16,
+      fontWeight: '700' as const,
+    },
+    title: {
+      fontSize: 20,
+      fontWeight: '700' as const,
+    },
+  },
+};

--- a/packages/domain/minimumSlice.ts
+++ b/packages/domain/minimumSlice.ts
@@ -1,5 +1,7 @@
 import { CanonicalStatus, mapPriorityScore } from './biomarkers.ts';
+import { EvidenceAnchor, getRuleEvidenceLink } from './evidenceRegistry.ts';
 import { getRuleProvenance, ProductEvidenceClass, RuleOrigin } from './provenance.ts';
+import { downgradeEvidenceClass, PanelConfiguration, ScoreLockedResult } from './userPreferences.ts';
 import { evaluateByThreshold } from './thresholds.ts';
 import {
   BiomarkerKey,
@@ -81,6 +83,12 @@ export interface MinimumSliceEvaluation {
     name: 'Priority Score';
     rawValue: number;
     value: number;
+    evidenceClass: string;
+    reducedConfidence?: {
+      excludedOptionalKeys: string[];
+    };
+    anchors: EvidenceAnchor[];
+    anchorCount: number;
     includedMarkerCount: number;
     topDrivers: string[];
     boundedModifierNote?: string;
@@ -91,8 +99,46 @@ export interface MinimumSliceEvaluation {
   recommendations: Recommendation[];
 }
 
+export function collectRuleIdsForPanel(panel: MinimumSlicePanelInput): string[] {
+  const entriesByMarker = new Map<BiomarkerKey, MinimumSliceEntryInput>();
+  for (const entry of panel.entries) {
+    entriesByMarker.set(entry.marker, {
+      ...entry,
+      collectedAt: entry.collectedAt ?? panel.collectedAt,
+    });
+  }
+
+  const orderedMarkers: BiomarkerKey[] = [...REQUIRED_MINIMUM_SLICE_MARKERS, ...OPTIONAL_MINIMUM_SLICE_MARKERS];
+  const ruleIds = new Set<string>();
+
+  for (const marker of orderedMarkers) {
+    const input = entriesByMarker.get(marker) ?? { marker, collectedAt: panel.collectedAt };
+    const assessment = assessInterpretability(input, new Date(panel.collectedAt));
+    const biomarker = getBiomarkerOrThrow(marker);
+    const thresholdEvaluation =
+      assessment.state === InterpretabilityState.Interpretable && input.value != null && input.unit
+        ? evaluateByThreshold({ marker, value: input.value, unit: input.unit })
+        : null;
+
+    const fallbackRuleIds = thresholdEvaluation?.ruleIds?.length
+      ? thresholdEvaluation.ruleIds
+      : getFallbackRuleIds(marker, assessment, input);
+
+    for (const ruleId of fallbackRuleIds) {
+      ruleIds.add(ruleId);
+    }
+
+    const biomarkerRuleId = getRuleEvidenceLink(biomarker.key)?.ruleId;
+    if (biomarkerRuleId) {
+      ruleIds.add(biomarkerRuleId);
+    }
+  }
+
+  return Array.from(ruleIds);
+}
+
 const REQUIRED_MINIMUM_SLICE_MARKERS: BiomarkerKey[] = ['apob', 'hba1c', 'glucose', 'ldl'];
-const OPTIONAL_MINIMUM_SLICE_MARKERS: BiomarkerKey[] = ['lpa', 'crp', 'ferritin'];
+const OPTIONAL_MINIMUM_SLICE_MARKERS: BiomarkerKey[] = ['lpa', 'crp'];
 
 function dedupeRecommendations(recommendations: Recommendation[]): Recommendation[] {
   const seen = new Set<string>();
@@ -266,52 +312,6 @@ function buildInterpretationRecommendation(entry: EvaluatedEntry): Recommendatio
     };
   }
 
-  if (entry.marker === 'ferritin') {
-    // Low ferritin: directly actionable.
-    if (
-      entry.canonicalStatus === CanonicalStatus.High ||
-      entry.canonicalStatus === CanonicalStatus.Critical
-    ) {
-      return {
-        type: entry.canonicalStatus === CanonicalStatus.Critical ? 'clinician_clarification' : 'monitor',
-        verdict: 'Low ferritin — iron stores need attention',
-        text:
-          entry.canonicalStatus === CanonicalStatus.Critical
-            ? 'Critically low ferritin warrants clinician review before any supplementation.'
-            : 'Ferritin is below the adequate range. Revisit dietary iron intake and track trend over the next panel.',
-        evidenceSummary: `Ferritin is interpretable and currently maps to ${entry.canonicalStatus} (low iron stores).`,
-        confidence: 'medium',
-        scope: 'iron-status context only — not a diagnosis of iron-deficiency anaemia',
-        handoffRequired: entry.canonicalStatus === CanonicalStatus.Critical,
-        ruleId: 'CTX-001',
-        anchorSourceId: undefined,
-        ruleOrigin: undefined,
-        productEvidenceClass: undefined,
-      };
-    }
-
-    // Elevated ferritin: context gate — always Borderline until context is collected.
-    if (entry.canonicalStatus === CanonicalStatus.Borderline) {
-      return {
-        type: 'collect_more_data',
-        verdict: 'Elevated ferritin — context needed before escalation',
-        text:
-          'Ferritin is above the good range but context (inflammation markers, liver function, iron-transport panel) is not yet captured. Collect context before treating this as a severity signal.',
-        evidenceSummary:
-          'Elevated ferritin without inflammation / liver / iron-transport context. CTX-001 holds interpretation at Borderline.',
-        confidence: 'medium',
-        scope: 'iron-storage context only — not a severity conclusion without supporting data',
-        handoffRequired: false,
-        ruleId: 'CTX-001',
-        anchorSourceId: undefined,
-        ruleOrigin: undefined,
-        productEvidenceClass: undefined,
-      };
-    }
-
-    return null;
-  }
-
   return null;
 }
 
@@ -430,9 +430,74 @@ function buildEntry(
   };
 }
 
-export function evaluateMinimumSlice(
+export interface PriorityScoreResult {
+  rawValue: number;
+  value: number;
+  evidenceClass: string;
+  anchors: EvidenceAnchor[];
+  anchorCount: number;
+  includedMarkerCount: number;
+  topDrivers: string[];
+  boundedModifierNote?: string;
+  excludedMarkerNote?: string;
+  coverageSummary: string;
+  freshnessNote: string;
+  name: 'Priority Score';
+}
+
+function aggregateTotalPriorityScoreWithEvidence(
+  rawValue: number,
+  anchors: EvidenceAnchor[] | undefined,
+  topDrivers: string[],
+  includedMarkerCount: number,
+  coverageSummary: string,
+  freshnessNote: string,
+  hasBoundedModifier: boolean,
+  hasExcludedSignals: boolean,
+): PriorityScoreResult {
+  const resolvedAnchors = anchors ?? [];
+  if (anchors !== undefined && resolvedAnchors.length === 0) {
+    throw new Error('UnanchoredScoreError: evidence anchors are required.');
+  }
+
+  const evidenceClass = resolvedAnchors.length === 0
+    ? 'unanchored'
+    : resolvedAnchors.some((anchor) => anchor.productEvidenceClass === 'P0')
+      ? 'strong'
+      : resolvedAnchors.some((anchor) => anchor.productEvidenceClass === 'P1')
+        ? 'moderate'
+        : 'limited';
+
+  const priorityScore: PriorityScoreResult = {
+    name: 'Priority Score',
+    rawValue,
+    value: evidenceClass === 'unanchored' ? 0 : mapPriorityScore(rawValue),
+    evidenceClass,
+    anchors: resolvedAnchors,
+    anchorCount: resolvedAnchors.length,
+    includedMarkerCount,
+    topDrivers,
+    coverageSummary,
+    freshnessNote,
+  };
+
+  if (hasBoundedModifier) {
+    priorityScore.boundedModifierNote =
+      'Bounded modifiers are visible but do not behave like major recurring core score drivers.';
+  }
+
+  if (hasExcludedSignals) {
+    priorityScore.excludedMarkerNote =
+      'Some interpretable signals are intentionally excluded from the hard core score.';
+  }
+
+  return priorityScore;
+}
+
+function evaluateMinimumSliceInternal(
   panel: MinimumSlicePanelInput,
   now: Date = new Date(),
+  evidenceAnchors?: EvidenceAnchor[],
 ): MinimumSliceEvaluation {
   const entriesByMarker = new Map<BiomarkerKey, MinimumSliceEntryInput>();
 
@@ -492,27 +557,18 @@ export function evaluateMinimumSlice(
   );
   const hasExcludedSignals = evaluatedEntries.some((entry) => !entry.scoreEligible && entry.interpretableState === InterpretabilityState.Interpretable);
 
-  const priorityScore: MinimumSliceEvaluation['priorityScore'] = {
-    name: 'Priority Score',
-    rawValue: rawScore,
-    value: mapPriorityScore(rawScore),
-    includedMarkerCount: includedEntries.length,
+  const priorityScore = aggregateTotalPriorityScoreWithEvidence(
+    rawScore,
+    evidenceAnchors,
     topDrivers,
-    coverageSummary: coverageNotes.join(' '),
-    freshnessNote: evaluatedEntries.some((entry) => entry.freshness === FreshnessState.Stale)
+    includedEntries.length,
+    coverageNotes.join(' '),
+    evaluatedEntries.some((entry) => entry.freshness === FreshnessState.Stale)
       ? 'At least one minimum-slice marker is stale and blocked from active scoring.'
       : 'Freshness is acceptable for the currently included score inputs.',
-  };
-
-  if (hasBoundedModifier) {
-    priorityScore.boundedModifierNote =
-      'Bounded modifiers are visible but do not behave like major recurring core score drivers.';
-  }
-
-  if (hasExcludedSignals) {
-    priorityScore.excludedMarkerNote =
-      'Some interpretable signals are intentionally excluded from the hard core score.';
-  }
+    hasBoundedModifier,
+    hasExcludedSignals,
+  );
 
   return {
     profileId: panel.profileId,
@@ -527,4 +583,60 @@ export function evaluateMinimumSlice(
     priorityScore,
     recommendations,
   };
+}
+
+export function evaluateMinimumSlice(
+  panel: MinimumSlicePanelInput,
+  now?: Date,
+  evidenceAnchors?: EvidenceAnchor[],
+): MinimumSliceEvaluation;
+export function evaluateMinimumSlice(
+  panel: MinimumSlicePanelInput,
+  panelConfiguration: PanelConfiguration,
+  now?: Date,
+  evidenceAnchors?: EvidenceAnchor[],
+): MinimumSliceEvaluation | ScoreLockedResult;
+export function evaluateMinimumSlice(
+  panel: MinimumSlicePanelInput,
+  panelConfigurationOrNow?: PanelConfiguration | Date,
+  nowOrEvidenceAnchors?: Date | EvidenceAnchor[],
+  evidenceAnchors?: EvidenceAnchor[],
+): MinimumSliceEvaluation | ScoreLockedResult {
+  const panelConfiguration = panelConfigurationOrNow instanceof Date || panelConfigurationOrNow === undefined
+    ? undefined
+    : panelConfigurationOrNow;
+  const now = panelConfigurationOrNow instanceof Date
+    ? panelConfigurationOrNow
+    : nowOrEvidenceAnchors instanceof Date
+      ? nowOrEvidenceAnchors
+      : new Date();
+  const resolvedEvidenceAnchors = Array.isArray(nowOrEvidenceAnchors)
+    ? nowOrEvidenceAnchors
+    : evidenceAnchors;
+
+  if (panelConfiguration?.excludedMandatoryKeys.size) {
+    return {
+      kind: 'score_locked',
+      reason: 'MANDATORY_MARKER_EXCLUDED',
+      missingKeys: Array.from(panelConfiguration.excludedMandatoryKeys) as ScoreLockedResult['missingKeys'],
+      userAction: 'RE_ENABLE_IN_SETTINGS',
+    };
+  }
+
+  const evaluation = evaluateMinimumSliceInternal(panel, now, resolvedEvidenceAnchors);
+
+  if (panelConfiguration?.excludedOptionalKeys.size) {
+    return {
+      ...evaluation,
+      priorityScore: {
+        ...evaluation.priorityScore,
+        evidenceClass: downgradeEvidenceClass(evaluation.priorityScore.evidenceClass as ProductEvidenceClass),
+        reducedConfidence: {
+          excludedOptionalKeys: Array.from(panelConfiguration.excludedOptionalKeys),
+        },
+      },
+    };
+  }
+
+  return evaluation;
 }

--- a/packages/domain/userPreferences.ts
+++ b/packages/domain/userPreferences.ts
@@ -1,0 +1,83 @@
+import { ProductEvidenceClass } from './provenance.ts';
+
+export const MANDATORY_MARKER_KEYS = ['apob', 'ldl', 'hba1c', 'glucose'] as const;
+export type MandatoryMarkerKey = typeof MANDATORY_MARKER_KEYS[number];
+
+export const OPTIONAL_MARKER_KEYS = [
+  'lpa',
+  'triglycerides',
+  'crp',
+  'vitamin_d',
+  'ferritin',
+  'b12',
+  'magnesium',
+  'dao',
+] as const;
+export type OptionalMarkerKey = typeof OPTIONAL_MARKER_KEYS[number];
+
+export const DEFAULT_HC_RECORD_TYPES = [
+  'Steps',
+  'HeartRate',
+  'RestingHeartRate',
+  'HeartRateVariabilityRms',
+  'SleepSession',
+  'ActiveCaloriesBurned',
+  'TotalCaloriesBurned',
+  'ExerciseSession',
+] as const;
+
+export type MarkerPreference = {
+  markerKey: string;
+  enabled: boolean;
+};
+
+export type WearablePreference = {
+  hcRecordType: string;
+  enabled: boolean;
+};
+
+export type PanelConfiguration = {
+  enabledMarkerKeys: Set<string>;
+  excludedMandatoryKeys: Set<string>;
+  excludedOptionalKeys: Set<string>;
+};
+
+export type ScoreLockedResult = {
+  kind: 'score_locked';
+  reason: 'MANDATORY_MARKER_EXCLUDED';
+  missingKeys: MandatoryMarkerKey[];
+  userAction: 'RE_ENABLE_IN_SETTINGS';
+};
+
+const EVIDENCE_CLASS_ORDER: ProductEvidenceClass[] = ['strong', 'moderate', 'limited', 'insufficient'];
+
+export function downgradeEvidenceClass(current: ProductEvidenceClass): ProductEvidenceClass {
+  const index = EVIDENCE_CLASS_ORDER.indexOf(current);
+  if (index === -1 || index === EVIDENCE_CLASS_ORDER.length - 1) {
+    return current;
+  }
+
+  return EVIDENCE_CLASS_ORDER[index + 1];
+}
+
+export function resolvePanelConfiguration(preferences: MarkerPreference[]): PanelConfiguration {
+  const prefMap = new Map(preferences.map((pref) => [pref.markerKey, pref.enabled]));
+
+  const excludedMandatoryKeys = new Set<string>(
+    MANDATORY_MARKER_KEYS.filter((key) => prefMap.get(key) === false),
+  );
+  const excludedOptionalKeys = new Set<string>(
+    OPTIONAL_MARKER_KEYS.filter((key) => prefMap.get(key) === false),
+  );
+
+  const enabledMarkerKeys = new Set<string>([
+    ...MANDATORY_MARKER_KEYS.filter((key) => !excludedMandatoryKeys.has(key)),
+    ...OPTIONAL_MARKER_KEYS.filter((key) => !excludedOptionalKeys.has(key)),
+  ]);
+
+  return {
+    enabledMarkerKeys,
+    excludedMandatoryKeys,
+    excludedOptionalKeys,
+  };
+}

--- a/supabase/migrations/20260421190000_phase0_user_preferences.sql
+++ b/supabase/migrations/20260421190000_phase0_user_preferences.sql
@@ -1,0 +1,44 @@
+-- ============================================================================
+-- phase0_user_preferences
+-- User-configurable panel and wearable source preference storage.
+-- ============================================================================
+
+-- user_marker_preferences
+CREATE TABLE user_marker_preferences (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  app_install_id uuid NOT NULL,
+  marker_key text NOT NULL,
+  enabled boolean NOT NULL DEFAULT true,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT uq_marker_pref UNIQUE (app_install_id, marker_key)
+);
+
+ALTER TABLE user_marker_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "owner_only_marker_prefs"
+  ON user_marker_preferences
+  FOR ALL
+  USING (app_install_id = (current_setting('app.install_id', true))::uuid)
+  WITH CHECK (app_install_id = (current_setting('app.install_id', true))::uuid);
+
+-- user_wearable_preferences
+CREATE TABLE user_wearable_preferences (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  app_install_id uuid NOT NULL,
+  hc_record_type text NOT NULL,
+  enabled boolean NOT NULL DEFAULT true,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT uq_wearable_pref UNIQUE (app_install_id, hc_record_type)
+);
+
+ALTER TABLE user_wearable_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "owner_only_wearable_prefs"
+  ON user_wearable_preferences
+  FOR ALL
+  USING (app_install_id = (current_setting('app.install_id', true))::uuid)
+  WITH CHECK (app_install_id = (current_setting('app.install_id', true))::uuid);
+
+-- down
+DROP TABLE IF EXISTS user_wearable_preferences;
+DROP TABLE IF EXISTS user_marker_preferences;


### PR DESCRIPTION
## Summary
- Add pure domain panel preference resolution and a score_locked wrapper path.
- Add the user preference migration and mobile data access layer for marker and wearable settings.
- Add a new data-sources settings screen scaffold and shared theme token file.

## Notes
- The branch is intentionally scoped to the A8 slice only.
- Unrelated local work remains uncommitted on the worktree and is not included here.

## Verification
- `git diff --check --cached`
- Full mobile typecheck was not run in this slice.
