### PR TITLE
docs(audit): add repo audit task proposals

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -36,6 +36,8 @@ Remaining gaps: physical Garmin/Health Connect testing, end-to-end Supabase inge
 
 ## Completed this session (2026-04-23)
 
+- ✅ Durchsicht der Codebasis durchgeführt und konkrete Aufgabenvorschläge für Tippfehler-, Bug-, Doku-/Kommentar- und Testverbesserung dokumentiert (`docs/planning/repo-audit-task-vorschlaege-2026-04-23.md`)
+
 - ✅ Reviewed `docs/ops/memory-system-v2.md` and executed the closeout checklist steps that were possible in the current worktree
 - ✅ Reassessed wearable sync seam; current app still uses a placeholder request payload and needs contract hardening before rollout
 - ✅ Expanded the wearable permission surface and aligned mobile docs/assertions to the canonical sync contract

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,6 +15,7 @@ For startup: read after CHECKPOINT.md. Never load memory/ or docs/archive/ at st
 
 ## 2026-04-23 — Codex (cleanup + closeout)
 
+- Durchsicht der Codebasis mit vier konkreten Follow-up-Tasks (Tippfehler, Programmierfehler, Doku-Unstimmigkeit, Testverbesserung) in `docs/planning/repo-audit-task-vorschlaege-2026-04-23.md` dokumentiert
 - Read and applied the `docs/ops/memory-system-v2.md` closeout checklist as far as the worktree allowed
 - Revalidated wearable sync status: current `WearableSyncScreen` still uses a placeholder request payload and needs contract hardening
 - Expanded the Health Connect permission surface to include `RestingHeartRate` and `HeartRateVariabilityRmssd`

--- a/docs/planning/repo-audit-task-vorschlaege-2026-04-23.md
+++ b/docs/planning/repo-audit-task-vorschlaege-2026-04-23.md
@@ -1,0 +1,60 @@
+# Repo-Audit: Aufgabenvorschläge (2026-04-23)
+
+## 1) Aufgabe: Tippfehler korrigieren (Dateinamen / Datenkatalog)
+
+**Problem:** Im Notion-Export sind Dateinamen mit `Tabel` statt `Table` abgelegt.
+
+**Beobachtung:**
+- `data/notion-export/05_1_Biomarker Panel Tabel.csv`
+- `data/notion-export/05_2_Biomarker Panel Tabel.csv`
+
+**Vorschlag (Task):**
+- Beide Dateien konsistent auf `...Table.csv` umbenennen.
+- Alle Referenzen in Doku/Skripten prüfen und anpassen.
+- Optional: kurzer Hinweis im Changelog/Audit-Log, damit keine Broken Links entstehen.
+
+---
+
+## 2) Aufgabe: Programmierfehler korrigieren (Ferritin-Logik)
+
+**Problem:** In `evaluateFerritin(...)` wird ein *niedriger* Ferritin-Wert aktuell als `CanonicalStatus.High` zurückgegeben.
+
+**Evidenz:**
+- Für `value < lowThreshold` wird `canonicalStatus: CanonicalStatus.High` gesetzt.
+
+**Vorschlag (Task):**
+- Rückgabestatus auf einen semantisch korrekten Zustand ändern (z. B. `Low` oder projektweit definierte äquivalente Stufe).
+- Prüfen, ob nachgelagerte Scoring- und Recommendation-Logik von dieser Korrektur betroffen ist.
+- Regressionstest ergänzen (siehe Task 4), damit diese Klassifikationsrichtung abgesichert ist.
+
+---
+
+## 3) Aufgabe: Kommentar-/Doku-Unstimmigkeit beheben (Health Connect Mapping)
+
+**Problem:** Architektur-Doku und TypeScript-Mapping sind für `active_minutes` auf Android Health Connect nicht konsistent.
+
+**Evidenz:**
+- Architektur-Doku nennt als Erst-Mapping u. a. `workout_session -> ExerciseSessionRecord`, führt aber `active_minutes` in der konkreten Android-Liste nicht sauber auf.
+- `src/lib/wearables/syncContract.ts` mappt `active_minutes` auf `ActiveCaloriesBurnedRecord` (mit Proxy-Kommentar).
+
+**Vorschlag (Task):**
+- Entscheidung dokumentieren: Ist `active_minutes` im V1 via `ActiveCaloriesBurnedRecord` wirklich gewollt oder soll es auf ein anderes Record-Modell.
+- Danach Doku (`docs/architecture/wearable-metric-keys-v1.md`) und Code (`syncContract.ts`) synchronisieren.
+- In der Doku explizit die Semantik-Risiken (Proxy-Mapping, Plattformunterschiede) festhalten.
+
+---
+
+## 4) Aufgabe: Test verbessern (Threshold-/Ferritin-Abdeckung)
+
+**Problem:** Es gibt derzeit keine gezielte Assertion-Suite, die die Ferritin-Branch-Logik direkt absichert; dadurch konnte der Status-Fehler unentdeckt bleiben.
+
+**Evidenz:**
+- Der Domain-Testlauf ist grün, aber eine dedizierte Assertion für `evaluateFerritin`-Grenzfälle fehlt.
+
+**Vorschlag (Task):**
+- Neue Assertions für `evaluateFerritin` ergänzen:
+  - unterhalb `lowCriticalThreshold`
+  - zwischen `lowCriticalThreshold` und `lowThreshold`
+  - Kontextfall für erhöhte Werte (`hasInflammationContext` true/false)
+  - unterschiedliche Grenzwerte für `sex: female/male`
+- Tests in den bestehenden `runMinimumSliceAssertions`-Pfad integrieren.


### PR DESCRIPTION
### Motivation
- Kurzprüfung der Codebasis zur Identifikation kleiner, umsetzbarer Korrektur- und Verbesserungsaufgaben und zur Hinterlegung dieser Vorschläge als planbares Backlog-Eintrag.

### Description
- Neue Planungsdatei `docs/planning/repo-audit-task-vorschlaege-2026-04-23.md` hinzugefügt, die vier konkrete Aufgaben beschreibt: Tippfehler-Korrektur, Ferritin-Logik-Fix, Health-Connect-Mapping-Konsistenz und Testverbesserung für Ferritin-Grenzfälle.
- `CHECKPOINT.md` aktualisiert, um die durchgeführte Codebasis-Durchsicht und das Audit-Dokument als erledigte Session-Aktion zu vermerken.
- `CONTEXT.md` aktualisiert, um die rolling-session-Notiz mit Verweis auf das neue Audit-Dokument zu ergänzen.
- Es wurden keine produktiven Codepfade geändert; die Änderungen sind rein dokumentarisch/planerisch.

### Testing
- `npm run typecheck` (`tsc --noEmit`) wurde ausgeführt und erfolgreich beendet.
- `npm run test:domain` (build + domain assertions) wurde ausgeführt und meldete: "All domain assertions passed."

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ea3240b07c832ba382dfc78906d2b6)