### PR TITLE
meta: align agent startup docs with memory-system-v2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 status: current
 canonical_for: agent working rules
 owner: repo
-last_verified: 2026-04-23
+last_verified: 2026-04-24
 supersedes: []
 superseded_by: null
 scope: repo
@@ -11,6 +11,19 @@ scope: repo
 # AGENTS.md
 
 Agent operating rules for this repository.
+
+## Default startup (all agents)
+
+1. Load and read `CHECKPOINT.md` — current state, active seam, next steps, blockers.
+2. Load and read `CONTEXT.md` — rolling summary of the last 2–3 sessions.
+3. Load `MEMORY.md` **only if needed** for durable boundaries, architecture invariants, or repo rules.
+4. Load a specific `docs/...` file **only if directly relevant** to the task.
+5. **Never load** `memory/` or `docs/archive/` at startup.
+
+Full session rules (startup order, closeout checklist, promotion rules): `docs/ops/memory-system-v2.md`  
+OpenClaw-specific differences: `docs/ops/openclaw.md`
+
+## Working rules
 
 - Agents are allowed to work across the full repository.
 - Agents may read, create, edit, move, rename, and delete files.
@@ -22,11 +35,13 @@ Agent operating rules for this repository.
 - Be explicit about uncertainty, risks, and assumptions.
 
 ## Output standards
+
 - Commit messages: `type(scope): description` — conventional commits
 - Never commit: raw health data, secrets, local scratch files
-- After any session: update CHECKPOINT.md + CONTEXT.md before closing
+- After any meaningful session: run the end-of-session checklist in `docs/ops/memory-system-v2.md`. At minimum, update `CHECKPOINT.md` + `CONTEXT.md` before closing.
 - Issues/PRs: close duplicates immediately, do not let them accumulate
 
 ## Supabase work
+
 - For any larger Supabase task or change (schema, migrations, RLS, Realtime, Edge Functions, Auth, Storage, project settings), follow `docs/ops/supabase-agent-workflow.md`.
 - If the task touches Supabase Realtime, include `docs/prompts/supabase-realtime-ai-assistant-guide.md` in the working context before proposing or implementing changes.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 status: current
 canonical_for: project entry point
 owner: repo
-last_verified: 2026-04-22
+last_verified: 2026-04-24
 supersedes: []
 superseded_by: null
 scope: repo
@@ -20,13 +20,17 @@ Current execution status lives in [CHECKPOINT.md](./CHECKPOINT.md).
 
 ## Start here
 
-This file is for broad human orientation.
-For meaningful repo work, use `CHECKPOINT.md` as the primary startup file.
+This file is for broad human orientation only — not required for agent startup.
 
-1. Start with [CHECKPOINT.md](./CHECKPOINT.md)
-2. Read [README.md](./README.md) only when you need broad repo orientation
-3. Read [MEMORY.md](./MEMORY.md) only for durable truth
-4. Read [docs/README.md](./docs/README.md) only when you need deeper docs navigation
+For any repo work, use this startup order:
+
+1. [CHECKPOINT.md](./CHECKPOINT.md) — current state, active seam, next steps, blockers
+2. [CONTEXT.md](./CONTEXT.md) — rolling summary of the last 2–3 sessions
+3. [MEMORY.md](./MEMORY.md) — only if you need durable boundaries or architecture rules
+4. [docs/README.md](./docs/README.md) — only when you need deeper docs navigation
+
+Full session and memory rules: [docs/ops/memory-system-v2.md](./docs/ops/memory-system-v2.md)  
+Agent working rules: [AGENTS.md](./AGENTS.md)
 
 ## Repo structure
 
@@ -45,11 +49,11 @@ One-L1fe/
 │   ├── planning/              # Backlog and next-step execution docs
 │   ├── research/              # Evidence gathering and unresolved questions
 │   ├── compliance/            # Intended-use and boundary-sensitive material
-│   ├── ops/                   # OpenClaw and repo operating guidance
+│   ├── ops/                   # Session workflow, memory system, and operating guidance
 │   ├── notion/                # Notion-specific design and migration notes
 │   ├── roadmap/               # Phased progress and checkpoints
 │   └── archive/               # Superseded docs kept for context
-├── memory/                    # Short-term working memory and daily notes
+├── memory/                    # Session scratch — daily notes only, never startup context
 ├── .github/                   # Repo hygiene, templates, CODEOWNERS, CI
 ├── MEMORY.md
 ├── CONTEXT.md
@@ -61,12 +65,13 @@ One-L1fe/
 
 Use each file layer for one job:
 
-- [README.md](./README.md) = broad project entry point and orientation
+- [README.md](./README.md) = broad project entry point and orientation (human, not agent startup)
 - [CHECKPOINT.md](./CHECKPOINT.md) = current state and next step for active work
-- [MEMORY.md](./MEMORY.md) = durable assumptions and long-lived decisions
 - [CONTEXT.md](./CONTEXT.md) = rolling 2–3 session summary for fast agent startup
-- [`memory/`](./memory/) = short-term working notes and daily notes (scratch only)
-- [`docs/ops/`](./docs/ops/) = session workflow and operating guidance
+- [MEMORY.md](./MEMORY.md) = durable assumptions and long-lived decisions (on demand)
+- [`memory/`](./memory/) = session scratch — daily notes only, archived at closeout
+- [`docs/ops/memory-system-v2.md`](./docs/ops/memory-system-v2.md) = canonical session and memory rules
+- [`docs/ops/`](./docs/ops/) = operating guidance (session workflow, OpenClaw)
 - [`docs/architecture/`](./docs/architecture/) = technical decisions that should stay true over time
 - [`docs/planning/`](./docs/planning/) = backlog and next work
 - [`docs/research/`](./docs/research/) = evidence gathering and unresolved questions
@@ -104,16 +109,22 @@ This repo uses a lightweight solo-founder workflow:
 - let CI validate typecheck and domain tests
 - update the real source-of-truth file when behavior or rules change
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for the operating rules.
+Agent working rules: [AGENTS.md](./AGENTS.md)  
+Contributing guidelines: [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## Core project docs
 
 ### Orientation
 - [CHECKPOINT.md](./CHECKPOINT.md)
-- [MEMORY.md](./MEMORY.md)
 - [CONTEXT.md](./CONTEXT.md)
+- [MEMORY.md](./MEMORY.md)
 - [AGENTS.md](./AGENTS.md)
 - [docs/README.md](./docs/README.md)
+
+### Session & memory ops
+- [docs/ops/memory-system-v2.md](./docs/ops/memory-system-v2.md)
+- [docs/ops/session-workflow.md](./docs/ops/session-workflow.md)
+- [docs/ops/openclaw.md](./docs/ops/openclaw.md)
 
 ### Architecture
 - [docs/architecture/overview.md](./docs/architecture/overview.md)
@@ -146,9 +157,6 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the operating rules.
 - [docs/research/v1-targeted-research-reconciliation-2026-04-12.md](./docs/research/v1-targeted-research-reconciliation-2026-04-12.md)
 - [docs/compliance/intended-use.md](./docs/compliance/intended-use.md)
 - [docs/compliance/data-handling-and-redaction.md](./docs/compliance/data-handling-and-redaction.md)
-- [docs/ops/openclaw.md](./docs/ops/openclaw.md)
-- [docs/ops/session-workflow.md](./docs/ops/session-workflow.md)
-- [docs/ops/memory-system-v2.md](./docs/ops/memory-system-v2.md)
 
 ## Working constraints
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Current execution status lives in [CHECKPOINT.md](./CHECKPOINT.md).
 
 This file is for broad human orientation only — not required for agent startup.
 
-For any repo work, use this startup order:
+For **agentic repo work**, use this startup order:
 
 1. [CHECKPOINT.md](./CHECKPOINT.md) — current state, active seam, next steps, blockers
 2. [CONTEXT.md](./CONTEXT.md) — rolling summary of the last 2–3 sessions

--- a/docs/ops/openclaw.md
+++ b/docs/ops/openclaw.md
@@ -2,13 +2,16 @@
 status: current
 canonical_for: OpenClaw repo operations
 owner: repo
-last_verified: 2026-04-18
+last_verified: 2026-04-24
 supersedes: []
 superseded_by: null
 scope: ops
+note: OpenClaw-specific addendum only. General session and memory rules are in docs/ops/memory-system-v2.md and AGENTS.md.
 ---
 
 # OpenClaw operations guide
+
+> Addendum for OpenClaw-specific behaviour only. Default startup order, memory model, and session rules are defined in [`AGENTS.md`](../../AGENTS.md) and [`docs/ops/memory-system-v2.md`](./memory-system-v2.md).
 
 ## Verdict
 
@@ -16,40 +19,38 @@ Use OpenClaw as a thin layer over clean repo truth. Do not rely on OpenClaw memo
 
 ## Startup order
 
+Follow the default startup defined in `AGENTS.md`:
 1. `CHECKPOINT.md`
-2. `README.md` — only when broad repo orientation is needed
-3. Only the most relevant deeper file for the task
+2. `CONTEXT.md`
+3. `MEMORY.md` — only if the task requires durable rules or architecture context
+4. One specific `docs/...` file — only if directly relevant
 
-- `MEMORY.md` only for durable truth or old decisions
-- Do not read broad parts of `docs/` by default
-- Use the read-on-demand map in `CHECKPOINT.md`
+Do **not** use `memory/YYYY-MM-DD.md` as startup context or for session continuity.
 
 ## Truth layers
 
 | Layer | File | Use for |
 |---|---|---|
-| Current execution truth | `CHECKPOINT.md` | Current state, active seam, next step, blockers, startup map |
+| Current execution truth | `CHECKPOINT.md` | Current state, active seam, next step, blockers |
+| Fast session context | `CONTEXT.md` | Rolling 2–3 session summary for quick startup |
 | Durable truth | `MEMORY.md` | Stable assumptions, durable architecture + repo rules |
-| Short-term working memory | `memory/YYYY-MM-DD.md` | Daily notes, temporary findings, handoff context |
+| Session scratch | `memory/YYYY-MM-DD.md` | Temporary findings — archive at closeout, never load at startup |
 | Deep reference | `docs/` | Architecture, planning, compliance, research — on demand only |
 
 ## Promotion rules
 
-Promote into `CHECKPOINT.md` when it becomes:
-- the real current state, active seam, next best step, current blocker, or startup-critical guardrail
+Promote into `CHECKPOINT.md` when it becomes the real current state, active seam, next best step, current blocker, or startup-critical guardrail.
 
-Promote into `MEMORY.md` when it becomes:
-- a durable product boundary, architecture decision, or repo operations rule
+Promote into `MEMORY.md` when it becomes a durable product boundary, architecture decision, or repo operations rule.
 
-Keep in `memory/YYYY-MM-DD.md` when it is:
-- recent, provisional, still being validated, or useful near-term but not yet durable
+Keep in `memory/YYYY-MM-DD.md` when it is recent, provisional, or useful near-term but not yet durable.
 
 ## OpenClaw feature posture
 
 **Good fit now:**
-- Startup on `CHECKPOINT.md`
+- Startup on `CHECKPOINT.md` + `CONTEXT.md`
 - Durable recall against `MEMORY.md`
-- Session continuity via daily notes in `memory/`
+- Session closeout via daily notes (scratch only, then archive)
 
 **Good fit later (after source cleanup):**
 - Richer compiled memory over canonical docs
@@ -66,10 +67,6 @@ Keep in `memory/YYYY-MM-DD.md` when it is:
 - **Founder/operator chat:** persistent sessions appropriate; still write important outcomes into repo files
 - **One-shot tasks / narrow workers:** minimal context; do not treat as durable memory surface
 - **Multiple user conversations:** keep sessions isolated when conversations should not share working memory
-
-## Heartbeat guidance
-
-Keep heartbeat behavior minimal. Repo files are the durable layer — not status chatter.
 
 ## Safety and privacy
 

--- a/docs/ops/session-workflow.md
+++ b/docs/ops/session-workflow.md
@@ -2,40 +2,50 @@
 status: current
 canonical_for: human-friendly session workflow
 owner: repo
-last_verified: 2026-04-18
+last_verified: 2026-04-24
 supersedes: []
 superseded_by: null
 scope: ops
+note: This file is a human-readable summary. Full rules and checklists live in docs/ops/memory-system-v2.md.
 ---
 
 # Session workflow
+
+> Human-friendly summary only. Authoritative session rules, startup order, and closeout checklist are in [`docs/ops/memory-system-v2.md`](./memory-system-v2.md).
 
 ## Verdict
 
 Before a reset or new chat, save the important current state into the repo truth layers. Do not rely on chat transcript alone.
 
-## Memory model
+## Memory model (v2)
 
-| File | Stores |
+| File | Role |
 |---|---|
-| `CHECKPOINT.md` | Current truth, active seam, next step, blockers |
-| `MEMORY.md` | What should stay true long-term: boundaries, architecture, repo rules |
-| `memory/YYYY-MM-DD.md` | Temporary findings, handoff notes, in-progress thoughts |
-
-## Before resetting a session
-
-1. What changed that future-me must not lose?
-2. Put current project truth into `CHECKPOINT.md`
-3. Put durable decisions into `MEMORY.md`
-4. Put short-lived notes into `memory/YYYY-MM-DD.md`
-5. If files changed, save them before resetting
+| `CHECKPOINT.md` | Current truth: active seam, next step, blockers — load every session |
+| `CONTEXT.md` | Rolling 2–3 session summary — load every session |
+| `MEMORY.md` | Durable boundaries, architecture, repo rules — load on demand only |
+| `memory/YYYY-MM-DD.md` | Session scratch — never load at startup; archive at closeout |
 
 ## Before starting a new chat
 
-Examples:
-- "Run session startup for One L1fe, then continue from CHECKPOINT.md."
-- "Run startup, read CHECKPOINT.md, and work on the current next step."
-- "Run startup, then use memory/2026-04-13.md only as short-term context, not as durable truth."
+1. Load `CHECKPOINT.md`.
+2. Load `CONTEXT.md`.
+3. Load `MEMORY.md` only if the task requires durable rules or architecture context.
+4. Do **not** load `memory/YYYY-MM-DD.md` at startup — it is scratch, not context.
+
+Example prompts:
+- "Run session startup for One L1fe — read CHECKPOINT.md and CONTEXT.md, then continue."
+- "Run startup, read CHECKPOINT.md + CONTEXT.md, then work on the current next step."
+
+## Before resetting or closing a session
+
+1. What changed that future-me must not lose?
+2. Update `CHECKPOINT.md` with current state, seam, next steps, blockers.
+3. Prepend a compact entry to `CONTEXT.md` (date + max 5 bullets; drop oldest if >3 entries).
+4. Promote durable decisions into `MEMORY.md` if needed.
+5. Write session scratch to `memory/YYYY-MM-DD.md`, then archive it to `docs/archive/memory/`.
+
+Full closeout checklist: `docs/ops/memory-system-v2.md`
 
 ## When to update which file
 
@@ -43,29 +53,20 @@ Examples:
 - Active seam changed
 - Next best step changed
 - Blocker appeared or was removed
-- Repo state moved in a way the next session must know immediately
+
+**Update `CONTEXT.md` when:**
+- Closing or resetting a session (one compact entry per session)
 
 **Update `MEMORY.md` when:**
 - A durable rule, boundary, or long-lived architecture decision became settled
 
 **Update `memory/YYYY-MM-DD.md` when:**
-- Something is useful soon but not yet durable
-- Handoff note or session closeout snapshot needed
+- Something is useful now but not yet durable (scratch only)
 
 ## What not to do
 
+- Do not load `memory/YYYY-MM-DD.md` as startup context
 - Do not put everything into `CHECKPOINT.md`
-- Do not turn `MEMORY.md` into a diary
+- Do not turn `MEMORY.md` into a diary or implementation inventory
 - Do not assume the next session will infer truth from old chat messages
 - Do not store raw personal health data in any of these files
-
-## Recommended closeout habit
-
-At the end of meaningful work, note:
-- Current seam
-- Next best step
-- Blockers
-- Any durable decision
-- Any short-term notes worth keeping
-
-If written into the right file, resets and new chats become safe.


### PR DESCRIPTION
## What this PR does

Block 1 of the repo cleanup plan: aligns the four agent-facing entry point files with `docs/ops/memory-system-v2.md` as the single canonical session/memory model.

## Files changed

### `AGENTS.md`
- Added **Default startup block** at the top: `CHECKPOINT.md` → `CONTEXT.md` → `MEMORY.md` on demand → one `docs/` file on demand → never `memory/` or `docs/archive/` at startup.
- Added explicit pointer to `memory-system-v2.md` for full rules and to `openclaw.md` for OpenClaw-specific differences.
- Updated end-of-session rule to reference the `memory-system-v2` closeout checklist.

### `docs/ops/session-workflow.md`
- Added note at top: this file is a human-readable summary; authoritative rules are in `memory-system-v2.md`.
- Replaced old 3-layer memory table (`CHECKPOINT / MEMORY / memory/YYYY-MM-DD`) with the v2 4-layer model (adds `CONTEXT.md`).
- Updated "Before starting a new chat" to use `CHECKPOINT.md` + `CONTEXT.md` as default startup; removed example that loaded `memory/YYYY-MM-DD.md` as startup context.
- Updated closeout steps to include `CONTEXT.md` entry.

### `docs/ops/openclaw.md`
- Added note at top: addendum only; general rules delegate to `AGENTS.md` + `memory-system-v2.md`.
- Replaced standalone startup section with pointer to `AGENTS.md` default startup.
- Added `CONTEXT.md` as explicit Fast-Session-Context layer in truth table.
- Removed implicit preference for daily notes as session continuity mechanism.

### `README.md`
- Clarified "Start here" as human orientation only, not required for agent startup.
- Added `CONTEXT.md` as step 2 in the startup order.
- Added pointer to `memory-system-v2.md` and `AGENTS.md` in startup section.
- Updated "Source of truth" table to include `CONTEXT.md` and `docs/ops/memory-system-v2.md`.
- Added "Session & memory ops" section to Core project docs.
- Changed `docs/` description for `memory/` to "session scratch — daily notes only, archived at closeout".

## What this does NOT change

- `CHECKPOINT.md`, `CONTEXT.md`, `MEMORY.md` content (Block 2, separate PR)
- `checkpoint.yaml`, `memory/README.md`, old PRDs, audit logs (Block 3)
- Any code, tests, or Supabase files

## Token impact

- Agents now have a single, unambiguous 5-line startup rule in the first file they read (`AGENTS.md`).
- `README.md` is no longer implicitly part of agent startup.
- `openclaw.md` no longer duplicates the general memory model.
- Expected reduction in default context per session: eliminates the need to cross-reference 3–4 files to resolve startup ambiguity.