### PR TITLE
meta: compress live context files (Block 2)

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -2,7 +2,7 @@
 status: current
 canonical_for: current execution state
 owner: repo
-last_verified: 2026-04-23
+last_verified: 2026-04-24
 supersedes: []
 superseded_by: null
 scope: repo
@@ -18,63 +18,28 @@ Remaining gaps: physical Garmin/Health Connect testing, end-to-end Supabase inge
 
 ## Current state
 
-- Branch state: `main`, aligned with `origin/main`
-- HEAD: `913d16ec85efb5ae727fc36cb9b7d638e7c5c1a7`
+- Branch: `main`, aligned with `origin/main`
+- HEAD: `3e4406e47f95bdbd6e06ff69d1779e85239f3367`
 - Active seam: physical-device Health Connect ingest proof + wearable sync contract hardening
 
 ## Pending PRs
 
-- `claude/real-app-install-id` — AsyncStorage-backed persistent UUID replacing `MOCK_APP_INSTALL_ID`; pending merge (intentionally held)
-- `#99 feat: user-configurable panel preferences` — still open and draft; not cleaned up in this pass
-- `#101 feat: mobile scoring and build tooling` — still open and draft; not cleaned up in this pass
+- `claude/real-app-install-id` — AsyncStorage-backed persistent UUID replacing `MOCK_APP_INSTALL_ID`; intentionally held
+- `#99 feat: user-configurable panel preferences` — open, draft
+- `#101 feat: mobile scoring and build tooling` — open, draft
 
 ## Blockers
 
 - No physical Garmin / Health Connect data source proof yet (WEARABLE-TD-001)
 - End-to-end Supabase ingest still needs an Android device run
-- Wearable sync request in app still uses placeholder payload (`as any`) and is not yet contract-complete
-
-## Completed this session (2026-04-23)
-
-- ✅ Reviewed `docs/ops/memory-system-v2.md` and executed the closeout checklist steps that were possible in the current worktree
-- ✅ Reassessed wearable sync seam; current app still uses a placeholder request payload and needs contract hardening before rollout
-- ✅ Expanded the wearable permission surface and aligned mobile docs/assertions to the canonical sync contract
-- ✅ Promoted durable notes into `MEMORY.md` and wrote/archived `memory/2026-04-23.md`
-- ✅ Closed stale GitHub PRs `#96`, `#97`, `#98`, and `#100` as superseded by later work on `main`
-- ✅ Closed issue `#104` as completed after confirming the runtime scoring call-site is now live on `main`
-- ✅ Restored local `main` to track `origin/main` and ignored local-only files `apps/mobile/.env` and `apps/mobile/android/app/debug.keystore`
-- ✅ Added a canonical Supabase agent workflow at `docs/ops/supabase-agent-workflow.md` and wired `AGENTS.md` to require it for larger Supabase work
-- ✅ Added prototype freeze runbook at `docs/ops/prototype-v1-freeze.md` (Expo start, env, migration baseline, tag/release flow)
-- ✅ Added optional Sentry crash reporting support in mobile app (`EXPO_PUBLIC_SENTRY_DSN`)
-- ✅ Replaced dev-insight visibility-only approach with explicit access guard path in the screen itself
-- ✅ Removed stale ghost-reference claim about `apps/mobile/healthConnectCollector.ts` from active checkpoint text
-- ✅ Ran secrets audit: `git log --all -S "supabase_service_role"` (no matches)
-
-## Completed previous session (2026-04-22)
-
-- ✅ Biomarker scoring audit — weighting hierarchy validated against Medicine 3.0 / Attia framework
-- ✅ `evidenceConfidenceModifier` + `scoringClass` fields specified on `BiomarkerDefinition` interface
-- ✅ `evaluateTriglycerides()` evaluator defined (LIP-003; optimalMax 100 mg/dL)
-- ✅ `evaluateDAO()` evaluator defined (CTX-003; LOW_CONFIDENCE flagged; modifier 0.3)
-- ✅ Threshold deltas documented: ApoB optimalMax → 60; Vitamin D optimalMin → 40; HbA1c/Glucose/CRP/LDL synced to `thresholds.ts`
-- ✅ `AUDIT_LOG.md` updated with full delta table + sources
-- ✅ `CHECKPOINT.md` updated
-- ✅ Expo mobile restart path unblocked by adding a runtime JS config-plugin entrypoint at `apps/mobile/plugins/with-health-connect.js`
-- ✅ `npm run start` now reaches Expo project startup in `apps/mobile`
-
-## Completed previous session (2026-04-21)
-
-- ✅ Repo cleanup: 11 stale branches deleted
-- ✅ Issues #95, #94, #89 closed (duplicates + already-merged)
-- ✅ Auto-delete branches on merge activated (GitHub repo setting)
-- ✅ `AGENTS.md` — output standards section added (commit messages, secrets, session closeout, issue hygiene)
+- Wearable sync request in app still uses placeholder payload (`as any`), not yet contract-complete
 
 ## Next steps
 
 1. Run the new wearable collector on a physical Android device and verify one end-to-end sync into Supabase.
 2. Remove placeholder wearable sync payload in `apps/mobile/WearableSyncScreen.tsx` and wire canonical `WearableSyncRequest`.
 3. Merge `claude/real-app-install-id` when ready.
-4. Triage the remaining draft PRs `#99` and `#101` for merge, split, or closure.
+4. Triage draft PRs `#99` and `#101` for merge, split, or closure.
 
 ## Deferred to post-v1
 

--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -18,8 +18,8 @@ Remaining gaps: physical Garmin/Health Connect testing, end-to-end Supabase inge
 
 ## Current state
 
-- Branch: `main`, aligned with `origin/main`
-- HEAD: `3e4406e47f95bdbd6e06ff69d1779e85239f3367`
+- Branch: `main`
+- Commit baseline: use Git history / PR merge metadata for exact HEAD; do not duplicate self-referential commit SHAs here
 - Active seam: physical-device Health Connect ingest proof + wearable sync contract hardening
 
 ## Pending PRs

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,55 +2,36 @@
 status: current
 canonical_for: rolling session context
 owner: repo
-last_verified: 2026-04-23
+last_verified: 2026-04-24
 scope: all-agents
 ---
 
 # CONTEXT.md — Rolling Session Summary
 
-Last 2–3 sessions. Hard cap: 60 lines. Updated every session by the closing agent.
+Last 2–3 sessions. Hard cap: 60 lines. Max 5 bullets per entry. Updated every session by the closing agent.
 For startup: read after CHECKPOINT.md. Never load memory/ or docs/archive/ at startup.
 
 ---
 
-## 2026-04-23 — Codex (cleanup + closeout)
+## 2026-04-24 — Perplexity (repo cleanup — Block 1)
 
-- Read and applied the `docs/ops/memory-system-v2.md` closeout checklist as far as the worktree allowed
-- Revalidated wearable sync status: current `WearableSyncScreen` still uses a placeholder request payload and needs contract hardening
-- Expanded the Health Connect permission surface to include `RestingHeartRate` and `HeartRateVariabilityRmssd`
-- Aligned wearable docs, assertions, and sync-client types to the canonical wearable contract
-- Wrote `memory/2026-04-23.md`, archived it to `docs/archive/memory/2026-04-23.md`, and promoted durable notes into `MEMORY.md`
-- Closed stale GitHub PRs `#96`, `#97`, `#98`, and `#100`; closed issue `#104` as completed
-- Restored the local checkout to a clean `main` tracking `origin/main`
-- Added local-ignore coverage for `apps/mobile/.env` and `apps/mobile/android/app/debug.keystore`
-- Added a canonical Supabase workflow doc and linked it from `AGENTS.md` so future agents load the Realtime prompt for bigger Supabase tasks
-- Added prototype hardening pass: mobile Sentry hook (`EXPO_PUBLIC_SENTRY_DSN`), explicit Dev Insight auth-guard, prototype-v1 freeze runbook, and secrets audit with no `supabase_service_role` hits
-- Current HEAD is `913d16ec85efb5ae727fc36cb9b7d638e7c5c1a7` on `main`; the Sentry/freeze changes are still in the working tree and will be committed in this closeout
+- Merged PR #106: aligned AGENTS.md, session-workflow, openclaw, README with memory-system-v2
+- AGENTS.md now has explicit 5-line default startup rule (CHECKPOINT → CONTEXT → MEMORY on demand)
+- session-workflow.md updated to v2 4-layer model; Daily Notes removed as startup context
+- openclaw.md reduced to addendum; delegates general rules to AGENTS + v2
+- README "Start here" now says "agentic repo work" and includes CONTEXT.md in startup order
 
-## 2026-04-21 — Claude Haiku (cleanup session)
+## 2026-04-23 — Codex (prototype hardening + closeout)
 
-- Repo cleanup: 11 stale branches deleted, issues #95/#94/#89 closed (duplicates/merged)
-- Auto-delete branches on merge activated; AGENTS.md output standards added
-- Open issues remaining: #88 (evidence → Priority Score), #69, #68 (backlog)
-- Pending: `claude/real-app-install-id` intentionally held, not yet merged
-- GitHub PAT setup for agent access; .env local only, gitignored
+- Wearable sync seam revalidated: `WearableSyncScreen` still uses placeholder payload, needs contract hardening
+- Health Connect permission surface expanded (`RestingHeartRate`, `HRV RMSSD`)
+- Prototype hardening: Sentry hook, dev-insight auth-guard, prototype-v1 freeze runbook, secrets audit (clean)
+- Closed stale PRs #96–#98, #100; closed issue #104
+- HEAD at `913d16ec` on main before this session's Block 1+2 commits
 
-## 2026-04-20 — Claude Code (session 3)
+## 2026-04-22 — ChatGPT (repo triage)
 
-- Executed verified small todos directly on `main`
-- Deleted dead duplicate hook: `apps/mobile/src/hooks/useWearableSource.ts`
-- Refreshed `README.md` front-matter `last_verified` to `2026-04-22`
-- Removed production-visible developer subtitle from `apps/mobile/MinimumSliceScreen.tsx`
-- Updated `docs/architecture/overview.md`: bumped `last_verified`, marked OpenAI layer as planned/not yet wired, added wearable ingest layer note
-- Updated `docs/planning/wearables-hard-facts-and-automation.md`: bumped `last_verified`, clarified Garmin Android path should be treated as Health Connect mediated in V1
-- Confirmed `memory/2026-04-17.md` was already archived; no action needed
-- Confirmed stale `GLOSSARY.md` README reference was already gone; no action needed
-- Archived three stale date-specific planning docs under `docs/archive/planning/`; direct deletion was blocked by safety layer, so lightweight redirect stubs remain at original paths
-
-## 2026-04-22 — ChatGPT (repo-access + task triage session)
-
-- Verified GitHub connector identity and permissions: account `gzug`, repo `gzug/One-L1fe`, write/admin confirmed
-- Reviewed open issues: #104 (Priority Score runtime call-site), #103 (wearable weighting ADR), #102 (normalization ADR)
-- Determined current open work is ADR-heavy; avoided risky code changes without settled decision points
-- Corrected stale `CHECKPOINT.md` next-step content: scoring fields are already implemented in code, runtime call-site is the real remaining gap
-- Recommended execution order: resolve #104 first via dedicated `compute-priority-score` edge function, then thin caller seam, then integration proof
+- Verified GitHub write/admin access for `gzug/One-L1fe`
+- Corrected stale CHECKPOINT next-step: scoring fields already implemented, runtime call-site was real gap
+- Open issues reviewed: #103 (wearable weighting ADR), #102 (normalization ADR) — ADR-heavy, no risky changes made
+- `claude/real-app-install-id` intentionally held


### PR DESCRIPTION
## What this PR does

Block 2 of the repo cleanup plan: compresses `CHECKPOINT.md` and `CONTEXT.md` to lean, token-efficient live-context files.

## Files changed

### `CHECKPOINT.md`
- **Removed** all three "Completed this/previous session" history blocks (moved to `CONTEXT.md` and Git history).
- **Kept** Verdict, Current state, Pending PRs, Blockers, Next steps, Deferred.
- Updated HEAD SHA to reflect Block 1 merge.
- **Token impact:** ~50% smaller; removes the biggest source of redundancy with `CONTEXT.md`.

### `CONTEXT.md`
- **Compressed** to 3 entries × max 5 bullets (v2 hard cap enforced).
- **Added** 2026-04-24 entry for today's Block 1 work.
- **Replaced** verbose 2026-04-23 entry with 5-bullet summary.
- **Replaced** verbose 2026-04-22 entry with 4-bullet summary.
- **Dropped** 2026-04-20 entry (oldest; content preserved in `docs/archive/memory/` and Git).
- **Token impact:** reduces default startup load significantly; CONTEXT.md now fits its 60-line cap.

## What this does NOT change
- `checkpoint.yaml`, `memory/README.md`, audit logs, old PRDs (Block 3)
- Any code, tests, or Supabase files