### PR TITLE
feat(proto): display foreground Health Connect snapshot

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "One L1fe",
     "slug": "one-l1fe-mobile",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
     "assetBundlePatterns": [
@@ -14,7 +14,7 @@
     "android": {
       "package": "com.onel1fe.mobile",
       "minSdkVersion": 26,
-      "versionCode": 3
+      "versionCode": 4
     },
     "web": {
       "bundler": "metro"

--- a/apps/mobile/prototypes/v1-marathon/src/PrototypeV1MarathonScreen.tsx
+++ b/apps/mobile/prototypes/v1-marathon/src/PrototypeV1MarathonScreen.tsx
@@ -23,6 +23,7 @@ import { ReadinessOrbit } from './components/ReadinessOrbit';
 import { ScoreTrendCard } from './components/ScoreTrendCard';
 import { TodaySignalsRow } from './components/TodaySignalsRow';
 import { WearableSourcesCard } from './components/WearableSourcesCard';
+import { HealthConnectLiveCard } from './components/HealthConnectLiveCard';
 import { checkHealthConnect } from './data/healthConnect';
 import type { HealthConnectStatus } from './data/healthConnect';
 import { nextActions } from './data/demoData';
@@ -191,6 +192,9 @@ function HomeView({
 
           {/* 4b. Wearable Data Overview */}
           <WearableSourcesCard hcStatus={hcStatus} onManageSources={onManageSources} />
+
+          {/* 4c. Live Health Connect display */}
+          <HealthConnectLiveCard />
 
           {/* 5. Recommendations */}
           <View style={s.section}>

--- a/apps/mobile/prototypes/v1-marathon/src/components/HealthConnectLiveCard.tsx
+++ b/apps/mobile/prototypes/v1-marathon/src/components/HealthConnectLiveCard.tsx
@@ -1,0 +1,229 @@
+import React, { useEffect, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { readLiveHealthConnectSnapshot } from '../data/healthConnectLive';
+import type { LiveHealthConnectSnapshot } from '../data/healthConnectLive';
+import { useTheme } from '../theme/ThemeContext';
+import { lineHeights, radius, spacing, typography } from '../theme/marathonTheme';
+import type { ThemeColors } from '../theme/marathonTheme';
+
+function formatFetchedAt(iso?: string): string {
+  if (!iso) return 'Not loaded';
+  try {
+    return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return 'Just now';
+  }
+}
+
+function statusLabel(status?: LiveHealthConnectSnapshot['status']): string {
+  switch (status) {
+    case 'available': return 'Live snapshot';
+    case 'partial': return 'Partial data';
+    case 'permission_required': return 'Permission needed';
+    case 'unsupported_platform': return 'Android only';
+    case 'module_unavailable': return 'Module unavailable';
+    case 'error': return 'Read failed';
+    default: return 'Checking';
+  }
+}
+
+export function HealthConnectLiveCard() {
+  const { colors } = useTheme();
+  const s = createStyles(colors);
+  const [snapshot, setSnapshot] = useState<LiveHealthConnectSnapshot | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function refresh() {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const next = await readLiveHealthConnectSnapshot();
+      setSnapshot(next);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+    // Run once on mount. Manual refresh covers updates while app stays open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const metrics = snapshot ? [
+    snapshot.metrics.stepsToday,
+    snapshot.metrics.distanceToday,
+    snapshot.metrics.activeCaloriesToday,
+    snapshot.metrics.restingHeartRate,
+    snapshot.metrics.hrvRmssd,
+    snapshot.metrics.sleepDuration,
+  ] : [];
+
+  const positive = snapshot?.status === 'available' || snapshot?.status === 'partial';
+
+  return (
+    <View style={s.card}>
+      <View style={s.headerRow}>
+        <View style={s.headerLeft}>
+          <Text style={s.title}>Health Connect Data</Text>
+          <Text style={s.sub}>
+            Display-only foreground read · scores are not recalculated yet
+          </Text>
+        </View>
+        <View style={[
+          s.statusPill,
+          { borderColor: colors.borderSubtle },
+        ]}>
+          <View style={[s.statusDot, { backgroundColor: positive ? colors.positive : colors.warning }]} />
+          <Text style={[s.statusText, { color: positive ? colors.positive : colors.textMuted }]}>
+            {statusLabel(snapshot?.status)}
+          </Text>
+        </View>
+      </View>
+
+      {snapshot?.message ? <Text style={s.message}>{snapshot.message}</Text> : null}
+
+      <View style={s.metricGrid}>
+        {metrics.length > 0 ? metrics.map((m) => (
+          <View key={m.label} style={s.metricBox}>
+            <Text style={s.metricLabel}>{m.label}</Text>
+            <View style={s.valueRow}>
+              <Text style={[
+                s.metricValue,
+                m.status === 'available' ? { color: colors.text } : { color: colors.textSubtle },
+              ]}>
+                {m.value}
+              </Text>
+              {m.unit ? <Text style={s.metricUnit}>{m.unit}</Text> : null}
+            </View>
+            {m.note ? <Text style={s.metricNote}>{m.note}</Text> : null}
+          </View>
+        )) : (
+          <Text style={s.message}>Checking Health Connect…</Text>
+        )}
+      </View>
+
+      <View style={s.footerRow}>
+        <Text style={s.footerText}>Updated {formatFetchedAt(snapshot?.fetchedAt)}</Text>
+        <Pressable
+          onPress={refresh}
+          disabled={busy}
+          style={[s.refreshBtn, { borderColor: colors.accentBorder, opacity: busy ? 0.5 : 1 }]}
+          accessibilityLabel="Refresh Health Connect data"
+        >
+          <Text style={[s.refreshText, { color: colors.accent }]}>
+            {busy ? 'Refreshing…' : 'Refresh'}
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    card: {
+      borderRadius: radius.lg,
+      backgroundColor: colors.surfaceElevated,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: colors.border,
+      padding: spacing.lg,
+      gap: spacing.md,
+    },
+    headerRow: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      justifyContent: 'space-between',
+      gap: spacing.sm,
+    },
+    headerLeft: { gap: 2, flex: 1 },
+    title: {
+      color: colors.text,
+      fontSize: typography.bodySmall,
+      fontWeight: '700',
+      letterSpacing: -0.1,
+    },
+    sub: {
+      color: colors.textSubtle,
+      fontSize: typography.micro,
+      lineHeight: lineHeights.caption,
+    },
+    statusPill: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 5,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderRadius: radius.pill,
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 3,
+      flexShrink: 0,
+    },
+    statusDot: { width: 6, height: 6, borderRadius: 3 },
+    statusText: { fontSize: typography.micro, fontWeight: '600' },
+    message: {
+      color: colors.textMuted,
+      fontSize: typography.caption,
+      lineHeight: lineHeights.caption,
+    },
+    metricGrid: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: spacing.sm,
+    },
+    metricBox: {
+      flexBasis: '47%',
+      flexGrow: 1,
+      borderRadius: radius.md,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: colors.borderSubtle,
+      backgroundColor: colors.surface,
+      padding: spacing.sm,
+      gap: 3,
+    },
+    metricLabel: {
+      color: colors.textSubtle,
+      fontSize: typography.micro,
+      fontWeight: '600',
+    },
+    valueRow: {
+      flexDirection: 'row',
+      alignItems: 'baseline',
+      gap: 4,
+    },
+    metricValue: {
+      fontSize: typography.body,
+      fontWeight: '800',
+      letterSpacing: -0.2,
+    },
+    metricUnit: {
+      color: colors.textSubtle,
+      fontSize: typography.micro,
+      fontWeight: '600',
+    },
+    metricNote: {
+      color: colors.textSubtle,
+      fontSize: 9,
+      lineHeight: 12,
+    },
+    footerRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: spacing.sm,
+    },
+    footerText: {
+      color: colors.textSubtle,
+      fontSize: typography.micro,
+    },
+    refreshBtn: {
+      borderWidth: StyleSheet.hairlineWidth,
+      borderRadius: radius.pill,
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.xs + 1,
+    },
+    refreshText: {
+      fontSize: typography.micro,
+      fontWeight: '700',
+    },
+  });
+}

--- a/apps/mobile/prototypes/v1-marathon/src/data/healthConnect.ts
+++ b/apps/mobile/prototypes/v1-marathon/src/data/healthConnect.ts
@@ -36,6 +36,7 @@ const V1_PERMISSIONS = [
   { accessType: 'read' as const, recordType: 'HeartRateVariabilityRmssd' as const },
   { accessType: 'read' as const, recordType: 'ExerciseSession' as const },
   { accessType: 'read' as const, recordType: 'ActiveCaloriesBurned' as const },
+  { accessType: 'read' as const, recordType: 'Distance' as const },
 ];
 
 async function loadModule() {

--- a/apps/mobile/prototypes/v1-marathon/src/data/healthConnectLive.ts
+++ b/apps/mobile/prototypes/v1-marathon/src/data/healthConnectLive.ts
@@ -1,0 +1,284 @@
+/**
+ * healthConnectLive.ts
+ *
+ * Foreground Health Connect reader for Prototype V1 - Marathon.
+ * Reads a small, display-only snapshot from Health Connect.
+ *
+ * Boundaries:
+ * - no background sync
+ * - no Supabase write
+ * - no score recomputation
+ * - no medical interpretation
+ */
+import { Platform } from 'react-native';
+
+export type LiveHealthMetric = {
+  label: string;
+  value: string;
+  unit?: string;
+  status: 'available' | 'missing' | 'error';
+  note?: string;
+};
+
+export type LiveHealthConnectSnapshot = {
+  status: 'unsupported_platform' | 'module_unavailable' | 'permission_required' | 'available' | 'partial' | 'error';
+  fetchedAt: string;
+  message?: string;
+  metrics: {
+    stepsToday: LiveHealthMetric;
+    distanceToday: LiveHealthMetric;
+    activeCaloriesToday: LiveHealthMetric;
+    restingHeartRate: LiveHealthMetric;
+    hrvRmssd: LiveHealthMetric;
+    sleepDuration: LiveHealthMetric;
+  };
+};
+
+type HcModule = {
+  getSdkStatus: () => Promise<number>;
+  initialize: () => Promise<boolean>;
+  getGrantedPermissions: () => Promise<any[]>;
+  readRecords: (recordType: string, options: any) => Promise<{ records?: any[] }>;
+  aggregateRecord: (request: any) => Promise<any>;
+  SdkAvailabilityStatus: {
+    SDK_UNAVAILABLE: number;
+    SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED: number;
+    SDK_AVAILABLE: number;
+  };
+};
+
+const missing = (label: string, note?: string): LiveHealthMetric => ({
+  label,
+  value: '—',
+  status: 'missing',
+  note,
+});
+
+const failed = (label: string, note?: string): LiveHealthMetric => ({
+  label,
+  value: '—',
+  status: 'error',
+  note,
+});
+
+const metric = (label: string, value: string, unit?: string, note?: string): LiveHealthMetric => ({
+  label,
+  value,
+  unit,
+  status: 'available',
+  note,
+});
+
+function emptyMetrics(note?: string): LiveHealthConnectSnapshot['metrics'] {
+  return {
+    stepsToday: missing('Steps today', note),
+    distanceToday: missing('Distance today', note),
+    activeCaloriesToday: missing('Active calories today', note),
+    restingHeartRate: missing('Resting heart rate', note),
+    hrvRmssd: missing('HRV RMSSD', note),
+    sleepDuration: missing('Sleep last night', note),
+  };
+}
+
+async function loadModule(): Promise<HcModule | null> {
+  if (Platform.OS !== 'android') return null;
+  try {
+    return (await import('react-native-health-connect')) as unknown as HcModule;
+  } catch {
+    return null;
+  }
+}
+
+function startOfToday(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function daysAgo(days: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d;
+}
+
+function hasPermission(granted: any[], recordType: string): boolean {
+  return granted.some((g) => g?.accessType === 'read' && g?.recordType === recordType);
+}
+
+async function safeAggregate(
+  mod: HcModule,
+  recordType: string,
+  startTime: Date,
+  endTime: Date,
+): Promise<any | null> {
+  try {
+    return await mod.aggregateRecord({
+      recordType,
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function safeLatestRecord(
+  mod: HcModule,
+  recordType: string,
+  startTime: Date,
+  endTime: Date,
+): Promise<any | null> {
+  try {
+    const result = await mod.readRecords(recordType, {
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
+      ascendingOrder: false,
+      pageSize: 20,
+    });
+    const records = Array.isArray(result?.records) ? result.records : [];
+    if (records.length === 0) return null;
+    return records.sort((a, b) => {
+      const at = new Date(a.endTime ?? a.time ?? a.startTime ?? 0).getTime();
+      const bt = new Date(b.endTime ?? b.time ?? b.startTime ?? 0).getTime();
+      return bt - at;
+    })[0];
+  } catch {
+    return null;
+  }
+}
+
+function formatDuration(raw: number | undefined): string | null {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return null;
+
+  // Library returns a number for Health Connect duration.
+  // Be defensive across possible ms / seconds / minutes representations.
+  let minutes: number;
+  if (raw > 24 * 60 * 60) {
+    minutes = Math.round(raw / 60000); // milliseconds
+  } else if (raw > 24 * 60) {
+    minutes = Math.round(raw / 60); // seconds
+  } else {
+    minutes = Math.round(raw); // minutes
+  }
+
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (h <= 0) return `${m}m`;
+  return `${h}h ${m.toString().padStart(2, '0')}m`;
+}
+
+export async function readLiveHealthConnectSnapshot(): Promise<LiveHealthConnectSnapshot> {
+  const fetchedAt = new Date().toISOString();
+
+  if (Platform.OS !== 'android') {
+    return {
+      status: 'unsupported_platform',
+      fetchedAt,
+      message: 'Health Connect is Android-only.',
+      metrics: emptyMetrics('Android-only'),
+    };
+  }
+
+  const mod = await loadModule();
+  if (!mod) {
+    return {
+      status: 'module_unavailable',
+      fetchedAt,
+      message: 'Health Connect module is not linked.',
+      metrics: emptyMetrics('Module unavailable'),
+    };
+  }
+
+  try {
+    const sdk = await mod.getSdkStatus();
+    if (sdk !== mod.SdkAvailabilityStatus.SDK_AVAILABLE) {
+      return {
+        status: 'permission_required',
+        fetchedAt,
+        message: 'Health Connect is unavailable or needs an update.',
+        metrics: emptyMetrics('Health Connect unavailable'),
+      };
+    }
+
+    await mod.initialize();
+    const granted = await mod.getGrantedPermissions();
+
+    const now = new Date();
+    const today = startOfToday();
+    const last7Days = daysAgo(7);
+    const last36Hours = new Date(now.getTime() - 36 * 60 * 60 * 1000);
+
+    const metrics = emptyMetrics('No permission or no data');
+
+    if (hasPermission(granted, 'Steps')) {
+      const agg = await safeAggregate(mod, 'Steps', today, now);
+      const count = agg?.COUNT_TOTAL;
+      metrics.stepsToday = typeof count === 'number'
+        ? metric('Steps today', Math.round(count).toLocaleString('en-US'), undefined, 'Health Connect')
+        : missing('Steps today', 'No steps today');
+    }
+
+    if (hasPermission(granted, 'Distance')) {
+      const agg = await safeAggregate(mod, 'Distance', today, now);
+      const km = agg?.DISTANCE?.inKilometers;
+      metrics.distanceToday = typeof km === 'number'
+        ? metric('Distance today', km.toFixed(1), 'km', 'Health Connect')
+        : missing('Distance today', 'No distance today');
+    }
+
+    if (hasPermission(granted, 'ActiveCaloriesBurned')) {
+      const agg = await safeAggregate(mod, 'ActiveCaloriesBurned', today, now);
+      const kcal = agg?.ACTIVE_CALORIES_TOTAL?.inKilocalories;
+      metrics.activeCaloriesToday = typeof kcal === 'number'
+        ? metric('Active calories today', Math.round(kcal).toLocaleString('en-US'), 'kcal', 'Health Connect')
+        : missing('Active calories today', 'No active calories today');
+    }
+
+    if (hasPermission(granted, 'RestingHeartRate')) {
+      const rec = await safeLatestRecord(mod, 'RestingHeartRate', last7Days, now);
+      metrics.restingHeartRate = typeof rec?.beatsPerMinute === 'number'
+        ? metric('Resting heart rate', Math.round(rec.beatsPerMinute).toString(), 'bpm', 'Latest 7 days')
+        : missing('Resting heart rate', 'No recent value');
+    }
+
+    if (hasPermission(granted, 'HeartRateVariabilityRmssd')) {
+      const rec = await safeLatestRecord(mod, 'HeartRateVariabilityRmssd', last7Days, now);
+      metrics.hrvRmssd = typeof rec?.heartRateVariabilityMillis === 'number'
+        ? metric('HRV RMSSD', Math.round(rec.heartRateVariabilityMillis).toString(), 'ms', 'Latest 7 days')
+        : missing('HRV RMSSD', 'No recent value');
+    }
+
+    if (hasPermission(granted, 'SleepSession')) {
+      const agg = await safeAggregate(mod, 'SleepSession', last36Hours, now);
+      const duration = formatDuration(agg?.SLEEP_DURATION_TOTAL);
+      metrics.sleepDuration = duration
+        ? metric('Sleep last night', duration, undefined, 'Last 36 hours')
+        : missing('Sleep last night', 'No recent sleep session');
+    }
+
+    const availableCount = Object.values(metrics).filter((m) => m.status === 'available').length;
+
+    if (availableCount === 0) {
+      return {
+        status: granted.length > 0 ? 'partial' : 'permission_required',
+        fetchedAt,
+        message: granted.length > 0 ? 'Permissions granted, but no recent Health Connect data found.' : 'No Health Connect permissions granted.',
+        metrics,
+      };
+    }
+
+    return {
+      status: availableCount === Object.keys(metrics).length ? 'available' : 'partial',
+      fetchedAt,
+      message: 'Display-only foreground Health Connect snapshot.',
+      metrics,
+    };
+  } catch (err: any) {
+    return {
+      status: 'error',
+      fetchedAt,
+      message: err?.message ?? 'Health Connect read failed.',
+      metrics: emptyMetrics('Read failed'),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a foreground Health Connect reader for the Marathon prototype.
- Displays steps, distance, active calories, resting HR, HRV RMSSD, and sleep duration where permissions/data exist.
- Adds Distance read permission to the prototype Health Connect request.
- Bumps mobile app version to 0.2.2 / Android versionCode 4.

## Boundaries

- No background sync.
- No Supabase write.
- No score recomputation.
- No medical interpretation.
- Health Connect values are display-only in this iteration.

## Validation

- npm --prefix apps/mobile run typecheck
- cd apps/mobile/android && ./gradlew app:assembleRelease
- APK contains assets/index.android.bundle

## Device validation still needed

Real Health Connect data must be checked on Android hardware with Garmin/Health Connect data available.