### PR TITLE
Repo cleanup: align mobile docs with Marathon V1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 node_modules/
 dist/
+
+# Local environment files
+.env
+.env.*
+!.env.example
+apps/mobile/.env
+apps/mobile/.env.*
+!apps/mobile/.env.example

--- a/apps/mobile/.env.prototype
+++ b/apps/mobile/.env.prototype
@@ -1,7 +1,10 @@
-# One L1fe — Prototype V1 - Marathon build config
-# Copy this file to .env.local and run: npx expo start --clear
+# OBSOLETE — historical context only
 #
-# Activates the prototype gate in App.tsx, bypassing auth and the full app shell.
-# Remove or set to 'false' to restore the full app.
+# The active app path no longer uses an env gate.
+# `apps/mobile/App.tsx` renders Prototype V1 - Marathon directly.
+#
+# Do not copy this file to `.env.local` for current development.
+# Keep real local env files untracked.
 
+# Historical flag only. No current effect expected.
 EXPO_PUBLIC_PROTOTYPE_V1_MARATHON=true

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,85 +1,58 @@
 # apps/mobile
 
-Thin Expo app for the One L1fe minimum-slice mobile seam.
+Expo mobile app for One L1fe.
 
-## What this is
+## Active app path
 
-- A minimal React Native / Expo screen that renders the minimum-slice lab form.
-- Uses the shared domain controller (`minimumSliceScreenController.ts`) and model.
-- Submits authenticated requests to the hosted Supabase edge function.
-- Auth is handled by Supabase (`@supabase/supabase-js`) - real app session, not env placeholders.
+The active root surface is **Prototype V1 - Marathon**.
 
-## Required env vars
-
-Create `apps/mobile/.env` (never commit):
-
-```
-EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL=https://<project-ref>.supabase.co
-EXPO_PUBLIC_ONE_L1FE_SUPABASE_ANON_KEY=<your-anon-key>
-# Optional: override the default function path slug
-# EXPO_PUBLIC_ONE_L1FE_FUNCTION_PATH=save-minimum-slice-interpretation
+```text
+App.tsx -> prototypes/v1-marathon/src/PrototypeV1MarathonScreen.tsx
 ```
 
-Get `SUPABASE_URL` and `SUPABASE_ANON_KEY` from: Supabase Dashboard -> Project -> Settings -> API.
+The previous authenticated minimum-slice shell is historical. Do not treat `LoginScreen.tsx`, `SessionBar.tsx`, or `MinimumSliceScreen.tsx` as the active root path unless a later PR explicitly restores that flow.
+
+## What this app does now
+
+- Renders the Marathon prototype directly from `App.tsx`.
+- Uses illustrative demo data where labelled.
+- Shows a foreground Health Connect snapshot when Android permissions and records are available.
+- Keeps Health Connect display-only: no background sync, no Supabase write, no score recomputation.
+- Keeps product copy bounded: no diagnosis, treatment, emergency triage, or clinical-risk-score claims.
 
 ## How to run
 
 ```bash
 cd apps/mobile
 npm install
-npx expo start
+npx expo start --clear
+# or: npx expo run:android
 ```
 
-Then open in iOS Simulator, Android Emulator, or Expo Go.
+No `.env.local` prototype gate is required for the active app path.
 
-## How to test a real authenticated submit
+## Build notes
 
-1. Ensure `.env` has real `EXPO_PUBLIC_ONE_L1FE_SUPABASE_URL` and `EXPO_PUBLIC_ONE_L1FE_SUPABASE_ANON_KEY`.
-2. Start the app: `npx expo start`.
-3. The app opens on the Login screen. Sign in with a real Supabase Auth user.
-4. Fill in the minimum-slice form (or use the pre-filled demo draft).
-5. Tap **Submit**.
-6. Expected: `Status: success`, `Interpretation run: <uuid>` shown in the Submission summary.
-7. Verify in Supabase Dashboard -> Table Editor -> `lab_results` that a row exists under the correct `profile_id`.
+- `apps/mobile/app.json` is the app-config source for Expo version fields.
+- Generated native files under `apps/mobile/android/` may drift and should not be edited unless intentionally accepting native project changes.
+- For a sideloadable local Android APK, use release builds, not debug builds:
 
-## Quick failure smoke checks
-
-Run these once before calling the seam proven:
-
-1. Wrong password -> Login screen shows an error, no crash.
-2. Missing env vars -> Login screen stays visible and shows a clear config error instead of crashing.
-3. Signed-out launch -> Login screen is shown instead of the form.
-4. Sign out from the signed-in screen -> app returns cleanly to Login without stale form access.
-5. Hosted function error -> submission summary shows an error instead of hanging silently.
-
-## Auth flow
-
-```
-App starts
-  +-- getMobileSupabaseClient().auth.getSession()
-       +-- session exists  -> show SessionBar + MinimumSlice form screen
-       +-- no session      -> show LoginScreen
-            +-- signInWithPassword() success -> show signed-in screen
-
-Signed-in screen
-  +-- SessionBar -> signOut() -> return to LoginScreen
-
-Form screen: Submit button
-  +-- controller.submit()
-       +-- createMobileSupabaseAuthSessionProvider().getSession()
-            +-- passes { user.id, access_token } to minimumSliceScreenController
-                 +-- POST /functions/v1/save-minimum-slice-interpretation
+```bash
+cd apps/mobile/android
+./gradlew app:assembleRelease
+unzip -l app/build/outputs/apk/release/app-release.apk | grep assets/index.android.bundle
 ```
 
-## File map
+## Historical backend/auth files
 
-| File | Role |
+These files are kept for future backend/domain work and are not safe to delete without import/reference audit:
+
+| File | Current role |
 |---|---|
-| `App.tsx` | Root component, auth state machine, signed-in shell |
-| `LoginScreen.tsx` | Email/password sign-in UI |
-| `SessionBar.tsx` | Signed-in session identity + sign-out action |
-| `mobileSupabaseAuth.ts` | Supabase client singleton + `MinimumSliceAuthSessionProvider` adapter |
-| `minimumSliceScreenController.ts` | Screen controller (auth-provider-agnostic) |
-| `minimumSliceScreenModel.ts` | Screen model, submit logic |
-| `minimumSliceHostedConfig.ts` | Hosted endpoint config |
-| `.env.example` | Env var template |
+| `LoginScreen.tsx` | Historical Supabase sign-in UI |
+| `SessionBar.tsx` | Historical signed-in session UI |
+| `mobileSupabaseAuth.ts` | Supabase mobile client/auth adapter; keep for later real-data path |
+| `minimumSliceScreenController.ts` | Historical minimum-slice submit controller |
+| `minimumSliceScreenModel.ts` | Historical minimum-slice screen model |
+| `minimumSliceHostedConfig.ts` | Historical hosted function config |
+| `.env.example` | Real Supabase env var template for later authenticated paths |

--- a/apps/mobile/prototypes/v1-marathon/src/data/copy.ts
+++ b/apps/mobile/prototypes/v1-marathon/src/data/copy.ts
@@ -6,7 +6,7 @@ export const prototypeCopy = {
   // Demo info modal
   demoInfoTitle: 'Demo data',
   demoInfoBody:
-    'All values shown are illustrative demo data. No values are stored or transmitted in this prototype. Real-source connections are active development work.',
+    'Preset values are illustrative demo data. Local edits may be stored on this device. Real-source connections are active development work.',
   demoInfoDismiss: 'Got it',
   demoInfoConnectCta: 'Connect a source →',
   demoInfoConnectHelper: 'Manage Garmin, Health Connect, and Blood Panels from Profile.',

--- a/apps/mobile/prototypes/v1-marathon/src/data/copy.ts
+++ b/apps/mobile/prototypes/v1-marathon/src/data/copy.ts
@@ -6,7 +6,7 @@ export const prototypeCopy = {
   // Demo info modal
   demoInfoTitle: 'Demo data',
   demoInfoBody:
-    'All values shown are illustrative demo data. No real health data is stored or transmitted in this prototype. Connect real sources in the full product.',
+    'All values shown are illustrative demo data. No values are stored or transmitted in this prototype. Real-source connections are active development work.',
   demoInfoDismiss: 'Got it',
   demoInfoConnectCta: 'Connect a source →',
   demoInfoConnectHelper: 'Manage Garmin, Health Connect, and Blood Panels from Profile.',


### PR DESCRIPTION
## Summary
- Documents `apps/mobile` as the Marathon V1 root app instead of the old minimum-slice auth shell.
- Marks `.env.prototype` obsolete and prevents future local env files from being committed.
- Clarifies demo modal wording to avoid implying a separate full-product path.

## Scope
- Docs and copy only.
- No file deletion.
- No generated Android/native edits.
- No Supabase, domain, compliance, architecture, or evidence docs touched.

## Not included
- Health Connect permission trimming was verified as needed, but the connector blocked the file update. Current plugin still declares more permissions than displayed foreground metrics.
- `CHECKPOINT.md` and `MEMORY.md` still need targeted updates; connector blocked the larger content updates.

## Validation
- Not run here: `npm --prefix apps/mobile run typecheck`.
- Not run here: `cd apps/mobile/android && ./gradlew app:assembleRelease`.
- Not run here: APK bundle check for `assets/index.android.bundle`.
