### PR TITLE
Refactor mobile app into active v2 prototype path

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -14,11 +14,11 @@ scope: repo
 
 - Stable branch: `main`.
 - Active mobile app: **One L1fe v2 prototype**.
-- UI identity: `One L1fe` with a small, low-emphasis `v2` label. Do not show Marathon in the product header.
-- Canonical app entry: `apps/mobile/App.tsx -> apps/mobile/prototypes/v1-marathon/src/PrototypeV1MarathonScreen.tsx`.
-- Note: the folder/component path still says `v1-marathon`; this is historical technical naming, not current UI/product framing.
+- Canonical app entry: `apps/mobile/App.tsx -> apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx`.
+- `apps/mobile/prototypes/v1-marathon/` remains as the previous Marathon-focused snapshot.
+- v2 has its own root, header, copy, and README.
+- v2 may temporarily import unchanged components from `v1-marathon`; fork a component into `v2/` before changing v2-specific behavior.
 - Previous authenticated minimum-slice/full-app shell: historical, not active root path.
-- No `.env.local` prototype gate is required.
 - App config source: `apps/mobile/app.json`.
 - Current Expo version: `0.2.2`; Android `versionCode: 4`; Android `minSdkVersion: 26`.
 - Native Android project exists and Health Connect is integrated. Keep using this native/prebuild path for Android-only native features.
@@ -35,17 +35,18 @@ npx expo start --clear
 
 ## Completed
 
-- Marathon-labelled prototype promoted into a broader One L1fe v2 prototype.
-- Header copy now removes Marathon and shows subtle `v2`.
-- `apps/mobile/README.md` updated to match active root path.
-- `.gitignore` now ignores local env files.
-- Demo modal copy states local edits may be stored on-device.
-- Release APK guidance remains: use release build and verify bundled JS.
+- v1 Marathon restored as prior snapshot identity.
+- v2 workspace created under `apps/mobile/prototypes/v2/`.
+- Root app now routes to `OneL1feV2Screen`.
+- v2 header shows `One L1fe` with subtle `v2`.
+- v2 README defines live-private-use buildout direction.
 
 ## Working rules
 
 - Keep `One L1fe` as canonical app name.
 - Keep `v2` visually secondary to the app name.
+- Keep v1 Marathon stable unless explicitly fixing that snapshot.
+- Fork v1 components into v2 before changing v2-specific behavior.
 - Keep demo data labelled.
 - Keep Health Connect claims display-only unless ingest is implemented.
 - Keep product framing bounded: no diagnosis, treatment, emergency triage, or clinical-risk-score claim.
@@ -54,9 +55,10 @@ npx expo start --clear
 
 ## Current blockers
 
+- Typecheck not run after v2 path creation.
+- Device QA not yet run for v2.
 - Full-app shell files have not yet been reference-audited for safe deletion.
 - Native Android version values drift from `app.json` unless regenerated/accepted intentionally.
-- Device QA not yet run for the v2 header/state.
 
 ## Next steps
 
@@ -65,4 +67,4 @@ npx expo start --clear
 3. Local APK fallback: `cd apps/mobile/android && ./gradlew app:assembleRelease`.
 4. APK check: `unzip -l apps/mobile/android/app/build/outputs/apk/release/app-release.apk | grep assets/index.android.bundle`.
 5. Device QA on Android.
-6. Start Scanner research/spike only after v2 device QA.
+6. Start Blood Intake / Scanner research as v2 work, not v1 Marathon work.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -25,15 +25,16 @@ Durable operating memory for **One L1fe (OL)**.
 
 ## Active mobile posture
 
-- Active mobile root: `apps/mobile/App.tsx -> apps/mobile/prototypes/v1-marathon/src/PrototypeV1MarathonScreen.tsx`.
+- Active mobile root: `apps/mobile/App.tsx -> apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx`.
 - Active app label: `One L1fe` with a small, low-emphasis `v2` marker.
-- Do not show Marathon in the product header or active user-facing label.
-- The `v1-marathon` folder/component naming is historical technical naming only.
+- `apps/mobile/prototypes/v1-marathon/` is the previous Marathon-focused snapshot.
+- v2 has its own root, header, copy, and README.
+- v2 may temporarily import unchanged components from `v1-marathon`; fork a component into `v2/` before changing v2-specific behavior.
 - Previous authenticated minimum-slice/full-app shell is historical, not active root path.
 - Historical auth/backend mobile files may be reused later: `LoginScreen.tsx`, `SessionBar.tsx`, `mobileSupabaseAuth.ts`, `minimumSliceScreenController.ts`, `minimumSliceScreenModel.ts`, `minimumSliceHostedConfig.ts`.
 - Do not delete historical mobile auth/backend files without import/reference audit.
 - No `.env.local` prototype gate is required.
-- Health Connect in the v2 prototype is foreground display-only: no background sync, no Supabase write, no score recomputation.
+- Health Connect in v2 is foreground display-only until ingest/scoring is explicitly implemented: no background sync, no Supabase write, no score recomputation.
 - Native Android project exists; keep using the current prebuild/native path for Android-only native features.
 
 ## Architecture posture

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,19 +1,18 @@
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
-import { PrototypeV1MarathonScreen } from './prototypes/v1-marathon/src/PrototypeV1MarathonScreen';
+import { OneL1feV2Screen } from './prototypes/v2/src/OneL1feV2Screen';
 
 /**
  * Root app surface.
  *
- * Prototype V1 - Marathon is now the canonical mobile app entry.
- * The previous authenticated minimum-slice shell is intentionally removed from
- * the active path so APK builds are predictable and login-free.
+ * One L1fe v2 is now the active mobile app entry for live private use.
+ * The previous `v1-marathon` prototype remains in the repo as a snapshot.
  */
 export default function App(): React.JSX.Element {
   return (
     <>
       <StatusBar style="auto" />
-      <PrototypeV1MarathonScreen />
+      <OneL1feV2Screen />
     </>
   );
 }

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -7,10 +7,12 @@ Expo mobile app for One L1fe.
 The active root surface is **One L1fe v2 prototype**.
 
 ```text
-App.tsx -> prototypes/v1-marathon/src/PrototypeV1MarathonScreen.tsx
+App.tsx -> prototypes/v2/src/OneL1feV2Screen.tsx
 ```
 
-The `v1-marathon` folder name is historical technical naming. The active user-facing product label is `One L1fe` with a small, low-emphasis `v2` marker. Do not show Marathon in the app header.
+`apps/mobile/prototypes/v1-marathon/` remains as the previous Marathon-focused snapshot.
+
+v2 has its own root screen, header, copy, and README. Unchanged modules may temporarily import from `v1-marathon`; fork a module into `v2/` before changing v2-specific behavior.
 
 The previous authenticated minimum-slice shell is historical. Do not treat `LoginScreen.tsx`, `SessionBar.tsx`, or `MinimumSliceScreen.tsx` as the active root path unless a later PR explicitly restores that flow.
 

--- a/apps/mobile/prototypes/v1-marathon/src/components/AppHeader.tsx
+++ b/apps/mobile/prototypes/v1-marathon/src/components/AppHeader.tsx
@@ -18,7 +18,6 @@ import { Platform, Pressable, StatusBar, StyleSheet, Text, View } from 'react-na
 import Svg, { Circle, Path } from 'react-native-svg';
 import { useTheme } from '../theme/ThemeContext';
 import { layout, spacing, typography } from '../theme/marathonTheme';
-import { prototypeCopy } from '../data/copy';
 
 type AppHeaderProps = {
   onProfilePress: () => void;
@@ -98,9 +97,9 @@ export function AppHeader({ onProfilePress, onDemoInfoPress }: AppHeaderProps) {
       ]}
     >
       <View style={styles.inner}>
-        <View style={styles.brandRow}>
-          <Text style={[styles.brandName, { color: colors.text }]}>{prototypeCopy.appName}</Text>
-          <Text style={[styles.brandSub, { color: colors.textSubtle }]}>{prototypeCopy.prototypeSub}</Text>
+        <View style={styles.brand}>
+          <Text style={[styles.brandName, { color: colors.text }]}>One L1fe</Text>
+          <Text style={[styles.brandSub, { color: colors.accent }]}>V1 — Marathon</Text>
         </View>
 
         <View style={styles.controls}>
@@ -151,11 +150,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
   },
-  brandRow: {
-    flexDirection: 'row',
-    alignItems: 'baseline',
-    gap: spacing.sm,
-  },
+  brand: { gap: 1 },
   brandName: {
     fontSize: typography.heroName,
     fontWeight: '700',
@@ -163,12 +158,10 @@ const styles = StyleSheet.create({
     lineHeight: 30,
   },
   brandSub: {
-    fontSize: typography.caption,
+    fontSize: typography.heroSub,
     fontWeight: '500',
-    letterSpacing: 0.8,
+    letterSpacing: 0.3,
     lineHeight: 16,
-    opacity: 0.48,
-    textTransform: 'lowercase',
   },
   controls: {
     flexDirection: 'row',

--- a/apps/mobile/prototypes/v1-marathon/src/data/copy.ts
+++ b/apps/mobile/prototypes/v1-marathon/src/data/copy.ts
@@ -1,7 +1,7 @@
 export const prototypeCopy = {
   // Identity
   appName: 'One L1fe',
-  prototypeSub: 'v2',
+  prototypeSub: 'V1 — Marathon',
 
   // Demo info modal
   demoInfoTitle: 'Demo data',

--- a/apps/mobile/prototypes/v2/README.md
+++ b/apps/mobile/prototypes/v2/README.md
@@ -1,0 +1,41 @@
+# One L1fe v2
+
+Status: active prototype workspace.
+
+This folder is the working path for the next One L1fe prototype level after `v1-marathon`.
+
+## Purpose
+
+- Keep `v1-marathon` as the previous Marathon-focused snapshot.
+- Continue product buildout in a separate v2 workspace.
+- Prepare the app for private live use by the owner and brother.
+- Keep user-facing framing broad: `One L1fe`, with a small low-emphasis `v2` marker.
+
+## Current implementation strategy
+
+v2 has its own root screen, copy, and header.
+
+Unchanged UI modules may still be imported from `../v1-marathon/src/*` until they need v2-specific changes. When a module changes for v2, copy it into this folder first and update imports.
+
+This avoids a noisy full-folder copy while still giving v2 a clear active path.
+
+## Active entry
+
+```text
+apps/mobile/App.tsx -> apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
+```
+
+## Product boundaries
+
+- Not diagnostic.
+- Not treatment.
+- Not emergency triage.
+- No score recomputation from Health Connect until explicitly implemented and validated.
+- Imported or scanned blood values must be user-reviewed before saving or scoring.
+
+## Next buildout direction
+
+1. Device QA on Android.
+2. Local realism: persistent profile, notes, and editable blood panels.
+3. Blood intake pipeline: manual entry first, then PDF/image/scan upload.
+4. Health Connect real-data integration only after display + consent + fallback rules are stable.

--- a/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
+++ b/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
@@ -11,26 +11,26 @@ import {
   View,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { ThemeProvider, useTheme } from '../../v1-marathon/src/theme/ThemeContext';
-import { useWebBackground } from '../../v1-marathon/src/theme/useWebBackground';
+import { ThemeProvider, useTheme } from './theme/ThemeContext';
+import { useWebBackground } from './theme/useWebBackground';
 import { AppHeaderV2 } from './components/AppHeaderV2';
-import { BloodContextCard } from '../../v1-marathon/src/components/BloodContextCard';
-import { CoachingCard } from '../../v1-marathon/src/components/CoachingCard';
-import { IdeasNotesCard } from '../../v1-marathon/src/components/IdeasNotesCard';
-import { ProfileScreen } from '../../v1-marathon/src/components/ProfileScreen';
-import { BloodResultsScreen } from '../../v1-marathon/src/screens/BloodResultsScreen';
-import { ReadinessOrbit } from '../../v1-marathon/src/components/ReadinessOrbit';
-import { ScoreTrendCard } from '../../v1-marathon/src/components/ScoreTrendCard';
-import { TodaySignalsRow } from '../../v1-marathon/src/components/TodaySignalsRow';
-import { WearableSourcesCard } from '../../v1-marathon/src/components/WearableSourcesCard';
-import { HealthConnectLiveCard } from '../../v1-marathon/src/components/HealthConnectLiveCard';
-import { checkHealthConnect } from '../../v1-marathon/src/data/healthConnect';
-import type { HealthConnectStatus } from '../../v1-marathon/src/data/healthConnect';
-import { nextActions } from '../../v1-marathon/src/data/demoData';
-import type { Period } from '../../v1-marathon/src/data/demoData';
+import { BloodContextCard } from './components/BloodContextCard';
+import { CoachingCard } from './components/CoachingCard';
+import { IdeasNotesCard } from './components/IdeasNotesCard';
+import { ProfileScreen } from './components/ProfileScreen';
+import { BloodResultsScreen } from './screens/BloodResultsScreen';
+import { ReadinessOrbit } from './components/ReadinessOrbit';
+import { ScoreTrendCard } from './components/ScoreTrendCard';
+import { TodaySignalsRow } from './components/TodaySignalsRow';
+import { WearableSourcesCard } from './components/WearableSourcesCard';
+import { HealthConnectLiveCard } from './components/HealthConnectLiveCard';
+import { checkHealthConnect } from './data/healthConnect';
+import type { HealthConnectStatus } from './data/healthConnect';
+import { nextActions } from './data/demoData';
+import type { Period } from './data/demoData';
 import { prototypeCopy } from './data/copy';
-import { layout, lineHeights, radius, spacing, typography } from '../../v1-marathon/src/theme/marathonTheme';
-import type { ThemeColors } from '../../v1-marathon/src/theme/marathonTheme';
+import { layout, lineHeights, radius, spacing, typography } from './theme/marathonTheme';
+import type { ThemeColors } from './theme/marathonTheme';
 
 export function OneL1feV2Screen() {
   return (

--- a/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
+++ b/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
@@ -10,24 +10,23 @@ import {
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
 import { ThemeProvider, useTheme } from './theme/ThemeContext';
 import { useWebBackground } from './theme/useWebBackground';
 import { AppHeaderV2 } from './components/AppHeaderV2';
-import { BloodContextCard } from './components/BloodContextCard';
-import { CoachingCard } from './components/CoachingCard';
-import { IdeasNotesCard } from './components/IdeasNotesCard';
-import { ProfileScreen } from './components/ProfileScreen';
-import { BloodResultsScreen } from './screens/BloodResultsScreen';
-import { ReadinessOrbit } from './components/ReadinessOrbit';
-import { ScoreTrendCard } from './components/ScoreTrendCard';
-import { TodaySignalsRow } from './components/TodaySignalsRow';
-import { WearableSourcesCard } from './components/WearableSourcesCard';
-import { HealthConnectLiveCard } from './components/HealthConnectLiveCard';
-import { checkHealthConnect } from './data/healthConnect';
-import type { HealthConnectStatus } from './data/healthConnect';
-import { nextActions } from './data/demoData';
-import type { Period } from './data/demoData';
+import { BloodContextCard } from '../../v1-marathon/src/components/BloodContextCard';
+import { CoachingCard } from '../../v1-marathon/src/components/CoachingCard';
+import { IdeasNotesCard } from '../../v1-marathon/src/components/IdeasNotesCard';
+import { ProfileScreen } from '../../v1-marathon/src/components/ProfileScreen';
+import { BloodResultsScreen } from '../../v1-marathon/src/screens/BloodResultsScreen';
+import { ReadinessOrbit } from '../../v1-marathon/src/components/ReadinessOrbit';
+import { ScoreTrendCard } from '../../v1-marathon/src/components/ScoreTrendCard';
+import { TodaySignalsRow } from '../../v1-marathon/src/components/TodaySignalsRow';
+import { WearableSourcesCard } from '../../v1-marathon/src/components/WearableSourcesCard';
+import { HealthConnectLiveCard } from '../../v1-marathon/src/components/HealthConnectLiveCard';
+import { checkHealthConnect } from '../../v1-marathon/src/data/healthConnect';
+import type { HealthConnectStatus } from '../../v1-marathon/src/data/healthConnect';
+import { nextActions } from '../../v1-marathon/src/data/demoData';
+import type { Period } from '../../v1-marathon/src/data/demoData';
 import { prototypeCopy } from './data/copy';
 import { layout, lineHeights, radius, spacing, typography } from './theme/marathonTheme';
 import type { ThemeColors } from './theme/marathonTheme';
@@ -94,12 +93,7 @@ function V2Shell() {
                   { backgroundColor: colors.surfaceElevated, borderColor: colors.border },
                 ]}
               >
-                <Ionicons
-                  name="information-circle"
-                  size={24}
-                  color={colors.accent}
-                  style={{ alignSelf: 'center' }}
-                />
+                <Text style={[demoOverlay.infoGlyph, { color: colors.accent }]}>i</Text>
                 <Text style={[demoOverlay.title, { color: colors.text }]}>
                   {prototypeCopy.demoInfoTitle}
                 </Text>
@@ -118,7 +112,7 @@ function V2Shell() {
                   ]}
                   accessibilityLabel="Connect a source"
                 >
-                  <Ionicons name="link-outline" size={14} color={colors.accent} />
+                  <Text style={[demoOverlay.connectIcon, { color: colors.accent }]}>↗</Text>
                   <Text style={[demoOverlay.connectBtnText, { color: colors.accent }]}>
                     {prototypeCopy.demoInfoConnectCta}
                   </Text>
@@ -155,7 +149,7 @@ function HomeView({
   const s = createHomeStyles(colors);
 
   const [period, setPeriod]     = useState<Period>('7D');
-  const [hcStatus, setHcStatus] = useState<HealthConnectStatus>('error');
+  const [hcStatus, setHcStatus] = useState<HealthConnectStatus>('unavailable');
 
   useEffect(() => {
     let cancelled = false;
@@ -265,6 +259,11 @@ const demoOverlay = StyleSheet.create({
     padding: spacing.xl,
     gap: spacing.sm,
   },
+  infoGlyph: {
+    alignSelf: 'center',
+    fontSize: typography.subtitle,
+    fontWeight: '800',
+  },
   title: {
     fontSize: typography.subtitle,
     fontWeight: '700',
@@ -292,6 +291,10 @@ const demoOverlay = StyleSheet.create({
     borderRadius: radius.pill,
     paddingVertical: spacing.sm,
     paddingHorizontal: spacing.lg,
+  },
+  connectIcon: {
+    fontSize: typography.bodySmall,
+    fontWeight: '800',
   },
   connectBtnText: {
     fontSize: typography.bodySmall,

--- a/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
+++ b/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
@@ -1,0 +1,310 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Modal,
+  Pressable,
+  SafeAreaView,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { ThemeProvider, useTheme } from '../../v1-marathon/src/theme/ThemeContext';
+import { useWebBackground } from '../../v1-marathon/src/theme/useWebBackground';
+import { AppHeaderV2 } from './components/AppHeaderV2';
+import { BloodContextCard } from '../../v1-marathon/src/components/BloodContextCard';
+import { CoachingCard } from '../../v1-marathon/src/components/CoachingCard';
+import { IdeasNotesCard } from '../../v1-marathon/src/components/IdeasNotesCard';
+import { ProfileScreen } from '../../v1-marathon/src/components/ProfileScreen';
+import { BloodResultsScreen } from '../../v1-marathon/src/screens/BloodResultsScreen';
+import { ReadinessOrbit } from '../../v1-marathon/src/components/ReadinessOrbit';
+import { ScoreTrendCard } from '../../v1-marathon/src/components/ScoreTrendCard';
+import { TodaySignalsRow } from '../../v1-marathon/src/components/TodaySignalsRow';
+import { WearableSourcesCard } from '../../v1-marathon/src/components/WearableSourcesCard';
+import { HealthConnectLiveCard } from '../../v1-marathon/src/components/HealthConnectLiveCard';
+import { checkHealthConnect } from '../../v1-marathon/src/data/healthConnect';
+import type { HealthConnectStatus } from '../../v1-marathon/src/data/healthConnect';
+import { nextActions } from '../../v1-marathon/src/data/demoData';
+import type { Period } from '../../v1-marathon/src/data/demoData';
+import { prototypeCopy } from './data/copy';
+import { layout, lineHeights, radius, spacing, typography } from '../../v1-marathon/src/theme/marathonTheme';
+import type { ThemeColors } from '../../v1-marathon/src/theme/marathonTheme';
+
+export function OneL1feV2Screen() {
+  return (
+    <ThemeProvider>
+      <V2Shell />
+    </ThemeProvider>
+  );
+}
+
+type ActiveView = 'home' | 'profile' | 'blood';
+
+function V2Shell() {
+  const { colors } = useTheme();
+  const [activeView, setActiveView]           = useState<ActiveView>('home');
+  const [demoInfoVisible, setDemoInfoVisible] = useState(false);
+
+  useWebBackground(colors.background);
+
+  function openProfile() {
+    setDemoInfoVisible(false);
+    setActiveView('profile');
+  }
+
+  return (
+    <>
+      <StatusBar
+        barStyle={colors.statusBar === 'dark' ? 'dark-content' : 'light-content'}
+        backgroundColor={colors.background}
+        translucent={false}
+      />
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
+        {activeView === 'blood' ? (
+          <BloodResultsScreen onClose={() => setActiveView('home')} />
+        ) : activeView === 'profile' ? (
+          <ProfileScreen
+            onClose={() => setActiveView('home')}
+            onViewBlood={() => setActiveView('blood')}
+          />
+        ) : (
+          <HomeView
+            onProfilePress={() => setActiveView('profile')}
+            onDemoInfoPress={() => setDemoInfoVisible(true)}
+            onViewBloodPanels={() => setActiveView('blood')}
+            onManageSources={() => setActiveView('profile')}
+          />
+        )}
+      </SafeAreaView>
+
+      <Modal
+        visible={demoInfoVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setDemoInfoVisible(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => setDemoInfoVisible(false)}>
+          <View style={demoOverlay.backdrop}>
+            <TouchableWithoutFeedback onPress={() => { /* absorb */ }}>
+              <View
+                style={[
+                  demoOverlay.sheet,
+                  { backgroundColor: colors.surfaceElevated, borderColor: colors.border },
+                ]}
+              >
+                <Ionicons
+                  name="information-circle"
+                  size={24}
+                  color={colors.accent}
+                  style={{ alignSelf: 'center' }}
+                />
+                <Text style={[demoOverlay.title, { color: colors.text }]}>
+                  {prototypeCopy.demoInfoTitle}
+                </Text>
+                <Text style={[demoOverlay.body, { color: colors.textMuted }]}>
+                  {prototypeCopy.demoInfoBody}
+                </Text>
+                <View style={[demoOverlay.divider, { backgroundColor: colors.borderSubtle }]} />
+                <Text style={[demoOverlay.helperText, { color: colors.textSubtle }]}>
+                  {prototypeCopy.demoInfoConnectHelper}
+                </Text>
+                <Pressable
+                  onPress={openProfile}
+                  style={[
+                    demoOverlay.connectBtn,
+                    { borderColor: colors.accentBorder, backgroundColor: colors.accentSoft },
+                  ]}
+                  accessibilityLabel="Connect a source"
+                >
+                  <Ionicons name="link-outline" size={14} color={colors.accent} />
+                  <Text style={[demoOverlay.connectBtnText, { color: colors.accent }]}>
+                    {prototypeCopy.demoInfoConnectCta}
+                  </Text>
+                </Pressable>
+                <Pressable
+                  onPress={() => setDemoInfoVisible(false)}
+                  style={demoOverlay.dismissBtn}
+                >
+                  <Text style={[demoOverlay.dismissText, { color: colors.textSubtle }]}>
+                    {prototypeCopy.demoInfoDismiss}
+                  </Text>
+                </Pressable>
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+    </>
+  );
+}
+
+function HomeView({
+  onProfilePress,
+  onDemoInfoPress,
+  onViewBloodPanels,
+  onManageSources,
+}: {
+  onProfilePress: () => void;
+  onDemoInfoPress: () => void;
+  onViewBloodPanels: () => void;
+  onManageSources: () => void;
+}) {
+  const { colors } = useTheme();
+  const s = createHomeStyles(colors);
+
+  const [period, setPeriod]     = useState<Period>('7D');
+  const [hcStatus, setHcStatus] = useState<HealthConnectStatus>('error');
+
+  useEffect(() => {
+    let cancelled = false;
+    checkHealthConnect().then((s) => {
+      if (!cancelled) setHcStatus(s.status);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <>
+      <AppHeaderV2 onProfilePress={onProfilePress} onDemoInfoPress={onDemoInfoPress} />
+
+      <ScrollView
+        contentContainerStyle={s.scroll}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={s.container}>
+          <ReadinessOrbit period={period} onPeriodChange={setPeriod} />
+
+          <ScoreTrendCard period={period} onPeriodChange={setPeriod} />
+
+          <View style={s.section}>
+            <SectionLabel text={prototypeCopy.sectionTodaySignals} />
+            <TodaySignalsRow />
+          </View>
+
+          <WearableSourcesCard hcStatus={hcStatus} onManageSources={onManageSources} />
+
+          <HealthConnectLiveCard />
+
+          <View style={s.section}>
+            <SectionLabel text={prototypeCopy.sectionRecommendations} />
+            {nextActions.map((action) => (
+              <CoachingCard key={action.id} action={action} />
+            ))}
+          </View>
+
+          <BloodContextCard onViewPress={onViewBloodPanels} />
+
+          <IdeasNotesCard />
+
+          <Text style={s.safetyNote}>{prototypeCopy.safetyNote}</Text>
+        </View>
+      </ScrollView>
+    </>
+  );
+}
+
+function SectionLabel({ text }: { text: string }) {
+  const { colors } = useTheme();
+  return (
+    <Text
+      style={{
+        color: colors.textSubtle,
+        fontSize: typography.caption,
+        fontWeight: '700',
+        textTransform: 'uppercase',
+        letterSpacing: 0.8,
+        paddingLeft: 2,
+      }}
+    >
+      {text}
+    </Text>
+  );
+}
+
+function createHomeStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    scroll: {
+      alignItems: 'center',
+      paddingTop: spacing.lg,
+      paddingBottom: spacing.xxxl,
+    },
+    container: {
+      width: '100%',
+      maxWidth: layout.maxWidth,
+      paddingHorizontal: layout.screenPaddingH,
+      gap: spacing.lg,
+    },
+    section: { gap: spacing.sm },
+    safetyNote: {
+      color: colors.textSubtle,
+      fontSize: typography.micro,
+      lineHeight: lineHeights.caption,
+      textAlign: 'center',
+      paddingHorizontal: spacing.xl,
+      paddingBottom: spacing.sm,
+    },
+  });
+}
+
+const demoOverlay = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.xl,
+  },
+  sheet: {
+    width: '100%',
+    maxWidth: 340,
+    borderRadius: radius.xl,
+    borderWidth: 1,
+    padding: spacing.xl,
+    gap: spacing.sm,
+  },
+  title: {
+    fontSize: typography.subtitle,
+    fontWeight: '700',
+    textAlign: 'center',
+    letterSpacing: -0.2,
+  },
+  body: {
+    fontSize: typography.bodySmall,
+    lineHeight: lineHeights.bodySmall,
+    textAlign: 'center',
+  },
+  divider: { height: 1, marginVertical: spacing.xs },
+  helperText: {
+    fontSize: typography.caption,
+    lineHeight: lineHeights.caption,
+    textAlign: 'center',
+  },
+  connectBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    alignSelf: 'stretch',
+    borderWidth: 1,
+    borderRadius: radius.pill,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.lg,
+  },
+  connectBtnText: {
+    fontSize: typography.bodySmall,
+    fontWeight: '700',
+    letterSpacing: 0.1,
+  },
+  dismissBtn: {
+    alignSelf: 'center',
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.md,
+    marginTop: spacing.xs,
+  },
+  dismissText: { fontSize: typography.caption, fontWeight: '500' },
+});
+
+export default OneL1feV2Screen;

--- a/apps/mobile/prototypes/v2/src/components/AppHeaderV2.tsx
+++ b/apps/mobile/prototypes/v2/src/components/AppHeaderV2.tsx
@@ -7,8 +7,8 @@
 import React from 'react';
 import { Platform, Pressable, StatusBar, StyleSheet, Text, View } from 'react-native';
 import Svg, { Circle, Path } from 'react-native-svg';
-import { useTheme } from '../../../v1-marathon/src/theme/ThemeContext';
-import { layout, spacing, typography } from '../../../v1-marathon/src/theme/marathonTheme';
+import { useTheme } from '../theme/ThemeContext';
+import { layout, spacing, typography } from '../theme/marathonTheme';
 import { prototypeCopy } from '../data/copy';
 
 type AppHeaderV2Props = {

--- a/apps/mobile/prototypes/v2/src/components/AppHeaderV2.tsx
+++ b/apps/mobile/prototypes/v2/src/components/AppHeaderV2.tsx
@@ -1,0 +1,175 @@
+/**
+ * AppHeaderV2
+ *
+ * Dedicated v2 header. Keeps One L1fe as the primary mark and renders `v2`
+ * as a small, low-emphasis marker.
+ */
+import React from 'react';
+import { Platform, Pressable, StatusBar, StyleSheet, Text, View } from 'react-native';
+import Svg, { Circle, Path } from 'react-native-svg';
+import { useTheme } from '../../../v1-marathon/src/theme/ThemeContext';
+import { layout, spacing, typography } from '../../../v1-marathon/src/theme/marathonTheme';
+import { prototypeCopy } from '../data/copy';
+
+type AppHeaderV2Props = {
+  onProfilePress: () => void;
+  onDemoInfoPress: () => void;
+};
+
+const ANDROID_TOP_INSET =
+  Platform.OS === 'android' ? (StatusBar.currentHeight ?? 24) : 0;
+
+const ICON_SIZE = 22;
+
+function IconInfo({ color }: { color: string }) {
+  return (
+    <Svg width={ICON_SIZE} height={ICON_SIZE} viewBox="0 0 22 22">
+      <Circle cx={11} cy={11} r={9} stroke={color} strokeWidth={1.6} fill="none" />
+      <Circle cx={11} cy={6.5} r={1.1} fill={color} />
+      <Path d="M11 9.6 L11 15.6" stroke={color} strokeWidth={1.8} strokeLinecap="round" fill="none" />
+    </Svg>
+  );
+}
+
+function IconSun({ color }: { color: string }) {
+  return (
+    <Svg width={ICON_SIZE} height={ICON_SIZE} viewBox="0 0 22 22">
+      <Circle cx={11} cy={11} r={3.6} stroke={color} strokeWidth={1.6} fill="none" />
+      <Path d="M11 2.5 L11 5"     stroke={color} strokeWidth={1.6} strokeLinecap="round" />
+      <Path d="M11 17 L11 19.5"   stroke={color} strokeWidth={1.6} strokeLinecap="round" />
+      <Path d="M2.5 11 L5 11"     stroke={color} strokeWidth={1.6} strokeLinecap="round" />
+      <Path d="M17 11 L19.5 11"   stroke={color} strokeWidth={1.6} strokeLinecap="round" />
+      <Path d="M5 5 L6.8 6.8"     stroke={color} strokeWidth={1.6} strokeLinecap="round" />
+      <Path d="M15.2 15.2 L17 17" stroke={color} strokeWidth={1.6} strokeLinecap="round" />
+      <Path d="M17 5 L15.2 6.8"   stroke={color} strokeWidth={1.6} strokeLinecap="round" />
+      <Path d="M5 17 L6.8 15.2"   stroke={color} strokeWidth={1.6} strokeLinecap="round" />
+    </Svg>
+  );
+}
+
+function IconMoon({ color }: { color: string }) {
+  return (
+    <Svg width={ICON_SIZE} height={ICON_SIZE} viewBox="0 0 22 22">
+      <Path
+        d="M17.5 13.2 A7.5 7.5 0 1 1 8.8 4.5 A6 6 0 0 0 17.5 13.2 Z"
+        fill={color}
+      />
+    </Svg>
+  );
+}
+
+function IconProfile({ color }: { color: string }) {
+  return (
+    <Svg width={ICON_SIZE} height={ICON_SIZE} viewBox="0 0 22 22">
+      <Circle cx={11} cy={11} r={9} stroke={color} strokeWidth={1.5} fill="none" />
+      <Circle cx={11} cy={9}  r={2.6} fill={color} />
+      <Path
+        d="M5.4 17.5 C6.3 14.9 8.4 13.7 11 13.7 C13.6 13.7 15.7 14.9 16.6 17.5"
+        stroke={color}
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        fill="none"
+      />
+    </Svg>
+  );
+}
+
+export function AppHeaderV2({ onProfilePress, onDemoInfoPress }: AppHeaderV2Props) {
+  const { colors, isDark, toggle } = useTheme();
+  const iconColor = colors.text;
+
+  return (
+    <View
+      style={[
+        styles.root,
+        {
+          borderBottomColor: colors.borderSubtle,
+          paddingTop: ANDROID_TOP_INSET + spacing.md,
+        },
+      ]}
+    >
+      <View style={styles.inner}>
+        <View style={styles.brandRow}>
+          <Text style={[styles.brandName, { color: colors.text }]}>{prototypeCopy.appName}</Text>
+          <Text style={[styles.brandSub, { color: colors.textSubtle }]}>{prototypeCopy.prototypeSub}</Text>
+        </View>
+
+        <View style={styles.controls}>
+          <Pressable
+            onPress={onDemoInfoPress}
+            style={styles.iconBtn}
+            accessibilityLabel="About demo data"
+            accessibilityRole="button"
+            hitSlop={10}
+          >
+            <IconInfo color={iconColor} />
+          </Pressable>
+          <Pressable
+            onPress={toggle}
+            style={styles.iconBtn}
+            accessibilityLabel={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+            accessibilityRole="button"
+            hitSlop={10}
+          >
+            {isDark ? <IconSun color={iconColor} /> : <IconMoon color={iconColor} />}
+          </Pressable>
+          <Pressable
+            onPress={onProfilePress}
+            style={styles.iconBtn}
+            accessibilityLabel="Open profile"
+            accessibilityRole="button"
+            hitSlop={10}
+          >
+            <IconProfile color={iconColor} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: layout.screenPaddingH,
+    paddingBottom: spacing.md,
+  },
+  inner: {
+    maxWidth: layout.maxWidth,
+    width: '100%',
+    alignSelf: 'center',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  brandRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: spacing.sm,
+  },
+  brandName: {
+    fontSize: typography.heroName,
+    fontWeight: '700',
+    letterSpacing: -0.8,
+    lineHeight: 30,
+  },
+  brandSub: {
+    fontSize: typography.caption,
+    fontWeight: '500',
+    letterSpacing: 0.8,
+    lineHeight: 16,
+    opacity: 0.42,
+    textTransform: 'lowercase',
+  },
+  controls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  iconBtn: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/apps/mobile/prototypes/v2/src/data/copy.ts
+++ b/apps/mobile/prototypes/v2/src/data/copy.ts
@@ -1,0 +1,60 @@
+export const prototypeCopy = {
+  // Identity
+  appName: 'One L1fe',
+  prototypeSub: 'v2',
+
+  // Demo info modal
+  demoInfoTitle: 'Demo data',
+  demoInfoBody:
+    'Preset values are illustrative demo data. Local edits may be stored on this device. Real-source connections are active development work.',
+  demoInfoDismiss: 'Got it',
+  demoInfoConnectCta: 'Connect a source →',
+  demoInfoConnectHelper: 'Manage Health Connect, wearable data, and Blood Panels from Profile.',
+
+  // Status labels
+  available: 'Available',
+  notAvailable: 'Not available',
+  needsAttention: 'Review',
+  planned: 'Planned',
+
+  // Score card
+  readinessInterpretation: 'One L1fe Score',
+  readinessInterpretationSub:
+    'Use as planning context, not medical advice. Real-data scoring is not active yet.',
+  readinessScoreLabel: 'Score',
+  dataCoverageLabel: 'Data coverage',
+
+  // Sections
+  sectionSignals: 'Training signals',
+  sectionBlood: 'Blood panels',
+  sectionCoaching: 'Next Actions',
+  sectionTrend: 'One L1fe Score Trend',
+  sectionNotes: 'Ideas & Notes',
+  sectionTodaySignals: "Today's Signals",
+  sectionRecommendations: 'Recommendations',
+
+  // Signal status glyphs
+  signalGlyphs: {
+    available: '•',
+    needs_attention: '•',
+    not_available: '◦',
+  } as Record<string, string>,
+
+  // Blood panels
+  bloodPanelCount: (n: number) => `${n} panel${n === 1 ? '' : 's'} on file`,
+  bloodPanelsViewCta: 'View blood panels',
+  bloodPanelsUploadPdf: 'Upload PDF',
+  bloodPanelsUploadPhoto: 'Upload photo',
+  bloodPanelsProtoNote: 'Upload not active yet',
+
+  // Notes
+  notesPlaceholder: 'Add a thought, observation, or question…',
+  notesSaveLabel: 'Save',
+  notesDiscardLabel: 'Discard',
+  notesEmptyHint: 'Tap to add an idea, observation, or question.',
+  notesEmptyAddLabel: '+ Add note',
+
+  // Safety
+  safetyNote:
+    'One L1fe organises training and health context. It does not diagnose, treat, or replace professional care.',
+} as const;

--- a/apps/mobile/prototypes/v2/src/theme/ThemeContext.tsx
+++ b/apps/mobile/prototypes/v2/src/theme/ThemeContext.tsx
@@ -1,0 +1,50 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import { darkColors, lightColors, type ThemeColors } from './marathonTheme';
+
+type ColorScheme = 'light' | 'dark';
+
+type ThemeContextValue = {
+  colors: ThemeColors;
+  scheme: ColorScheme;
+  isDark: boolean;
+  toggle: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  // Light is the default.
+  const [scheme, setScheme] = useState<ColorScheme>('light');
+
+  const toggle = useCallback(() => {
+    setScheme((s) => (s === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      colors: scheme === 'dark' ? darkColors : lightColors,
+      scheme,
+      isDark: scheme === 'dark',
+      toggle,
+    }),
+    [scheme, toggle],
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used inside ThemeProvider');
+  }
+  return ctx;
+}

--- a/apps/mobile/prototypes/v2/src/theme/marathonTheme.ts
+++ b/apps/mobile/prototypes/v2/src/theme/marathonTheme.ts
@@ -1,0 +1,145 @@
+// One L1fe — V2 — Design tokens
+// Single source of truth for Android and Web in the v2 workspace.
+
+export const spacing = {
+  xs:   4,
+  sm:   8,
+  md:   12,
+  lg:   16,
+  xl:   24,
+  xxl:  32,
+  xxxl: 56,
+} as const;
+
+export const radius = {
+  sm:   6,
+  md:   10,
+  lg:   14,
+  xl:   20,
+  pill: 99,
+} as const;
+
+export const typography = {
+  heroName:            26,
+  heroSub:             12,
+  heroInterpretation:  19,
+  subtitle:            15,
+  body:                14,
+  bodySmall:           13,
+  caption:             11,
+  micro:               10,
+} as const;
+
+export const lineHeights = {
+  heroInterpretation: 25,
+  body:               21,
+  bodySmall:          19,
+  caption:            16,
+} as const;
+
+export const layout = {
+  screenPaddingH: 18,
+  maxWidth:       480,
+} as const;
+
+export type ThemeColors = {
+  background:        string;
+  surface:           string;
+  surfaceElevated:   string;
+  border:            string;
+  borderSubtle:      string;
+  text:              string;
+  textMuted:         string;
+  textSubtle:        string;
+  accent:            string;
+  accentBorder:      string;
+  accentSoft:        string;
+  positive:          string;
+  warning:           string;
+  warningSoft:       string;
+  danger:            string;
+  scoreStrong:       string;
+  scoreStrongSoft:   string;
+  scoreSteady:       string;
+  scoreSteadySoft:   string;
+  scoreSoft:         string;
+  scoreSoftSoft:     string;
+  scoreLow:          string;
+  scoreLowSoft:      string;
+  ringTrack:         string;
+  ringProgress:      string;
+  progressTrack:     string;
+  profileSectionBg:  string;
+  profileRowBorder:  string;
+  demoBanner:        string;
+  demoBannerBorder:  string;
+  statusBar:         'dark' | 'light';
+};
+
+export const lightColors: ThemeColors = {
+  background:       '#F9F7F4',
+  surface:          '#F3F0EB',
+  surfaceElevated:  '#FFFFFF',
+  border:           'rgba(60,40,20,0.10)',
+  borderSubtle:     'rgba(60,40,20,0.055)',
+  text:             '#1C1917',
+  textMuted:        '#5A5249',
+  textSubtle:       '#9A928A',
+  accent:           '#C4612C',
+  accentBorder:     'rgba(196,97,44,0.25)',
+  accentSoft:       'rgba(196,97,44,0.06)',
+  positive:         '#3A7A58',
+  warning:          '#A86E28',
+  warningSoft:      'rgba(168,110,40,0.08)',
+  danger:           '#993636',
+  scoreStrong:      '#3A7A58',
+  scoreStrongSoft:  'rgba(58,122,88,0.10)',
+  scoreSteady:      '#B07B1E',
+  scoreSteadySoft:  'rgba(176,123,30,0.10)',
+  scoreSoft:        '#A86E28',
+  scoreSoftSoft:    'rgba(168,110,40,0.10)',
+  scoreLow:         '#993636',
+  scoreLowSoft:     'rgba(153,54,54,0.08)',
+  ringTrack:        '#EDE8E2',
+  ringProgress:     '#C4612C',
+  progressTrack:    '#EDE8E2',
+  profileSectionBg: '#FFFFFF',
+  profileRowBorder: 'rgba(60,40,20,0.06)',
+  demoBanner:       '#FEF7F2',
+  demoBannerBorder: 'rgba(196,97,44,0.18)',
+  statusBar:        'dark',
+};
+
+export const darkColors: ThemeColors = {
+  background:       '#0A0A0B',
+  surface:          '#111113',
+  surfaceElevated:  '#141416',
+  border:           'rgba(255,255,255,0.07)',
+  borderSubtle:     'rgba(255,255,255,0.035)',
+  text:             '#F2EFEA',
+  textMuted:        '#A8A29A',
+  textSubtle:       '#6E6862',
+  accent:           '#E07A45',
+  accentBorder:     'rgba(224,122,69,0.32)',
+  accentSoft:       'rgba(224,122,69,0.10)',
+  positive:         '#5BAE7C',
+  warning:          '#D69846',
+  warningSoft:      'rgba(214,152,70,0.12)',
+  danger:           '#C25A5A',
+  scoreStrong:      '#5BAE7C',
+  scoreStrongSoft:  'rgba(91,174,124,0.12)',
+  scoreSteady:      '#D69846',
+  scoreSteadySoft:  'rgba(214,152,70,0.12)',
+  scoreSoft:        '#D87A45',
+  scoreSoftSoft:    'rgba(216,122,69,0.10)',
+  scoreLow:         '#C25A5A',
+  scoreLowSoft:     'rgba(194,90,90,0.10)',
+  ringTrack:        '#1F1F22',
+  ringProgress:     '#E07A45',
+  progressTrack:    '#1F1F22',
+  profileSectionBg: '#141416',
+  profileRowBorder: 'rgba(255,255,255,0.05)',
+  demoBanner:       '#161616',
+  demoBannerBorder: 'rgba(224,122,69,0.22)',
+  statusBar:        'light',
+};

--- a/apps/mobile/prototypes/v2/src/theme/useWebBackground.ts
+++ b/apps/mobile/prototypes/v2/src/theme/useWebBackground.ts
@@ -1,0 +1,22 @@
+/**
+ * useWebBackground
+ * Tiny helper — web only.
+ * Sets document.body and html background-color on mount so the page
+ * background matches the app theme instead of flashing white.
+ * No-op on Android/iOS.
+ */
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
+
+export function useWebBackground(backgroundColor: string) {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const prev = document.body.style.backgroundColor;
+    document.body.style.backgroundColor = backgroundColor;
+    document.documentElement.style.backgroundColor = backgroundColor;
+    return () => {
+      document.body.style.backgroundColor = prev;
+      document.documentElement.style.backgroundColor = prev;
+    };
+  }, [backgroundColor]);
+}


### PR DESCRIPTION
## Summary
- Restores `v1-marathon` as the prior Marathon snapshot identity.
- Adds `apps/mobile/prototypes/v2/` as the active One L1fe v2 workspace.
- Routes `apps/mobile/App.tsx` to `prototypes/v2/src/OneL1feV2Screen.tsx`.
- Adds dedicated v2 copy/header/theme/web-background helper.
- Removes Ionicons from the v2 root modal and initializes Health Connect status to `unavailable` instead of `error`.
- Updates `CHECKPOINT.md`, `MEMORY.md`, and `apps/mobile/README.md` to document v2 as active.

## Merge blocker
- Run `npm --prefix apps/mobile run typecheck` before merge.
- Update branch from latest `main` if GitHub reports it behind.

## Accepted architecture for this PR
v2 may temporarily import unchanged modules from `v1-marathon` until those modules need v2-specific behavior.

Rule after merge:
- Work only in `apps/mobile/prototypes/v2/` for current product changes.
- Fork a v1 module into `v2/` before changing its behavior for v2.
- Do not move or delete `v1-marathon` until v2 device QA passes.

## Future cleanup, not required for this merge
Target later structure:

```text
apps/mobile/prototypes/
├─ v2/                         active app
└─ archive/
   └─ v1-marathon/             frozen snapshot
```

Only do this once v2 no longer imports from v1.

## Validation
Not run here:
- `npm --prefix apps/mobile run typecheck`
- EAS preview build
- Android device QA
