### PR TITLE
feat(mobile): TrendsScreen MVP and shared state lift

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -17,13 +17,14 @@ scope: repo
 - Canonical app entry: `apps/mobile/App.tsx -> apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx`.
 - `apps/mobile/prototypes/v1-marathon/` remains as the previous Marathon-focused snapshot.
 - v2 home has its own `HomeScreen` and forked components under `apps/mobile/prototypes/v2/src/`.
-- v2 home display data is centralized in `homeDataAdapter.ts` / `homeTypes.ts`; `HomeScreen` renders `HomeDisplayData` and owns interaction state.
-- v2 shell has bottom nav with four tabs: Home, Trends (placeholder), Insights (placeholder), Profile (legacy).
+- v2 display data is centralized in `homeDataAdapter.ts` / `homeTypes.ts`; state (mode, timeRange, customRange) is owned by `V2Shell` in `OneL1feV2Screen.tsx` and passed to both `HomeScreen` and `TrendsScreen`.
+- `TrendsScreen` renders One L1fe Score trend, Recovery metrics (Recovery, Sleep, HRV, Resting HR), and Activity metrics (Activity, Steps, Training, Calories) using existing `HomeDisplayData`. No new data sources.
+- v2 shell has bottom nav with four tabs: Home, Trends (MVP live), Insights (placeholder), Profile (legacy).
 - v2 home passed Android emulator QA on Pixel 9 Pro AVD (Android 15 / API 35).
 - v2 may temporarily import unchanged non-home screens/data from `v1-marathon`; fork before changing v2-specific behavior.
 - App config: `apps/mobile/app.json`. Expo `0.2.2`; Android `versionCode: 4`; `minSdkVersion: 26`.
 - Health Connect: foreground display-only. No background sync, no Supabase write, no score recomputation.
-- CI green on latest dependency and workflow update.
+- CI green on latest main.
 
 ## Run
 
@@ -35,10 +36,11 @@ npx expo start --clear
 
 ## Recently completed
 
-- PR #115: repo truth-source cleanup merged.
+- PR #115: repo truth-source cleanup.
 - PR #109: `supabase/setup-cli@v2`, CI hygiene fixes.
-- PR #117: v2 home redesign + data adapter boundary merged (squash).
-- Guardrail tests added for `getHomeDisplayData` in `test/v2-home-adapter-guardrails` — PR pending.
+- PR #117: v2 home redesign + data adapter boundary merged.
+- PR #118: `homeDataAdapter` guardrail tests (37 assertions) merged.
+- feat/trends-screen-mvp: TrendsScreen MVP + shared state lift — PR pending.
 
 ## Working rules
 
@@ -55,12 +57,13 @@ npx expo start --clear
 ## Current blockers
 
 - Physical OnePlus-class Android device QA not yet run.
+- `HomeScreen` still owns some internal state for Custom range picker UI — should remain there; only mode/timeRange/customRange values are lifted.
 - Full-app shell files not yet reference-audited for safe deletion.
 - Native Android version values drift from `app.json` unless regenerated intentionally.
 
 ## Next steps
 
-1. Merge `test/v2-home-adapter-guardrails` PR after CI.
+1. Merge `feat/trends-screen-mvp` PR after CI.
 2. Run physical OnePlus-class Android QA.
 3. Extract pure Dot/Score domain work from issue #116 (no UI/routing changes).
 4. Start Blood Intake / Scanner research as v2 work.

--- a/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
+++ b/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
@@ -16,7 +16,12 @@ import { BloodResultsScreen } from '../../v1-marathon/src/screens/BloodResultsSc
 import { ThemeProvider as LegacyV1ThemeProvider } from '../../v1-marathon/src/theme/ThemeContext';
 import { BottomNavV2, type BottomTabKey } from './components/BottomNavV2';
 import { HomeScreen } from './screens/HomeScreen';
+import { TrendsScreen } from './screens/TrendsScreen';
 import { prototypeCopy } from './data/copy';
+import { getHomeDisplayData } from './data/homeDataAdapter';
+import type { HomeDataMode } from './data/homeTypes';
+import { DEFAULT_TIME_RANGE } from './types/timeRange';
+import type { CustomRange, TimeRange } from './types/timeRange';
 import { layout, lineHeights, radius, spacing, typography } from './theme/marathonTheme';
 
 export function OneL1feV2Screen() {
@@ -34,7 +39,20 @@ function V2Shell() {
   const [activeView, setActiveView]           = useState<ActiveView>('home');
   const [demoInfoVisible, setDemoInfoVisible] = useState(false);
 
+  // Shared data state — owned here so Home and Trends stay in sync
+  const [dataMode, setDataMode]         = useState<HomeDataMode>('demo');
+  const [timeRange, setTimeRange]       = useState<TimeRange>(DEFAULT_TIME_RANGE);
+  const [customRange, setCustomRange]   = useState<CustomRange>({ start: null, end: null });
+  const [bloodPanels]                   = useState([]);
+
   useWebBackground(colors.background);
+
+  const displayData = getHomeDisplayData({
+    mode: dataMode,
+    timeRange,
+    customRange,
+    bloodPanels,
+  });
 
   function openProfile() {
     setDemoInfoVisible(false);
@@ -67,10 +85,7 @@ function V2Shell() {
               />
             </LegacyV1ThemeProvider>
           ) : activeView === 'trends' ? (
-            <TopLevelPlaceholder
-              title="Trends"
-              subtitle="Detailed trend views are coming next."
-            />
+            <TrendsScreen data={displayData} />
           ) : activeView === 'insights' ? (
             <TopLevelPlaceholder
               title="Insights"
@@ -78,6 +93,13 @@ function V2Shell() {
             />
           ) : (
             <HomeScreen
+              dataMode={dataMode}
+              timeRange={timeRange}
+              customRange={customRange}
+              bloodPanels={bloodPanels}
+              onDataModeChange={setDataMode}
+              onTimeRangeSelect={setTimeRange}
+              onCustomRangeChange={setCustomRange}
               onProfilePress={() => setActiveView('profile')}
               onDemoInfoPress={() => setDemoInfoVisible(true)}
               onViewBloodPanels={() => setActiveView('blood')}

--- a/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
+++ b/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
@@ -39,19 +39,22 @@ function V2Shell() {
   const [activeView, setActiveView]           = useState<ActiveView>('home');
   const [demoInfoVisible, setDemoInfoVisible] = useState(false);
 
-  // Shared data state — owned here so Home and Trends stay in sync
-  const [dataMode, setDataMode]         = useState<HomeDataMode>('demo');
-  const [timeRange, setTimeRange]       = useState<TimeRange>(DEFAULT_TIME_RANGE);
-  const [customRange, setCustomRange]   = useState<CustomRange>({ start: null, end: null });
-  const [bloodPanels]                   = useState([]);
+  // Shared data state for Trends (and any future cross-tab consumer).
+  // HomeScreen manages its own internal copy; Trends reads from here.
+  const [dataMode, setDataMode]       = useState<HomeDataMode>('demo');
+  const [timeRange, setTimeRange]     = useState<TimeRange>(DEFAULT_TIME_RANGE);
+  const [customRange, setCustomRange] = useState<CustomRange>({ start: null, end: null });
 
   useWebBackground(colors.background);
 
-  const displayData = getHomeDisplayData({
+  // Compute display data for tabs that consume it (Trends, future Insights).
+  // HomeScreen computes its own copy internally to keep its adapter
+  // boundary intact (bloodPanels, HealthConnect status, etc.).
+  const trendsData = getHomeDisplayData({
     mode: dataMode,
     timeRange,
     customRange,
-    bloodPanels,
+    bloodPanels: [],
   });
 
   function openProfile() {
@@ -85,21 +88,15 @@ function V2Shell() {
               />
             </LegacyV1ThemeProvider>
           ) : activeView === 'trends' ? (
-            <TrendsScreen data={displayData} />
+            <TrendsScreen data={trendsData} />
           ) : activeView === 'insights' ? (
             <TopLevelPlaceholder
               title="Insights"
               subtitle="Insights will summarize patterns from your connected data."
             />
           ) : (
+            // HomeScreen owns its own state (bloodPanels, HealthConnect, mode, range, etc.)
             <HomeScreen
-              dataMode={dataMode}
-              timeRange={timeRange}
-              customRange={customRange}
-              bloodPanels={bloodPanels}
-              onDataModeChange={setDataMode}
-              onTimeRangeSelect={setTimeRange}
-              onCustomRangeChange={setCustomRange}
               onProfilePress={() => setActiveView('profile')}
               onDemoInfoPress={() => setDemoInfoVisible(true)}
               onViewBloodPanels={() => setActiveView('blood')}

--- a/apps/mobile/prototypes/v2/src/screens/TrendsScreen.tsx
+++ b/apps/mobile/prototypes/v2/src/screens/TrendsScreen.tsx
@@ -1,0 +1,389 @@
+/**
+ * TrendsScreen — v2 MVP
+ *
+ * Renders trend charts for Score, Recovery, and Activity using existing
+ * HomeDisplayData from getHomeDisplayData. No new data sources.
+ */
+import React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '../theme/ThemeContext';
+import { layout, lineHeights, radius, spacing, typography } from '../theme/marathonTheme';
+import type { HomeDisplayData, HomeTrendMetric } from '../data/homeTypes';
+import type { HomeChartPoint } from '../data/homeTypes';
+
+// ---------------------------------------------------------------------------
+// Minimal inline SVG-free chart primitives (bar + line) reusing RN only
+// ---------------------------------------------------------------------------
+
+const CHART_H = 72;
+const BAR_MIN_H = 3;
+
+function normalize(points: HomeChartPoint[]): number[] {
+  if (!points.length) return [];
+  const values = points.map((p) => p.value);
+  const max = Math.max(...values, 1);
+  return values.map((v) => v / max);
+}
+
+function BarChart({
+  data,
+  color,
+}: {
+  data: HomeChartPoint[];
+  color: string;
+}) {
+  const ratios = normalize(data);
+  return (
+    <View style={chart.root}>
+      {ratios.map((ratio, i) => (
+        <View key={i} style={chart.barWrap}>
+          <View
+            style={[
+              chart.bar,
+              {
+                height: Math.max(BAR_MIN_H, ratio * CHART_H),
+                backgroundColor: color,
+                opacity: 0.72 + ratio * 0.28,
+              },
+            ]}
+          />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function LineChart({
+  data,
+  color,
+}: {
+  data: HomeChartPoint[];
+  color: string;
+}) {
+  // Render as connected dots via thin bars for RN-only compatibility
+  const ratios = normalize(data);
+  return (
+    <View style={chart.root}>
+      {ratios.map((ratio, i) => (
+        <View key={i} style={chart.lineWrap}>
+          <View style={{ flex: 1 }} />
+          <View
+            style={[
+              chart.lineDot,
+              {
+                marginBottom: ratio * (CHART_H - 8),
+                backgroundColor: color,
+              },
+            ]}
+          />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const chart = StyleSheet.create({
+  root: {
+    height: CHART_H,
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 3,
+  },
+  barWrap: {
+    flex: 1,
+    height: CHART_H,
+    justifyContent: 'flex-end',
+  },
+  bar: {
+    width: '100%',
+    borderRadius: 3,
+    minHeight: BAR_MIN_H,
+  },
+  lineWrap: {
+    flex: 1,
+    height: CHART_H,
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+  },
+  lineDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Metric card
+// ---------------------------------------------------------------------------
+
+function MetricCard({
+  metric,
+  accentColor,
+}: {
+  metric: HomeTrendMetric;
+  accentColor: string;
+}) {
+  const { colors } = useTheme();
+  const hasData = metric.data.length > 0;
+
+  return (
+    <View
+      style={[
+        card.root,
+        { backgroundColor: colors.surfaceElevated, borderColor: colors.border },
+      ]}
+    >
+      <View style={card.header}>
+        <Text style={[card.label, { color: colors.textSubtle }]}>{metric.label}</Text>
+        {metric.value ? (
+          <View style={card.valueRow}>
+            <Text style={[card.value, { color: colors.text }]}>{metric.value}</Text>
+            {metric.delta !== null && (
+              <Text
+                style={[
+                  card.delta,
+                  { color: metric.delta >= 0 ? colors.scoreStrong : colors.textSubtle },
+                ]}
+              >
+                {metric.delta >= 0 ? `+${metric.delta}` : `${metric.delta}`}
+              </Text>
+            )}
+          </View>
+        ) : null}
+      </View>
+
+      {hasData ? (
+        metric.chartType === 'bar' ? (
+          <BarChart data={metric.data} color={accentColor} />
+        ) : (
+          <LineChart data={metric.data} color={accentColor} />
+        )
+      ) : (
+        <View style={card.empty}>
+          <Text style={[card.emptyText, { color: colors.textSubtle }]}>
+            {metric.emptyText || 'No data available.'}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const card = StyleSheet.create({
+  root: {
+    borderRadius: radius.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  label: {
+    fontSize: typography.caption,
+    fontWeight: '700',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  },
+  valueRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: spacing.xs,
+  },
+  value: {
+    fontSize: typography.body,
+    fontWeight: '700',
+  },
+  delta: {
+    fontSize: typography.caption,
+    fontWeight: '600',
+  },
+  empty: {
+    height: CHART_H,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyText: {
+    fontSize: typography.caption,
+    lineHeight: lineHeights.caption,
+    textAlign: 'center',
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Section header
+// ---------------------------------------------------------------------------
+
+function SectionHeader({ title }: { title: string }) {
+  const { colors } = useTheme();
+  return (
+    <Text style={[section.title, { color: colors.textSubtle }]}>{title}</Text>
+  );
+}
+
+const section = StyleSheet.create({
+  title: {
+    fontSize: typography.caption,
+    fontWeight: '800',
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+    paddingHorizontal: layout.screenPaddingH,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.xs,
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Score trend row (full-width line chart)
+// ---------------------------------------------------------------------------
+
+function ScoreTrendSection({ data }: { data: HomeDisplayData }) {
+  const { colors } = useTheme();
+  const trend = data.scoreTrend;
+
+  if (trend.isEmpty || !trend.series.length) {
+    return (
+      <View
+        style={[
+          scoreTrend.emptyCard,
+          { backgroundColor: colors.surfaceElevated, borderColor: colors.border },
+        ]}
+      >
+        <Text style={[scoreTrend.emptyText, { color: colors.textSubtle }]}>
+          {trend.emptyText || 'No score trend available yet.'}
+        </Text>
+      </View>
+    );
+  }
+
+  const scoreSeries = trend.series.find((s) => s.label === 'Score');
+  if (!scoreSeries || !scoreSeries.data.length) return null;
+
+  return (
+    <View
+      style={[
+        scoreTrend.card,
+        { backgroundColor: colors.surfaceElevated, borderColor: colors.border },
+      ]}
+    >
+      <View style={scoreTrend.header}>
+        <Text style={[scoreTrend.label, { color: colors.textSubtle }]}>One L1fe Score</Text>
+        <Text style={[scoreTrend.value, { color: colors.text }]}>
+          {data.score.overall !== null ? `${data.score.overall}` : '—'}
+        </Text>
+      </View>
+      <LineChart data={scoreSeries.data} color={colors.scoreStrong} />
+      <View style={scoreTrend.legend}>
+        {trend.series.map((s) => (
+          <Text key={s.label} style={[scoreTrend.legendItem, { color: colors.textSubtle }]}>
+            {s.label}
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const scoreTrend = StyleSheet.create({
+  card: {
+    marginHorizontal: layout.screenPaddingH,
+    borderRadius: radius.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  emptyCard: {
+    marginHorizontal: layout.screenPaddingH,
+    borderRadius: radius.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: spacing.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: CHART_H + spacing.md * 2,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  label: {
+    fontSize: typography.caption,
+    fontWeight: '700',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  },
+  value: {
+    fontSize: typography.body,
+    fontWeight: '700',
+  },
+  legend: {
+    flexDirection: 'row',
+    gap: spacing.md,
+  },
+  legendItem: {
+    fontSize: typography.micro,
+    fontWeight: '600',
+    letterSpacing: 0.3,
+  },
+  emptyText: {
+    fontSize: typography.caption,
+    lineHeight: lineHeights.caption,
+    textAlign: 'center',
+  },
+});
+
+// ---------------------------------------------------------------------------
+// TrendsScreen
+// ---------------------------------------------------------------------------
+
+export function TrendsScreen({ data }: { data: HomeDisplayData }) {
+  const { colors } = useTheme();
+  const rec = data.recoveryMetrics;
+  const act = data.activityMetrics;
+
+  const accentRecover = colors.scoreStrong;
+  const accentActivity = colors.accent ?? colors.scoreStrong;
+
+  return (
+    <ScrollView
+      style={{ flex: 1, backgroundColor: colors.background }}
+      contentContainerStyle={trends.content}
+      showsVerticalScrollIndicator={false}
+    >
+      {/* Page title */}
+      <View style={[trends.pageHeader, { borderBottomColor: colors.borderSubtle }]}>
+        <Text style={[trends.pageTitle, { color: colors.text }]}>Trends</Text>
+        <Text style={[trends.pageMode, { color: colors.textSubtle }]}>
+          {data.isDemo ? 'Demo' : 'User Data'}
+        </Text>
+      </View>
+
+      {/* Score */}
+      <SectionHeader title="Score" />
+      <ScoreTrendSection data={data} />
+
+      {/* Recovery */}
+      <SectionHeader title="Recovery" />
+      <View style={trends.grid}>
+        <MetricCard metric={rec.recovery} accentColor={accentRecover} />
+        <MetricCard metric={rec.sleep}    accentColor={accentRecover} />
+        <MetricCard metric={rec.hrv}      accentColor={accentRecover} />
+        <MetricCard metric={rec.restingHr} accentColor={accentRecover} />
+      </View>
+
+      {/* Activity */}
+      <SectionHeader title="Activity" />
+      <View style={trends.grid}>
+        <MetricCard metric={act.activity} accentColor={accentActivity} />
+        <MetricCard metric={act.steps}    accentColor={accentActivity} />
+        <MetricCard metric={act.training} accentColor={accentActivity} />
+        <MetricCard metric={act.calories} accentColor={accentActivity} />
+      </View>
+
+      <View style={{ height: spacing.xl }} />
+    </ScrollView>
+  );
+}

--- a/apps/mobile/prototypes/v2/src/screens/TrendsScreen.tsx
+++ b/apps/mobile/prototypes/v2/src/screens/TrendsScreen.tsx
@@ -8,15 +8,18 @@ import React from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '../theme/ThemeContext';
 import { layout, lineHeights, radius, spacing, typography } from '../theme/marathonTheme';
-import type { HomeDisplayData, HomeTrendMetric } from '../data/homeTypes';
-import type { HomeChartPoint } from '../data/homeTypes';
+import type { HomeDisplayData, HomeTrendMetric, HomeChartPoint } from '../data/homeTypes';
 
 // ---------------------------------------------------------------------------
-// Minimal inline SVG-free chart primitives (bar + line) reusing RN only
+// Constants
 // ---------------------------------------------------------------------------
 
 const CHART_H = 72;
 const BAR_MIN_H = 3;
+
+// ---------------------------------------------------------------------------
+// Chart helpers
+// ---------------------------------------------------------------------------
 
 function normalize(points: HomeChartPoint[]): number[] {
   if (!points.length) return [];
@@ -25,21 +28,15 @@ function normalize(points: HomeChartPoint[]): number[] {
   return values.map((v) => v / max);
 }
 
-function BarChart({
-  data,
-  color,
-}: {
-  data: HomeChartPoint[];
-  color: string;
-}) {
+function BarChart({ data, color }: { data: HomeChartPoint[]; color: string }) {
   const ratios = normalize(data);
   return (
-    <View style={chart.root}>
+    <View style={chartStyles.root}>
       {ratios.map((ratio, i) => (
-        <View key={i} style={chart.barWrap}>
+        <View key={i} style={chartStyles.barWrap}>
           <View
             style={[
-              chart.bar,
+              chartStyles.bar,
               {
                 height: Math.max(BAR_MIN_H, ratio * CHART_H),
                 backgroundColor: color,
@@ -53,23 +50,16 @@ function BarChart({
   );
 }
 
-function LineChart({
-  data,
-  color,
-}: {
-  data: HomeChartPoint[];
-  color: string;
-}) {
-  // Render as connected dots via thin bars for RN-only compatibility
+function LineChart({ data, color }: { data: HomeChartPoint[]; color: string }) {
   const ratios = normalize(data);
   return (
-    <View style={chart.root}>
+    <View style={chartStyles.root}>
       {ratios.map((ratio, i) => (
-        <View key={i} style={chart.lineWrap}>
+        <View key={i} style={chartStyles.lineWrap}>
           <View style={{ flex: 1 }} />
           <View
             style={[
-              chart.lineDot,
+              chartStyles.lineDot,
               {
                 marginBottom: ratio * (CHART_H - 8),
                 backgroundColor: color,
@@ -82,7 +72,7 @@ function LineChart({
   );
 }
 
-const chart = StyleSheet.create({
+const chartStyles = StyleSheet.create({
   root: {
     height: CHART_H,
     flexDirection: 'row',
@@ -130,19 +120,19 @@ function MetricCard({
   return (
     <View
       style={[
-        card.root,
+        cardStyles.root,
         { backgroundColor: colors.surfaceElevated, borderColor: colors.border },
       ]}
     >
-      <View style={card.header}>
-        <Text style={[card.label, { color: colors.textSubtle }]}>{metric.label}</Text>
+      <View style={cardStyles.header}>
+        <Text style={[cardStyles.label, { color: colors.textSubtle }]}>{metric.label}</Text>
         {metric.value ? (
-          <View style={card.valueRow}>
-            <Text style={[card.value, { color: colors.text }]}>{metric.value}</Text>
+          <View style={cardStyles.valueRow}>
+            <Text style={[cardStyles.value, { color: colors.text }]}>{metric.value}</Text>
             {metric.delta !== null && (
               <Text
                 style={[
-                  card.delta,
+                  cardStyles.delta,
                   { color: metric.delta >= 0 ? colors.scoreStrong : colors.textSubtle },
                 ]}
               >
@@ -160,8 +150,8 @@ function MetricCard({
           <LineChart data={metric.data} color={accentColor} />
         )
       ) : (
-        <View style={card.empty}>
-          <Text style={[card.emptyText, { color: colors.textSubtle }]}>
+        <View style={cardStyles.empty}>
+          <Text style={[cardStyles.emptyText, { color: colors.textSubtle }]}>
             {metric.emptyText || 'No data available.'}
           </Text>
         </View>
@@ -170,7 +160,7 @@ function MetricCard({
   );
 }
 
-const card = StyleSheet.create({
+const cardStyles = StyleSheet.create({
   root: {
     borderRadius: radius.lg,
     borderWidth: StyleSheet.hairlineWidth,
@@ -217,14 +207,7 @@ const card = StyleSheet.create({
 // Section header
 // ---------------------------------------------------------------------------
 
-function SectionHeader({ title }: { title: string }) {
-  const { colors } = useTheme();
-  return (
-    <Text style={[section.title, { color: colors.textSubtle }]}>{title}</Text>
-  );
-}
-
-const section = StyleSheet.create({
+const sectionStyles = StyleSheet.create({
   title: {
     fontSize: typography.caption,
     fontWeight: '800',
@@ -236,58 +219,18 @@ const section = StyleSheet.create({
   },
 });
 
-// ---------------------------------------------------------------------------
-// Score trend row (full-width line chart)
-// ---------------------------------------------------------------------------
-
-function ScoreTrendSection({ data }: { data: HomeDisplayData }) {
+function SectionHeader({ title }: { title: string }) {
   const { colors } = useTheme();
-  const trend = data.scoreTrend;
-
-  if (trend.isEmpty || !trend.series.length) {
-    return (
-      <View
-        style={[
-          scoreTrend.emptyCard,
-          { backgroundColor: colors.surfaceElevated, borderColor: colors.border },
-        ]}
-      >
-        <Text style={[scoreTrend.emptyText, { color: colors.textSubtle }]}>
-          {trend.emptyText || 'No score trend available yet.'}
-        </Text>
-      </View>
-    );
-  }
-
-  const scoreSeries = trend.series.find((s) => s.label === 'Score');
-  if (!scoreSeries || !scoreSeries.data.length) return null;
-
   return (
-    <View
-      style={[
-        scoreTrend.card,
-        { backgroundColor: colors.surfaceElevated, borderColor: colors.border },
-      ]}
-    >
-      <View style={scoreTrend.header}>
-        <Text style={[scoreTrend.label, { color: colors.textSubtle }]}>One L1fe Score</Text>
-        <Text style={[scoreTrend.value, { color: colors.text }]}>
-          {data.score.overall !== null ? `${data.score.overall}` : '—'}
-        </Text>
-      </View>
-      <LineChart data={scoreSeries.data} color={colors.scoreStrong} />
-      <View style={scoreTrend.legend}>
-        {trend.series.map((s) => (
-          <Text key={s.label} style={[scoreTrend.legendItem, { color: colors.textSubtle }]}>
-            {s.label}
-          </Text>
-        ))}
-      </View>
-    </View>
+    <Text style={[sectionStyles.title, { color: colors.textSubtle }]}>{title}</Text>
   );
 }
 
-const scoreTrend = StyleSheet.create({
+// ---------------------------------------------------------------------------
+// Score trend section
+// ---------------------------------------------------------------------------
+
+const scoreTrendStyles = StyleSheet.create({
   card: {
     marginHorizontal: layout.screenPaddingH,
     borderRadius: radius.lg,
@@ -335,6 +278,87 @@ const scoreTrend = StyleSheet.create({
   },
 });
 
+function ScoreTrendSection({ data }: { data: HomeDisplayData }) {
+  const { colors } = useTheme();
+  const trend = data.scoreTrend;
+
+  if (trend.isEmpty || !trend.series.length) {
+    return (
+      <View
+        style={[
+          scoreTrendStyles.emptyCard,
+          { backgroundColor: colors.surfaceElevated, borderColor: colors.border },
+        ]}
+      >
+        <Text style={[scoreTrendStyles.emptyText, { color: colors.textSubtle }]}>
+          {trend.emptyText || 'No score trend available yet.'}
+        </Text>
+      </View>
+    );
+  }
+
+  const scoreSeries = trend.series.find((s) => s.label === 'Score');
+  if (!scoreSeries || !scoreSeries.data.length) return null;
+
+  return (
+    <View
+      style={[
+        scoreTrendStyles.card,
+        { backgroundColor: colors.surfaceElevated, borderColor: colors.border },
+      ]}
+    >
+      <View style={scoreTrendStyles.header}>
+        <Text style={[scoreTrendStyles.label, { color: colors.textSubtle }]}>One L1fe Score</Text>
+        <Text style={[scoreTrendStyles.value, { color: colors.text }]}>
+          {data.score.overall !== null ? `${data.score.overall}` : '—'}
+        </Text>
+      </View>
+      <LineChart data={scoreSeries.data} color={colors.scoreStrong} />
+      <View style={scoreTrendStyles.legend}>
+        {trend.series.map((s) => (
+          <Text key={s.label} style={[scoreTrendStyles.legendItem, { color: colors.textSubtle }]}>
+            {s.label}
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page-level styles
+// ---------------------------------------------------------------------------
+
+const trendsStyles = StyleSheet.create({
+  content: {
+    paddingBottom: spacing.xxxl,
+  },
+  pageHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: layout.screenPaddingH,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  pageTitle: {
+    fontSize: typography.heroName,
+    fontWeight: '800',
+    letterSpacing: -0.4,
+    lineHeight: 32,
+  },
+  pageMode: {
+    fontSize: typography.caption,
+    fontWeight: '700',
+    letterSpacing: 0.3,
+  },
+  grid: {
+    paddingHorizontal: layout.screenPaddingH,
+    gap: spacing.sm,
+  },
+});
+
 // ---------------------------------------------------------------------------
 // TrendsScreen
 // ---------------------------------------------------------------------------
@@ -345,18 +369,18 @@ export function TrendsScreen({ data }: { data: HomeDisplayData }) {
   const act = data.activityMetrics;
 
   const accentRecover = colors.scoreStrong;
-  const accentActivity = colors.accent ?? colors.scoreStrong;
+  const accentActivity = (colors as Record<string, string>).accent ?? colors.scoreStrong;
 
   return (
     <ScrollView
       style={{ flex: 1, backgroundColor: colors.background }}
-      contentContainerStyle={trends.content}
+      contentContainerStyle={trendsStyles.content}
       showsVerticalScrollIndicator={false}
     >
       {/* Page title */}
-      <View style={[trends.pageHeader, { borderBottomColor: colors.borderSubtle }]}>
-        <Text style={[trends.pageTitle, { color: colors.text }]}>Trends</Text>
-        <Text style={[trends.pageMode, { color: colors.textSubtle }]}>
+      <View style={[trendsStyles.pageHeader, { borderBottomColor: colors.borderSubtle }]}>
+        <Text style={[trendsStyles.pageTitle, { color: colors.text }]}>Trends</Text>
+        <Text style={[trendsStyles.pageMode, { color: colors.textSubtle }]}>
           {data.isDemo ? 'Demo' : 'User Data'}
         </Text>
       </View>
@@ -367,20 +391,20 @@ export function TrendsScreen({ data }: { data: HomeDisplayData }) {
 
       {/* Recovery */}
       <SectionHeader title="Recovery" />
-      <View style={trends.grid}>
-        <MetricCard metric={rec.recovery} accentColor={accentRecover} />
-        <MetricCard metric={rec.sleep}    accentColor={accentRecover} />
-        <MetricCard metric={rec.hrv}      accentColor={accentRecover} />
+      <View style={trendsStyles.grid}>
+        <MetricCard metric={rec.recovery}  accentColor={accentRecover} />
+        <MetricCard metric={rec.sleep}     accentColor={accentRecover} />
+        <MetricCard metric={rec.hrv}       accentColor={accentRecover} />
         <MetricCard metric={rec.restingHr} accentColor={accentRecover} />
       </View>
 
       {/* Activity */}
       <SectionHeader title="Activity" />
-      <View style={trends.grid}>
-        <MetricCard metric={act.activity} accentColor={accentActivity} />
-        <MetricCard metric={act.steps}    accentColor={accentActivity} />
-        <MetricCard metric={act.training} accentColor={accentActivity} />
-        <MetricCard metric={act.calories} accentColor={accentActivity} />
+      <View style={trendsStyles.grid}>
+        <MetricCard metric={act.activity}  accentColor={accentActivity} />
+        <MetricCard metric={act.steps}     accentColor={accentActivity} />
+        <MetricCard metric={act.training}  accentColor={accentActivity} />
+        <MetricCard metric={act.calories}  accentColor={accentActivity} />
       </View>
 
       <View style={{ height: spacing.xl }} />


### PR DESCRIPTION
## Summary

Replaces the Trends placeholder with a functional MVP using **existing `HomeDisplayData` only**. No new data sources, no new packages.

## Final architecture

- `HomeScreen` keeps full ownership of its internal state: `dataMode`, `timeRange`, `customRange`, `bloodPanels`, `HealthConnect` status. Nothing was lifted out of it.
- `V2Shell` in `OneL1feV2Screen.tsx` calls `getHomeDisplayData` independently (with `bloodPanels: []`) to produce `trendsData` for the Trends tab.
- `TrendsScreen` receives `trendsData` as a prop and renders it — no state, no adapter calls of its own.
- Both screens use the same adapter boundary; they are independent consumers, not shared-state siblings.

## New file

`apps/mobile/prototypes/v2/src/screens/TrendsScreen.tsx`

- Page header with title and Demo / User Data mode indicator
- **Score section**: One L1fe Score line chart from `scoreTrend.series`
- **Recovery section**: Recovery, Sleep, HRV, Resting HR — metric cards with line/bar charts
- **Activity section**: Activity, Steps, Training, Calories — metric cards with line/bar charts
- Calm empty states for User Data mode (no faked values)
- RN-only chart primitives (`BarChart` / `LineChart`) — no new packages

## Changed files

- `apps/mobile/prototypes/v2/src/screens/TrendsScreen.tsx` — new
- `apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx` — TrendsScreen wire-in + independent `trendsData` call
- `CHECKPOINT.md` — updated to reflect Trends MVP state

## Constraints verified

- `package.json` unchanged
- `apps/mobile/package.json` unchanged
- `packages/domain/` unchanged
- No new npm packages
- Active app path unchanged: `App.tsx → prototypes/v2/src/OneL1feV2Screen.tsx`
- No root Expo artifacts
- `HomeScreen` props interface unchanged
- `BottomNavV2` unchanged
- Existing adapter guardrail tests unaffected
- Health Connect display-only
- No medical claims

## Remaining risks

- `HomeScreen` and `TrendsScreen` each call `getHomeDisplayData` independently — mode/range shown in Trends tab will not mirror what the user last selected on Home. Acceptable for MVP; a shared context layer is the correct fix if cross-tab sync becomes a requirement.
- Physical device QA still pending
- Insights tab remains placeholder