### PR TITLE
docs: refresh v2 truth files after trends merge

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -15,16 +15,15 @@ scope: repo
 - Stable branch: `main`.
 - Active mobile app: **One L1fe v2 prototype**.
 - Canonical app entry: `apps/mobile/App.tsx -> apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx`.
-- `apps/mobile/prototypes/v1-marathon/` remains as the previous Marathon-focused snapshot.
-- v2 home has its own `HomeScreen` and forked components under `apps/mobile/prototypes/v2/src/`.
-- v2 display data is centralized in `homeDataAdapter.ts` / `homeTypes.ts`; state (mode, timeRange, customRange) is owned by `V2Shell` in `OneL1feV2Screen.tsx` and passed to both `HomeScreen` and `TrendsScreen`.
-- `TrendsScreen` renders One L1fe Score trend, Recovery metrics (Recovery, Sleep, HRV, Resting HR), and Activity metrics (Activity, Steps, Training, Calories) using existing `HomeDisplayData`. No new data sources.
-- v2 shell has bottom nav with four tabs: Home, Trends (MVP live), Insights (placeholder), Profile (legacy).
-- v2 home passed Android emulator QA on Pixel 9 Pro AVD (Android 15 / API 35).
-- v2 may temporarily import unchanged non-home screens/data from `v1-marathon`; fork before changing v2-specific behavior.
-- App config: `apps/mobile/app.json`. Expo `0.2.2`; Android `versionCode: 4`; `minSdkVersion: 26`.
-- Health Connect: foreground display-only. No background sync, no Supabase write, no score recomputation.
-- CI green on latest main.
+- v2 code lives under `apps/mobile/prototypes/v2/src/`; `v1-marathon/` remains the previous Marathon snapshot.
+- v2 bottom nav: Home, Trends, Insights, Profile.
+- Home and Trends are live; Insights is a placeholder; Profile uses the legacy Profile screen.
+- Home display data is centralized in `homeDataAdapter.ts` / `homeTypes.ts`; adapter guardrail tests are merged.
+- Trends uses existing `HomeDisplayData` only: Score, Recovery, Sleep, HRV, Resting HR, Activity, Steps, Training, Calories.
+- Home and Trends currently consume adapter data independently; cross-tab mode/range sync is a follow-up only if QA shows confusion.
+- Health Connect is foreground display-only: no background sync, no Supabase write, no score recomputation.
+- App config: `apps/mobile/app.json`; Expo `0.2.2`, Android `versionCode: 4`, `minSdkVersion: 26`.
+- CI is green on latest `main`.
 
 ## Run
 
@@ -34,22 +33,12 @@ npx expo start --clear
 # or: npx expo run:android
 ```
 
-## Recently completed
-
-- PR #115: repo truth-source cleanup.
-- PR #109: `supabase/setup-cli@v2`, CI hygiene fixes.
-- PR #117: v2 home redesign + data adapter boundary merged.
-- PR #118: `homeDataAdapter` guardrail tests (37 assertions) merged.
-- feat/trends-screen-mvp: TrendsScreen MVP + shared state lift — PR pending.
-
 ## Working rules
 
-- Keep `One L1fe` as canonical app name.
-- Keep `v2` visually secondary.
+- Keep `One L1fe` as canonical app name; keep `v2` visually secondary.
 - Keep v1 Marathon stable unless explicitly fixing that snapshot.
 - Fork v1 components into v2 before changing v2-specific behavior.
-- Keep demo data labelled.
-- Keep Health Connect claims display-only unless ingest is implemented.
+- Keep demo data labelled and User Data empty states honest.
 - Keep product framing bounded: no diagnosis, treatment, emergency triage, or clinical-risk-score claim.
 - Do not commit secrets or local build artifacts.
 - Do not delete full-app/auth/backend files without import/reference audit.
@@ -57,14 +46,13 @@ npx expo start --clear
 ## Current blockers
 
 - Physical OnePlus-class Android device QA not yet run.
-- `HomeScreen` still owns some internal state for Custom range picker UI — should remain there; only mode/timeRange/customRange values are lifted.
 - Full-app shell files not yet reference-audited for safe deletion.
 - Native Android version values drift from `app.json` unless regenerated intentionally.
 
 ## Next steps
 
-1. Merge `feat/trends-screen-mvp` PR after CI.
-2. Run physical OnePlus-class Android QA.
-3. Extract pure Dot/Score domain work from issue #116 (no UI/routing changes).
-4. Start Blood Intake / Scanner research as v2 work.
-5. EAS preview build when ready for broader QA.
+1. Run Android QA for Home + Trends on emulator and, if possible, physical OnePlus-class device.
+2. Fix only small QA defects: clipped text, hidden controls, broken charts, touch targets.
+3. If QA shows cross-tab confusion, add a minimal shared mode/range sync layer.
+4. Extract pure Dot/Score domain work from issue #116 in an isolated branch with no UI changes.
+5. Start Blood Intake / Scanner research as a requirements doc/issue, not code.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,15 +8,15 @@ scope: all-agents
 
 # CONTEXT.md — Rolling Session Summary
 
-Last 2–3 sessions. Hard cap: 60 lines. Max 5 bullets per entry. Updated every session by the closing agent.
-For startup: read after CHECKPOINT.md. Never load memory/ or docs/archive/ at startup.
+Last 2–3 sessions. Hard cap: 60 lines. Max 5 bullets per entry. Updated by closing agents.
+For startup: read after CHECKPOINT.md. Never load `memory/` or `docs/archive/` at startup.
 
 ---
 
-## 2026-05-02 — Codex (v2 Home redesign closeout)
+## 2026-05-02 — Codex (v2 Home + Trends)
 
-- Active app path still runs through `apps/mobile/App.tsx -> apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx`; v2 Home ownership is now separate from the legacy v1 ThemeProvider boundary.
-- The active v2 Home was redesigned into a score-first structure with a persistent header, Demo/User Data mode, global time range plus local Custom range picker, multi-ring One L1fe Score, contributor legend, separate score trend, Recovery/Activity metric cards, Health Inputs, Nutrition Hub, Notes & Ideas, source status, safety note, and bottom nav with Home/Trends/Insights/Profile.
-- New v2-local files under `apps/mobile/prototypes/v2/src/data/` now provide a `HomeDisplayData` adapter boundary for mode, time range/custom range, contributor groups, score trend, metric chart data, Health Inputs, and Nutrition Hub so `HomeScreen` mostly renders display data instead of shaping it inline.
-- Legacy Blood Results and Profile stay on the existing v1 screens; Blood Markers CTA still opens Blood Results, Profile stays reachable from the bottom nav, and Trends/Insights remain lightweight placeholders.
-- No `package.json`, `apps/mobile/package.json`, `packages/domain/`, active entry, navigation library, detail screen, or runtime scoring changes were introduced; `npm run typecheck`, `npm run typecheck:mobile`, `npm run test:domain`, and Android dev run/QA on `Pixel_9_Pro` passed.
+- Active app path remains `apps/mobile/App.tsx -> apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx`; v2 Home is separated from the legacy v1 ThemeProvider boundary.
+- Home is score-first: persistent header, Demo/User Data mode, global time range with Custom picker, multi-ring One L1fe Score, contributor legend, score trend, Recovery/Activity cards, Health Inputs, Nutrition Hub, Notes & Ideas, source status, safety note, and bottom nav.
+- `homeDataAdapter.ts` / `homeTypes.ts` define the v2 `HomeDisplayData` boundary; guardrail tests cover demo/user data, time ranges, empty states, blood panel scoping, and future contributors.
+- Trends MVP is live and uses existing `HomeDisplayData` only for Score, Recovery, Sleep, HRV, Resting HR, Activity, Steps, Training, and Calories; Insights remains a placeholder.
+- No package, `packages/domain/`, active entry, navigation library, runtime scoring, or backend changes were introduced. CI is green; physical OnePlus-class QA is still pending.


### PR DESCRIPTION
## Summary

Refreshes repo truth files after PR #119 was merged.

## Changes

- `CHECKPOINT.md`
  - Removes stale `feat/trends-screen-mvp` pending state
  - States that Home and Trends are live, Insights remains placeholder
  - Shortens current facts and next steps
  - Keeps Android QA and cross-tab mode/range sync as explicit follow-ups

- `CONTEXT.md`
  - Compresses the v2 Home + Trends handoff
  - Removes excess batch detail
  - States that Trends MVP is live and physical OnePlus-class QA is pending

## Constraints

- Docs-only
- No app code changes
- No package changes
- No `packages/domain/` changes

## Next

Run Android QA for Home + Trends on emulator and, if possible, physical OnePlus-class device.