### PR TITLE
qa(mobile): verify v2 home and trends Android pass

### DIFF
--- a/CHECKPOINT.md
+++ b/CHECKPOINT.md
@@ -15,6 +15,7 @@ scope: repo
 - Stable branch: `main`.
 - Active mobile app: **One L1fe v2 prototype**.
 - Canonical app entry: `apps/mobile/App.tsx -> apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx`.
+- Android device QA was run on `Pixel_9_Pro` against the checked-out v2 shell on 2026-05-02.
 - `apps/mobile/prototypes/v1-marathon/` remains as the previous Marathon-focused snapshot.
 - v2 has its own root, header, copy, and README.
 - v2 may temporarily import unchanged components from `v1-marathon`; fork a component into `v2/` before changing v2-specific behavior.
@@ -42,6 +43,7 @@ npx expo start --clear
 - Root and mobile TypeScript checks passed locally on 2026-05-01.
 - Stale broad PRs #99, #101, #105, and #108 closed after preserving extraction work in issue #116.
 - PR #109 merged: `supabase/setup-cli@v2`, native Android resource hygiene exception, optional hygiene roots, and linked Supabase lint scoped to `public` schema.
+- Android QA found a live blank-screen regression caused by mixed v2/v1 theme ownership; fixed locally on `qa/v2-home-trends-android-pass` by unifying the live v2 shell onto the legacy theme context used by rendered cards.
 
 ## Working rules
 
@@ -57,15 +59,16 @@ npx expo start --clear
 
 ## Current blockers
 
-- Device QA not yet run for v2.
 - Full-app shell files have not yet been reference-audited for safe deletion.
 - Native Android version values drift from `app.json` unless regenerated/accepted intentionally.
+- External session summary and checked-out repo truth diverge: the live `main` shell still renders the older score/trend/profile flow and does not contain the claimed Home/Trends/bottom-nav surface.
 
 ## Next steps
 
-1. Device QA on Android for the active v2 prototype.
-2. Preferred preview path: EAS preview build.
-3. Local APK fallback: `cd apps/mobile/android && ./gradlew app:assembleRelease`.
-4. APK check: `unzip -l apps/mobile/android/app/build/outputs/apk/release/app-release.apk | grep assets/index.android.bundle`.
-5. Extract pure Dot/Score domain work from issue #116 in a fresh code session; no UI/routing changes in that PR.
-6. Start Blood Intake / Scanner research as v2 work, not v1 Marathon work.
+1. Merge the Android QA fix from `qa/v2-home-trends-android-pass`.
+2. Reconcile repo truth before further v2 QA: confirm whether PRs #117–#120 were actually merged into this checkout or whether the branch history summary is stale.
+3. Preferred preview path: EAS preview build.
+4. Local APK fallback: `cd apps/mobile/android && ./gradlew app:assembleRelease`.
+5. APK check: `unzip -l apps/mobile/android/app/build/outputs/apk/release/app-release.apk | grep assets/index.android.bundle`.
+6. Extract pure Dot/Score domain work from issue #116 in a fresh code session; no UI/routing changes in that PR.
+7. Start Blood Intake / Scanner research as v2 work, not v1 Marathon work.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,6 +13,14 @@ For startup: read after CHECKPOINT.md. Never load memory/ or docs/archive/ at st
 
 ---
 
+## 2026-05-02 — Codex (Android QA pass on checked-out v2 shell)
+
+- Ran `npm run typecheck`, `npm run typecheck:mobile`, `npm run test:domain`, then `cd apps/mobile && npx expo run:android` on `Pixel_9_Pro`; app installed and launched.
+- Android initially showed a blank white screen; `adb logcat` traced it to `ReadinessOrbit` calling legacy `useTheme` outside its owner provider.
+- Fixed the regression narrowly by pointing `apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx` and `components/AppHeaderV2.tsx` at the legacy theme context already used by the rendered v1-marathon cards.
+- Verified Home render, profile open, demo-info modal, scroll, and dark-mode toggle on device after the fix.
+- Important repo-truth finding: the checked-out `main` does not match the external summary claiming merged Home/Trends/bottom-nav work; the live shell is still the older score/trend/profile flow.
+
 ## 2026-05-01 — ChatGPT (agent efficiency docs cleanup)
 
 - `AGENTS.md` now carries task-type routing so agents can jump directly to the right repo path.

--- a/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
+++ b/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
@@ -10,7 +10,10 @@ import {
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
-import { ThemeProvider, useTheme } from './theme/ThemeContext';
+import {
+  ThemeProvider as LegacyThemeProvider,
+  useTheme,
+} from '../../v1-marathon/src/theme/ThemeContext';
 import { useWebBackground } from './theme/useWebBackground';
 import { AppHeaderV2 } from './components/AppHeaderV2';
 import { BloodContextCard } from '../../v1-marathon/src/components/BloodContextCard';
@@ -33,9 +36,9 @@ import type { ThemeColors } from './theme/marathonTheme';
 
 export function OneL1feV2Screen() {
   return (
-    <ThemeProvider>
+    <LegacyThemeProvider>
       <V2Shell />
-    </ThemeProvider>
+    </LegacyThemeProvider>
   );
 }
 

--- a/apps/mobile/prototypes/v2/src/components/AppHeaderV2.tsx
+++ b/apps/mobile/prototypes/v2/src/components/AppHeaderV2.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { Platform, Pressable, StatusBar, StyleSheet, Text, View } from 'react-native';
 import Svg, { Circle, Path } from 'react-native-svg';
-import { useTheme } from '../theme/ThemeContext';
+import { useTheme } from '../../../v1-marathon/src/theme/ThemeContext';
 import { layout, spacing, typography } from '../theme/marathonTheme';
 import { prototypeCopy } from '../data/copy';
 


### PR DESCRIPTION
## Summary
- fix Android blank-screen regression caused by mixed v2/v1 theme provider ownership in the checked-out v2 shell
- document the Android QA pass and repo-truth mismatch in CHECKPOINT/CONTEXT
- verify Home render, profile open, demo info modal, scroll, and dark mode on Pixel_9_Pro

## Checks
- npm run typecheck
- npm run typecheck:mobile
- npm run test:domain
- cd apps/mobile && npx expo run:android

## Notes
- The checked-out repo state does not currently include the claimed Home/Trends/bottom-nav shell from the external summary. This PR fixes the live Android regression on the code that actually exists in the checkout.