### PR TITLE
feat(mobile): polish v2 prototype — global header, score card, accordion

### DIFF
--- a/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
+++ b/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
@@ -14,6 +14,7 @@ import { useWebBackground } from './theme/useWebBackground';
 import { ProfileScreen } from '../../v1-marathon/src/components/ProfileScreen';
 import { BloodResultsScreen } from '../../v1-marathon/src/screens/BloodResultsScreen';
 import { ThemeProvider as LegacyV1ThemeProvider } from '../../v1-marathon/src/theme/ThemeContext';
+import { AppHeaderV2 } from './components/AppHeaderV2';
 import { BottomNavV2, type BottomTabKey } from './components/BottomNavV2';
 import { HomeScreen } from './screens/HomeScreen';
 import { TrendsScreen } from './screens/TrendsScreen';
@@ -67,6 +68,19 @@ function V2Shell() {
     setActiveView(tab);
   }
 
+  function handleTimeRangeSelect(range: TimeRange) {
+    setTimeRange(range);
+    if (range !== 'custom') {
+      setCustomRange({ start: null, end: null });
+    }
+  }
+
+  function handleCustomRangeChange(range: CustomRange) {
+    setCustomRange(range);
+  }
+
+  const showGlobalHeader = activeView !== 'blood' && activeView !== 'profile';
+
   return (
     <>
       <StatusBar
@@ -75,6 +89,18 @@ function V2Shell() {
         translucent={false}
       />
       <SafeAreaView style={{ flex: 1, backgroundColor: colors.background }}>
+        {showGlobalHeader ? (
+          <AppHeaderV2
+            onProfilePress={openProfile}
+            onDemoInfoPress={() => setDemoInfoVisible(true)}
+            dataMode={dataMode}
+            onDataModeChange={setDataMode}
+            timeRange={timeRange}
+            customRange={customRange}
+            onTimeRangeSelect={handleTimeRangeSelect}
+          />
+        ) : null}
+
         <View style={{ flex: 1, overflow: 'hidden' }}>
           {activeView === 'blood' ? (
             <LegacyV1ThemeProvider>
@@ -95,12 +121,16 @@ function V2Shell() {
               subtitle="Insights will summarize patterns from your connected data."
             />
           ) : (
-            // HomeScreen owns its own state (bloodPanels, HealthConnect, mode, range, etc.)
             <HomeScreen
               onProfilePress={() => setActiveView('profile')}
               onDemoInfoPress={() => setDemoInfoVisible(true)}
               onViewBloodPanels={() => setActiveView('blood')}
               onManageSources={() => setActiveView('profile')}
+              dataMode={dataMode}
+              timeRange={timeRange}
+              customRange={customRange}
+              onTimeRangeSelect={handleTimeRangeSelect}
+              onCustomRangeChange={handleCustomRangeChange}
             />
           )}
         </View>

--- a/apps/mobile/prototypes/v2/src/components/AppHeaderV2.tsx
+++ b/apps/mobile/prototypes/v2/src/components/AppHeaderV2.tsx
@@ -4,8 +4,8 @@
  * Dedicated v2 header. Keeps One L1fe as the primary mark and renders `v2`
  * as a small, low-emphasis marker.
  */
-import React from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import React, { useRef, useState } from 'react';
+import { Modal, Pressable, StyleSheet, Text, TouchableWithoutFeedback, View } from 'react-native';
 import Svg, { Circle, Path } from 'react-native-svg';
 import { useTheme } from '../theme/ThemeContext';
 import { layout, radius, spacing, typography, type ThemeColors } from '../theme/marathonTheme';
@@ -102,9 +102,6 @@ export function AppHeaderV2({
 }: AppHeaderV2Props) {
   const { colors, isDark, toggle } = useTheme();
   const iconColor = colors.text;
-  const customLabel = customRange.start && customRange.end
-    ? `${formatShortDate(customRange.start)}-${formatShortDate(customRange.end)}`
-    : 'Custom';
 
   return (
     <View
@@ -199,40 +196,185 @@ export function AppHeaderV2({
             })}
           </View>
 
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.rangeRow}
-            style={styles.rangeScroller}
-          >
-            {TIME_RANGE_OPTIONS.map((range) => {
-              const active = timeRange === range;
-              return (
-                <Pressable
-                  key={range}
-                  onPress={() => onTimeRangeSelect(range)}
-                  accessibilityRole="button"
-                  accessibilityState={{ selected: active }}
-                  style={[
-                    styles.rangeButton,
-                    {
-                      backgroundColor: active ? softMint(colors) : colors.surface,
-                      borderColor: active ? colors.accentBorder : colors.borderSubtle,
-                    },
-                  ]}
-                >
-                  <Text style={[styles.rangeButtonText, { color: active ? colors.text : colors.textSubtle }]}>
-                    {range === 'custom' ? customLabel : TIME_RANGE_LABELS[range]}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </ScrollView>
+          <CompactRangeDropdown
+            value={timeRange}
+            customRange={customRange}
+            onSelect={onTimeRangeSelect}
+            colors={colors}
+          />
         </View>
       </View>
     </View>
   );
 }
+
+function CompactRangeDropdown({
+  value,
+  customRange,
+  onSelect,
+  colors,
+}: {
+  value: TimeRange;
+  customRange: CustomRange;
+  onSelect: (range: TimeRange) => void;
+  colors: ThemeColors;
+}) {
+  const [open, setOpen] = useState(false);
+  const [menuY, setMenuY] = useState(0);
+  const triggerRef = useRef<View>(null);
+
+  const customLabel =
+    customRange.start && customRange.end
+      ? `${formatShortDate(customRange.start)}–${formatShortDate(customRange.end)}`
+      : 'Custom';
+  const activeLabel = value === 'custom' ? customLabel : TIME_RANGE_LABELS[value];
+
+  function handleOpen() {
+    if (triggerRef.current) {
+      triggerRef.current.measureInWindow((_x, y, _w, h) => {
+        setMenuY(y + h + 4);
+        setOpen(true);
+      });
+    } else {
+      setMenuY(100);
+      setOpen(true);
+    }
+  }
+
+  return (
+    <>
+      <View ref={triggerRef} collapsable={false} style={dropStyles.triggerWrap}>
+        <Pressable
+          onPress={handleOpen}
+          style={[
+            dropStyles.trigger,
+            {
+              backgroundColor: softMint(colors),
+              borderColor: colors.accentBorder,
+            },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel={`Time range: ${activeLabel}. Tap to change.`}
+          accessibilityState={{ expanded: open }}
+        >
+          <Text style={[dropStyles.triggerText, { color: colors.text }]}>{activeLabel}</Text>
+          <Text style={[dropStyles.chevron, { color: colors.textSubtle }]}>{open ? '▴' : '▾'}</Text>
+        </Pressable>
+      </View>
+
+      <Modal
+        visible={open}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setOpen(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => setOpen(false)}>
+          <View style={dropStyles.backdrop}>
+            <TouchableWithoutFeedback onPress={() => { /* absorb */ }}>
+              <View
+                style={[
+                  dropStyles.menu,
+                  {
+                    top: menuY,
+                    backgroundColor: colors.surfaceElevated,
+                    borderColor: colors.border,
+                  },
+                ]}
+              >
+                {TIME_RANGE_OPTIONS.map((opt) => {
+                  const active = value === opt;
+                  const optLabel = opt === 'custom' ? customLabel : TIME_RANGE_LABELS[opt];
+                  return (
+                    <Pressable
+                      key={opt}
+                      onPress={() => {
+                        onSelect(opt);
+                        setOpen(false);
+                      }}
+                      style={[
+                        dropStyles.option,
+                        active && { backgroundColor: softMint(colors) },
+                      ]}
+                      accessibilityRole="menuitem"
+                      accessibilityState={{ selected: active }}
+                    >
+                      <Text
+                        style={[
+                          dropStyles.optionText,
+                          { color: active ? colors.text : colors.textMuted },
+                          active && { fontWeight: '800' },
+                        ]}
+                      >
+                        {optLabel}
+                      </Text>
+                      {active ? (
+                        <Text style={[dropStyles.checkmark, { color: colors.scoreStrong }]}>✓</Text>
+                      ) : null}
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </TouchableWithoutFeedback>
+          </View>
+        </TouchableWithoutFeedback>
+      </Modal>
+    </>
+  );
+}
+
+const dropStyles = StyleSheet.create({
+  triggerWrap: {
+    flex: 1,
+  },
+  trigger: {
+    flex: 1,
+    minHeight: 42,
+    borderRadius: radius.pill,
+    borderWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+  },
+  triggerText: {
+    fontSize: typography.caption,
+    fontWeight: '800',
+  },
+  chevron: {
+    fontSize: typography.micro,
+    fontWeight: '800',
+  },
+  backdrop: {
+    flex: 1,
+  },
+  menu: {
+    position: 'absolute',
+    right: layout.screenPaddingH,
+    minWidth: 160,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    overflow: 'hidden',
+  },
+  option: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    minHeight: 44,
+  },
+  optionText: {
+    fontSize: typography.bodySmall,
+    fontWeight: '600',
+    flex: 1,
+  },
+  checkmark: {
+    fontSize: typography.bodySmall,
+    fontWeight: '800',
+    marginLeft: spacing.sm,
+  },
+});
 
 const styles = StyleSheet.create({
   root: {
@@ -311,24 +453,5 @@ const styles = StyleSheet.create({
     fontSize: typography.caption,
     fontWeight: '800',
     letterSpacing: 0,
-  },
-  rangeScroller: {
-    flex: 1,
-  },
-  rangeRow: {
-    gap: spacing.sm,
-    paddingRight: spacing.md,
-  },
-  rangeButton: {
-    minHeight: 42,
-    borderRadius: radius.pill,
-    borderWidth: StyleSheet.hairlineWidth,
-    paddingHorizontal: spacing.md,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  rangeButtonText: {
-    fontSize: typography.caption,
-    fontWeight: '800',
   },
 });

--- a/apps/mobile/prototypes/v2/src/screens/HomeScreen.tsx
+++ b/apps/mobile/prototypes/v2/src/screens/HomeScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import Svg, { Circle, Path, Rect } from 'react-native-svg';
-import { AppHeaderV2 } from '../components/AppHeaderV2';
 import { IdeasNotesCard } from '../components/IdeasNotesCard';
 import { prototypeCopy } from '../data/copy';
 import { getHomeDisplayData } from '../data/homeDataAdapter';
@@ -19,7 +18,6 @@ import { useTheme } from '../theme/ThemeContext';
 import { layout, lineHeights, radius, spacing, typography } from '../theme/marathonTheme';
 import type { ThemeColors } from '../theme/marathonTheme';
 import {
-  DEFAULT_TIME_RANGE,
   type CustomRange,
   type TimeRange,
 } from '../types/timeRange';
@@ -33,16 +31,21 @@ type HomeScreenProps = {
   onDemoInfoPress: () => void;
   onViewBloodPanels: () => void;
   onManageSources: () => void;
+  dataMode: HomeDataMode;
+  timeRange: TimeRange;
+  customRange: CustomRange;
+  onTimeRangeSelect: (range: TimeRange) => void;
+  onCustomRangeChange: (range: CustomRange) => void;
 };
 
-const SCORE_RING_SIZE = 150;
-const OUTER_RING_STROKE = 10;
-const INNER_RING_STROKE = 6;
-const SCORE_RING_COLORS = ['#D7EFDB', '#C7DFCC', '#B2D5B8', '#94CFA0'];
-const SCORE_TEXT_LIGHT = '#3F7F56';
-const SCORE_TEXT_DARK = '#B2D5B8';
-const RECOVERY_COLOR = '#7FB88E';
-const ACTIVITY_COLOR = '#94CFA0';
+const SCORE_RING_SIZE = 160;
+const OUTER_RING_STROKE = 12;
+const INNER_RING_STROKE = 8;
+const SCORE_RING_COLORS = ['#7EC8AA', '#5DB890', '#3DA876', '#2B9463'];
+const SCORE_TEXT_LIGHT = '#1A5C38';
+const SCORE_TEXT_DARK = '#94CFA0';
+const RECOVERY_COLOR = '#5BA0B0';
+const ACTIVITY_COLOR = '#D4903A';
 const BLOOD_COLOR = '#6F9F79';
 const FUTURE_COLOR = '#B8B2AA';
 const SOFT_NEGATIVE = '#C97872';
@@ -150,17 +153,17 @@ function colorForKey(key: HomeMetricColorKey, colors: ThemeColors, score: number
     case 'future':
       return FUTURE_COLOR;
     case 'sleep':
-      return '#A8CCB0';
+      return '#7DBBC9';
     case 'hrv':
-      return '#88B894';
+      return '#4A8A98';
     case 'restingHr':
-      return colors.positive;
+      return '#3A7A88';
     case 'steps':
-      return '#9FCFA8';
+      return '#E5A857';
     case 'training':
-      return '#86BE91';
+      return '#C47A28';
     case 'calories':
-      return colors.scoreStrong;
+      return '#B86A18';
     default:
       return colors.scoreStrong;
   }
@@ -171,18 +174,28 @@ export function HomeScreen({
   onDemoInfoPress,
   onViewBloodPanels,
   onManageSources,
+  dataMode,
+  timeRange,
+  customRange,
+  onTimeRangeSelect,
+  onCustomRangeChange,
 }: HomeScreenProps) {
   const { colors } = useTheme();
   const s = createHomeStyles(colors);
 
-  const [dataMode, setDataMode] = useState<HomeDataMode>('demo');
-  const [timeRange, setTimeRange] = useState<TimeRange>(DEFAULT_TIME_RANGE);
-  const [customRange, setCustomRange] = useState<CustomRange>({ start: null, end: null });
   const [customOpen, setCustomOpen] = useState(false);
   const [recoveryMetric, setRecoveryMetric] = useState<HomeTrendMetricKey>('recovery');
   const [activityMetric, setActivityMetric] = useState<HomeTrendMetricKey>('activity');
   const [hcStatus, setHcStatus] = useState<HealthConnectStatus>('unavailable');
   const [bloodPanels, setBloodPanels] = useState<BloodPanel[]>([]);
+
+  useEffect(() => {
+    if (timeRange === 'custom') {
+      setCustomOpen(true);
+    } else {
+      setCustomOpen(false);
+    }
+  }, [timeRange]);
 
   useEffect(() => {
     let cancelled = false;
@@ -211,41 +224,22 @@ export function HomeScreen({
     [bloodPanels, customRange, dataMode, timeRange],
   );
 
-  function selectTimeRange(range: TimeRange) {
-    setTimeRange(range);
-    if (range === 'custom') {
-      setCustomOpen(true);
-      return;
-    }
-    setCustomOpen(false);
-  }
-
   function selectCustomDate(date: Date) {
-    setTimeRange('custom');
-    setCustomOpen(true);
-    setCustomRange((current) => {
-      if (!current.start || current.end) {
-        return { start: date, end: null };
-      }
-      if (date.getTime() < current.start.getTime()) {
-        return { start: date, end: null };
-      }
-      return { start: current.start, end: date };
-    });
+    const prev = customRange;
+    let next: CustomRange;
+    if (!prev.start || prev.end) {
+      next = { start: date, end: null };
+    } else if (date.getTime() < prev.start.getTime()) {
+      next = { start: date, end: null };
+    } else {
+      next = { start: prev.start, end: date };
+    }
+    onTimeRangeSelect('custom');
+    onCustomRangeChange(next);
   }
 
   return (
     <>
-      <AppHeaderV2
-        onProfilePress={onProfilePress}
-        onDemoInfoPress={onDemoInfoPress}
-        dataMode={dataMode}
-        onDataModeChange={setDataMode}
-        timeRange={timeRange}
-        customRange={customRange}
-        onTimeRangeSelect={selectTimeRange}
-      />
-
       <ScrollView
         style={s.scrollView}
         contentContainerStyle={s.scroll}
@@ -422,21 +416,21 @@ function MultiRingScore({
       <Svg width={SCORE_RING_SIZE} height={SCORE_RING_SIZE} viewBox={`0 0 ${SCORE_RING_SIZE} ${SCORE_RING_SIZE}`}>
         <ProgressCircle
           value={score}
-          radius={66}
+          radius={72}
           strokeWidth={OUTER_RING_STROKE}
           color={scoreTone(score, colors)}
           trackColor={colors.ringTrack}
         />
         <ProgressCircle
           value={recoveryScore}
-          radius={50}
+          radius={54}
           strokeWidth={INNER_RING_STROKE}
           color={RECOVERY_COLOR}
           trackColor={colors.progressTrack}
         />
         <ProgressCircle
           value={activityScore}
-          radius={39}
+          radius={40}
           strokeWidth={INNER_RING_STROKE}
           color={ACTIVITY_COLOR}
           trackColor={colors.progressTrack}
@@ -589,26 +583,61 @@ function ContributorLegend({
   colors: ThemeColors;
 }) {
   const s = createHomeStyles(colors);
+  const [recoveryOpen, setRecoveryOpen] = React.useState(true);
+  const [activityOpen, setActivityOpen] = React.useState(false);
   return (
     <View style={s.legendCard}>
-      <ContributorRow item={contributors.recovery} colors={colors} />
-      {contributors.recovery.inputs?.map((item) => (
+      <Pressable
+        onPress={() => setRecoveryOpen((o) => !o)}
+        style={s.accordionHeader}
+        accessibilityRole="button"
+        accessibilityState={{ expanded: recoveryOpen }}
+      >
+        <View style={[s.contributorDot, { backgroundColor: RECOVERY_COLOR }]} />
+        <Text style={[s.contributorLabel, { fontWeight: '800' }]}>{contributors.recovery.label}</Text>
+        <Text style={s.contributorValue}>
+          {contributors.recovery.value === null ? '--' : `${clamp(contributors.recovery.value)}%`}
+        </Text>
+        <Text style={[s.accordionChevron, { color: colors.textSubtle }]}>
+          {recoveryOpen ? '▾' : '▸'}
+        </Text>
+      </Pressable>
+      {recoveryOpen && contributors.recovery.inputs?.map((item) => (
         <ContributorRow key={item.label} item={item} colors={colors} sub />
       ))}
 
       <View style={s.legendDivider} />
 
-      <ContributorRow item={contributors.activity} colors={colors} />
-      {contributors.activity.inputs?.map((item) => (
+      <Pressable
+        onPress={() => setActivityOpen((o) => !o)}
+        style={s.accordionHeader}
+        accessibilityRole="button"
+        accessibilityState={{ expanded: activityOpen }}
+      >
+        <View style={[s.contributorDot, { backgroundColor: ACTIVITY_COLOR }]} />
+        <Text style={[s.contributorLabel, { fontWeight: '800' }]}>{contributors.activity.label}</Text>
+        <Text style={s.contributorValue}>
+          {contributors.activity.value === null ? '--' : `${clamp(contributors.activity.value)}%`}
+        </Text>
+        <Text style={[s.accordionChevron, { color: colors.textSubtle }]}>
+          {activityOpen ? '▾' : '▸'}
+        </Text>
+      </Pressable>
+      {activityOpen && contributors.activity.inputs?.map((item) => (
         <ContributorRow key={item.label} item={item} colors={colors} sub />
       ))}
 
       <View style={s.legendDivider} />
 
       <ContributorRow item={contributors.bloodMarkers} colors={colors} />
-      {contributors.future.map((item) => (
-        <FutureContributor key={item.label} label={item.label} colors={colors} />
-      ))}
+
+      {contributors.future.length > 0 && (
+        <View style={s.futureSection}>
+          {contributors.future.map((item) => (
+            <FutureContributor key={item.label} label={item.label} colors={colors} />
+          ))}
+        </View>
+      )}
     </View>
   );
 }
@@ -1042,7 +1071,7 @@ function createHomeStyles(colors: ThemeColors) {
     scroll: {
       alignItems: 'center',
       paddingTop: spacing.md,
-      paddingBottom: spacing.xxxl,
+      paddingBottom: 100,
     },
     container: {
       width: '100%',
@@ -1156,17 +1185,17 @@ function createHomeStyles(colors: ThemeColors) {
       justifyContent: 'center',
     },
     scoreValue: {
-      fontSize: 36,
-      lineHeight: 42,
-      fontWeight: '800',
-      letterSpacing: 0,
+      fontSize: 42,
+      lineHeight: 48,
+      fontWeight: '900',
+      letterSpacing: -1,
       fontVariant: ['tabular-nums'],
     },
     scoreLabel: {
       color: colors.textSubtle,
       fontSize: typography.micro,
       fontWeight: '800',
-      letterSpacing: 0.4,
+      letterSpacing: 0.6,
       textTransform: 'uppercase',
     },
     scoreTrendCard: {
@@ -1235,6 +1264,20 @@ function createHomeStyles(colors: ThemeColors) {
       height: StyleSheet.hairlineWidth,
       backgroundColor: colors.borderSubtle,
       marginVertical: spacing.xs,
+    },
+    accordionHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      minHeight: 26,
+      gap: spacing.xs,
+    },
+    accordionChevron: {
+      fontSize: typography.caption,
+      fontWeight: '800',
+      marginLeft: 2,
+    },
+    futureSection: {
+      opacity: 0.55,
     },
     contributorRow: {
       flexDirection: 'row',

--- a/apps/mobile/prototypes/v2/src/screens/TrendsScreen.tsx
+++ b/apps/mobile/prototypes/v2/src/screens/TrendsScreen.tsx
@@ -331,27 +331,7 @@ function ScoreTrendSection({ data }: { data: HomeDisplayData }) {
 
 const trendsStyles = StyleSheet.create({
   content: {
-    paddingBottom: spacing.xxxl,
-  },
-  pageHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: layout.screenPaddingH,
-    paddingTop: spacing.lg,
-    paddingBottom: spacing.sm,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-  },
-  pageTitle: {
-    fontSize: typography.heroName,
-    fontWeight: '800',
-    letterSpacing: -0.4,
-    lineHeight: 32,
-  },
-  pageMode: {
-    fontSize: typography.caption,
-    fontWeight: '700',
-    letterSpacing: 0.3,
+    paddingBottom: 100,
   },
   grid: {
     paddingHorizontal: layout.screenPaddingH,
@@ -377,14 +357,6 @@ export function TrendsScreen({ data }: { data: HomeDisplayData }) {
       contentContainerStyle={trendsStyles.content}
       showsVerticalScrollIndicator={false}
     >
-      {/* Page title */}
-      <View style={[trendsStyles.pageHeader, { borderBottomColor: colors.borderSubtle }]}>
-        <Text style={[trendsStyles.pageTitle, { color: colors.text }]}>Trends</Text>
-        <Text style={[trendsStyles.pageMode, { color: colors.textSubtle }]}>
-          {data.isDemo ? 'Demo' : 'User Data'}
-        </Text>
-      </View>
-
       {/* Score */}
       <SectionHeader title="Score" />
       <ScoreTrendSection data={data} />


### PR DESCRIPTION
## Summary

- **Global sticky header**: `AppHeaderV2` lifted out of `HomeScreen` to `V2Shell`; renders once across Home / Trends / Insights tabs, hidden on Profile / Blood screens.
- **Shared state**: `dataMode`, `timeRange`, `customRange` now live in `V2Shell` — both Home and Trends consume the same source of truth; switching tabs preserves the selected range.
- **Compact time-range dropdown**: replaces the old scrollable pills row with a single `CompactRangeDropdown` button (`1W ▾`). Tapping opens a Modal menu positioned directly below the trigger via `measureInWindow`; active option shows a green ✓.
- **Score card polish**:
  - Three rings now use visually distinct color families: green outer (overall score), teal middle (recovery), amber inner (activity); sub-metric legend colors cascade to the same families.
  - Center score: 42 px / weight 900 for stronger readability.
  - Recovery and Activity rows are accordion-expandable (Recovery default-open, Activity default-closed); Blood Markers stays one row; future contributors wrapped in 0.55-opacity `futureSection`.
- **Scroll padding**: `paddingBottom` raised to 100 px on Home and Trends to prevent bottom-nav overlap.

## Android QA (Pixel 9 Pro emulator)

- ✅ Home: three distinct rings, readable 68% center, expanded Recovery sub-rows, collapsed Activity
- ✅ Trends: global header persists, same Demo/1W state, no page-header duplication
- ✅ Dropdown: opens below trigger, "1W" active with ✓, all 7 options selectable, backdrop dismisses
- ✅ Bottom nav: content clears nav bar, no overlap
- ✅ `npm run typecheck` — clean
- ✅ `npm run typecheck:mobile` — clean
- ✅ `npm run test:domain` — all domain assertions passed

## Remaining risks

1. **Custom range picker unreachable from Trends**: the calendar date-picker renders inside `HomeScreen`'s ScrollView. If a user is on Trends and picks "Custom" from the global dropdown, `timeRange` becomes `'custom'` but there is no picker to select start/end — the data recomputes with `{start: null, end: null}` and shows the empty-range fallback. Fix options: auto-switch to Home when Custom is selected, render the picker at V2Shell level, or hide Custom on non-Home tabs. Not addressed in this PR.
2. **Trends metric colors not updated**: `TrendsScreen` uses `colors.scoreStrong` for all recovery cards and `colors.accent` for activity. The new teal/amber families apply only to `HomeScreen`. Cross-screen color unification is a separate pass.
3. **Custom range label shows "Custom" when dates are incomplete**: minor UX roughness if user picks a start date but no end date — label in dropdown trigger says "Custom" with no date hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)