### PR TITLE
polish(mobile): v2 brand lockup, semantic tokens, responsive score card

### DIFF
--- a/apps/mobile/prototypes/v2/src/components/AppHeaderV2.tsx
+++ b/apps/mobile/prototypes/v2/src/components/AppHeaderV2.tsx
@@ -1,9 +1,3 @@
-/**
- * AppHeaderV2
- *
- * Dedicated v2 header. Keeps One L1fe as the primary mark and renders `v2`
- * as a small, low-emphasis marker.
- */
 import React, { useRef, useState } from 'react';
 import { Modal, Pressable, StyleSheet, Text, TouchableWithoutFeedback, View } from 'react-native';
 import Svg, { Circle, Path } from 'react-native-svg';
@@ -29,21 +23,19 @@ type AppHeaderV2Props = {
 
 const ICON_SIZE = 22;
 
-function softMint(colors: ThemeColors) {
-  return colors.statusBar === 'dark' ? 'rgba(178,213,184,0.12)' : 'rgba(215,239,219,0.42)';
-}
-
 function formatShortDate(date: Date | null) {
   if (!date) return 'Select date';
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
-function IconInfo({ color }: { color: string }) {
+// Logo mark: open circle + integrated "1", brand green
+function IconLogoMark({ color, size = 26 }: { color: string; size?: number }) {
   return (
-    <Svg width={ICON_SIZE} height={ICON_SIZE} viewBox="0 0 22 22">
-      <Circle cx={11} cy={11} r={9} stroke={color} strokeWidth={1.6} fill="none" />
-      <Circle cx={11} cy={6.5} r={1.1} fill={color} />
-      <Path d="M11 9.6 L11 15.6" stroke={color} strokeWidth={1.8} strokeLinecap="round" fill="none" />
+    <Svg width={size} height={size} viewBox="0 0 26 26">
+      <Circle cx={13} cy={13} r={10.5} stroke={color} strokeWidth={1.7} fill="none" />
+      {/* "1" — top-left serif, main vertical, base line */}
+      <Path d="M10 10 L13 8 L13 19" stroke={color} strokeWidth={1.9} strokeLinecap="round" strokeLinejoin="round" fill="none" />
+      <Path d="M10.5 19 L15.5 19" stroke={color} strokeWidth={1.9} strokeLinecap="round" fill="none" />
     </Svg>
   );
 }
@@ -114,35 +106,27 @@ export function AppHeaderV2({
       ]}
     >
       <View style={styles.inner}>
+        {/* Top row: brand lockup left, controls right */}
         <View style={styles.topRow}>
           <View style={styles.brandRow}>
+            <IconLogoMark color={colors.brandGreen} size={26} />
             <Text style={[styles.brandName, { color: colors.text }]}>
-              One L<Text style={{ color: colors.scoreStrong }}>1</Text>fe
-            </Text>
-            <Text style={[styles.brandSub, { color: colors.textSubtle }]}>
-              {prototypeCopy.prototypeSub}
+              One L<Text style={{ color: colors.brandGreen }}>1</Text>fe
             </Text>
           </View>
 
           <View style={styles.controls}>
-            <Pressable
-              onPress={onDemoInfoPress}
-              style={({ pressed }) => [
-                styles.iconBtn,
-                { backgroundColor: colors.surface, borderColor: colors.borderSubtle },
-                pressed && { opacity: 0.7 },
-              ]}
-              accessibilityLabel="About demo data"
-              accessibilityRole="button"
-              hitSlop={8}
-            >
-              <IconInfo color={iconColor} />
-            </Pressable>
+            <CompactRangeDropdown
+              value={timeRange}
+              customRange={customRange}
+              onSelect={onTimeRangeSelect}
+              colors={colors}
+            />
             <Pressable
               onPress={toggle}
               style={({ pressed }) => [
                 styles.iconBtn,
-                { backgroundColor: colors.surface, borderColor: colors.borderSubtle },
+                { backgroundColor: colors.surfaceSoft, borderColor: colors.borderSubtle },
                 pressed && { opacity: 0.7 },
               ]}
               accessibilityLabel={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
@@ -155,7 +139,7 @@ export function AppHeaderV2({
               onPress={onProfilePress}
               style={({ pressed }) => [
                 styles.iconBtn,
-                { backgroundColor: colors.surface, borderColor: colors.borderSubtle },
+                { backgroundColor: colors.surfaceSoft, borderColor: colors.borderSubtle },
                 pressed && { opacity: 0.7 },
               ]}
               accessibilityLabel="Open profile"
@@ -167,11 +151,12 @@ export function AppHeaderV2({
           </View>
         </View>
 
-        <View style={styles.controlRow}>
+        {/* Bottom row: data mode toggle, info button */}
+        <View style={styles.modeRow}>
           <View
             style={[
               styles.modeToggle,
-              { backgroundColor: colors.surface, borderColor: colors.borderSubtle },
+              { backgroundColor: colors.surfaceSoft, borderColor: colors.borderSubtle },
             ]}
             accessibilityRole="tablist"
           >
@@ -185,23 +170,30 @@ export function AppHeaderV2({
                   accessibilityState={{ selected: active }}
                   style={[
                     styles.modeButton,
-                    active && { backgroundColor: colors.surfaceElevated, borderColor: colors.accentBorder },
+                    active && { backgroundColor: colors.surface, borderColor: colors.brandGreen + '44' },
                   ]}
                 >
                   <Text style={[styles.modeButtonText, { color: active ? colors.text : colors.textSubtle }]}>
-                    {mode === 'user' ? 'User Data' : 'Demo'}
+                    {mode === 'user' ? 'My Data' : 'Demo'}
                   </Text>
                 </Pressable>
               );
             })}
           </View>
 
-          <CompactRangeDropdown
-            value={timeRange}
-            customRange={customRange}
-            onSelect={onTimeRangeSelect}
-            colors={colors}
-          />
+          <Pressable
+            onPress={onDemoInfoPress}
+            style={({ pressed }) => [
+              styles.infoBtn,
+              { backgroundColor: colors.surfaceSoft, borderColor: colors.borderSubtle },
+              pressed && { opacity: 0.7 },
+            ]}
+            accessibilityLabel="About demo data"
+            accessibilityRole="button"
+            hitSlop={8}
+          >
+            <Text style={[styles.infoBtnText, { color: colors.textSubtle }]}>i</Text>
+          </Pressable>
         </View>
       </View>
     </View>
@@ -243,15 +235,16 @@ function CompactRangeDropdown({
 
   return (
     <>
-      <View ref={triggerRef} collapsable={false} style={dropStyles.triggerWrap}>
+      <View ref={triggerRef} collapsable={false}>
         <Pressable
           onPress={handleOpen}
-          style={[
+          style={({ pressed }) => [
             dropStyles.trigger,
             {
-              backgroundColor: softMint(colors),
-              borderColor: colors.accentBorder,
+              backgroundColor: colors.brandGreenSoft,
+              borderColor: colors.brandGreen + '44',
             },
+            pressed && { opacity: 0.8 },
           ]}
           accessibilityRole="button"
           accessibilityLabel={`Time range: ${activeLabel}. Tap to change.`}
@@ -276,8 +269,8 @@ function CompactRangeDropdown({
                   dropStyles.menu,
                   {
                     top: menuY,
-                    backgroundColor: colors.surfaceElevated,
-                    borderColor: colors.border,
+                    backgroundColor: colors.surface,
+                    borderColor: colors.borderSubtle,
                   },
                 ]}
               >
@@ -293,7 +286,7 @@ function CompactRangeDropdown({
                       }}
                       style={[
                         dropStyles.option,
-                        active && { backgroundColor: softMint(colors) },
+                        active && { backgroundColor: colors.brandGreenSoft },
                       ]}
                       accessibilityRole="menuitem"
                       accessibilityState={{ selected: active }}
@@ -301,14 +294,14 @@ function CompactRangeDropdown({
                       <Text
                         style={[
                           dropStyles.optionText,
-                          { color: active ? colors.text : colors.textMuted },
+                          { color: active ? colors.text : colors.textSubtle },
                           active && { fontWeight: '800' },
                         ]}
                       >
                         {optLabel}
                       </Text>
                       {active ? (
-                        <Text style={[dropStyles.checkmark, { color: colors.scoreStrong }]}>✓</Text>
+                        <Text style={[dropStyles.checkmark, { color: colors.brandGreen }]}>✓</Text>
                       ) : null}
                     </Pressable>
                   );
@@ -323,19 +316,16 @@ function CompactRangeDropdown({
 }
 
 const dropStyles = StyleSheet.create({
-  triggerWrap: {
-    flex: 1,
-  },
   trigger: {
-    flex: 1,
-    minHeight: 42,
+    height: 36,
     borderRadius: radius.pill,
-    borderWidth: StyleSheet.hairlineWidth,
+    borderWidth: 1,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     gap: spacing.xs,
     paddingHorizontal: spacing.md,
+    minWidth: 52,
   },
   triggerText: {
     fontSize: typography.caption,
@@ -351,10 +341,15 @@ const dropStyles = StyleSheet.create({
   menu: {
     position: 'absolute',
     right: layout.screenPaddingH,
-    minWidth: 160,
+    minWidth: 140,
     borderRadius: radius.lg,
-    borderWidth: 1,
+    borderWidth: StyleSheet.hairlineWidth,
     overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 4,
   },
   option: {
     flexDirection: 'row',
@@ -381,68 +376,59 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
     paddingHorizontal: layout.screenPaddingH,
     paddingTop: spacing.sm,
-    paddingBottom: spacing.sm,
+    paddingBottom: spacing.xs,
   },
   inner: {
     maxWidth: layout.maxWidth,
     width: '100%',
     alignSelf: 'center',
-    gap: spacing.sm,
+    gap: spacing.xs,
   },
   topRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    gap: spacing.md,
+    minHeight: 40,
   },
   brandRow: {
     flexDirection: 'row',
-    alignItems: 'baseline',
+    alignItems: 'center',
     gap: spacing.sm,
   },
   brandName: {
     fontSize: typography.heroName,
     fontWeight: '700',
-    letterSpacing: -0.8,
+    letterSpacing: -0.5,
     lineHeight: 30,
-  },
-  brandSub: {
-    fontSize: typography.caption,
-    fontWeight: '500',
-    letterSpacing: 0.8,
-    lineHeight: 16,
-    opacity: 0.42,
-    textTransform: 'lowercase',
   },
   controls: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing.sm,
+    gap: spacing.xs,
   },
   iconBtn: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
     borderWidth: StyleSheet.hairlineWidth,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  controlRow: {
+  modeRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.sm,
   },
   modeToggle: {
-    width: 156,
-    minHeight: 42,
+    height: 32,
     flexDirection: 'row',
     borderRadius: radius.pill,
     borderWidth: StyleSheet.hairlineWidth,
-    padding: 3,
-    gap: 3,
+    padding: 2,
+    gap: 2,
   },
   modeButton: {
-    flex: 1,
+    paddingHorizontal: spacing.md,
     borderRadius: radius.pill,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: 'transparent',
@@ -451,7 +437,20 @@ const styles = StyleSheet.create({
   },
   modeButtonText: {
     fontSize: typography.caption,
-    fontWeight: '800',
-    letterSpacing: 0,
+    fontWeight: '700',
+    letterSpacing: 0.1,
+  },
+  infoBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  infoBtnText: {
+    fontSize: typography.bodySmall,
+    fontWeight: '700',
+    lineHeight: 18,
   },
 });

--- a/apps/mobile/prototypes/v2/src/data/homeDataAdapter.ts
+++ b/apps/mobile/prototypes/v2/src/data/homeDataAdapter.ts
@@ -105,7 +105,7 @@ export function getHomeDisplayData({
       },
       bloodMarkers: {
         id: 'bloodMarkers',
-        label: 'Blood Markers',
+        label: 'Test Results',
         value: bloodMarkersScore,
         delta: null,
         colorKey: 'blood',
@@ -114,7 +114,6 @@ export function getHomeDisplayData({
         { label: 'DNA Insights' },
         { label: 'Stool Test' },
         { label: 'Urine Test' },
-        { label: 'Nutrition' },
       ],
     },
     scoreTrend: createScoreTrend(isDemo, trendData),

--- a/apps/mobile/prototypes/v2/src/screens/HomeScreen.tsx
+++ b/apps/mobile/prototypes/v2/src/screens/HomeScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import Svg, { Circle, Path, Rect } from 'react-native-svg';
 import { IdeasNotesCard } from '../components/IdeasNotesCard';
 import { prototypeCopy } from '../data/copy';
@@ -17,6 +17,7 @@ import type {
 import { useTheme } from '../theme/ThemeContext';
 import { layout, lineHeights, radius, spacing, typography } from '../theme/marathonTheme';
 import type { ThemeColors } from '../theme/marathonTheme';
+import { SCORE_CARD_SPLIT_WIDTH } from '../theme/v2Tokens';
 import {
   type CustomRange,
   type TimeRange,
@@ -41,13 +42,6 @@ type HomeScreenProps = {
 const SCORE_RING_SIZE = 160;
 const OUTER_RING_STROKE = 12;
 const INNER_RING_STROKE = 8;
-const SCORE_RING_COLORS = ['#7EC8AA', '#5DB890', '#3DA876', '#2B9463'];
-const SCORE_TEXT_LIGHT = '#1A5C38';
-const SCORE_TEXT_DARK = '#94CFA0';
-const RECOVERY_COLOR = '#5BA0B0';
-const ACTIVITY_COLOR = '#D4903A';
-const BLOOD_COLOR = '#6F9F79';
-const FUTURE_COLOR = '#B8B2AA';
 const SOFT_NEGATIVE = '#C97872';
 const CALENDAR_DAYS = 35;
 
@@ -130,14 +124,13 @@ function createCalendarDays() {
 
 function scoreTone(score: number | null, colors: ThemeColors) {
   if (score === null) return colors.textSubtle;
-  if (score >= 85) return SCORE_RING_COLORS[3];
-  if (score >= 70) return SCORE_RING_COLORS[2];
-  if (score >= 50) return SCORE_RING_COLORS[1];
-  return SCORE_RING_COLORS[0];
+  if (score >= 70) return colors.brandGreen;
+  if (score >= 50) return colors.scoreSoft;
+  return colors.scoreLow;
 }
 
 function softMint(colors: ThemeColors) {
-  return colors.statusBar === 'dark' ? 'rgba(178,213,184,0.12)' : 'rgba(215,239,219,0.42)';
+  return colors.brandGreenSoft;
 }
 
 function colorForKey(key: HomeMetricColorKey, colors: ThemeColors, score: number | null = null) {
@@ -145,27 +138,29 @@ function colorForKey(key: HomeMetricColorKey, colors: ThemeColors, score: number
     case 'score':
       return scoreTone(score, colors);
     case 'recovery':
-      return RECOVERY_COLOR;
+      return colors.recovery;
     case 'activity':
-      return ACTIVITY_COLOR;
+      return colors.activity;
     case 'blood':
-      return BLOOD_COLOR;
+      return colors.testResults;
     case 'future':
-      return FUTURE_COLOR;
+      return colors.disabled;
+    // recovery sub-metrics: lighter shades of recovery green
     case 'sleep':
-      return '#7DBBC9';
+      return '#72D4A2';
     case 'hrv':
-      return '#4A8A98';
+      return '#36B078';
     case 'restingHr':
-      return '#3A7A88';
+      return '#1FA367';
+    // activity sub-metrics: lighter shades of activity amber
     case 'steps':
-      return '#E5A857';
+      return '#F5B85A';
     case 'training':
-      return '#C47A28';
+      return '#E8882A';
     case 'calories':
-      return '#B86A18';
+      return '#D46A18';
     default:
-      return colors.scoreStrong;
+      return colors.brandGreen;
   }
 }
 
@@ -369,19 +364,23 @@ function ScoreCard({
   colors: ThemeColors;
 }) {
   const s = createHomeStyles(colors);
+  const { width } = useWindowDimensions();
+  const isWide = width >= SCORE_CARD_SPLIT_WIDTH;
   return (
     <View style={s.scoreCard}>
       <View style={s.scoreHeader}>
         <View style={{ flex: 1 }}>
           <Text style={s.cardEyebrow}>{score.contextLabel}</Text>
-          <Text style={s.scoreTitle}>One L1fe Score</Text>
+          <Text style={s.scoreTitle}>
+            One L<Text style={{ color: colors.brandGreen }}>1</Text>fe Score
+          </Text>
         </View>
-        <View style={s.coveragePill}>
+        <View style={[s.coveragePill, { borderColor: colors.borderSubtle }]}>
           <Text style={s.coverageText}>{score.coverageLabel}</Text>
         </View>
       </View>
 
-      <View style={s.scoreBodyRow}>
+      <View style={[s.scoreBodyRow, isWide && s.scoreBodyRowWide]}>
         <MultiRingScore
           score={score.overall}
           recoveryScore={score.recovery}
@@ -392,6 +391,7 @@ function ScoreCard({
         <ContributorLegend
           contributors={contributors}
           colors={colors}
+          flex={isWide}
         />
       </View>
     </View>
@@ -410,7 +410,7 @@ function MultiRingScore({
   colors: ThemeColors;
 }) {
   const s = createHomeStyles(colors);
-  const centerColor = colors.statusBar === 'dark' ? SCORE_TEXT_DARK : SCORE_TEXT_LIGHT;
+  const centerColor = score === null ? colors.textSubtle : colors.brandGreen;
   return (
     <View style={s.scoreRingWrap}>
       <Svg width={SCORE_RING_SIZE} height={SCORE_RING_SIZE} viewBox={`0 0 ${SCORE_RING_SIZE} ${SCORE_RING_SIZE}`}>
@@ -425,19 +425,19 @@ function MultiRingScore({
           value={recoveryScore}
           radius={54}
           strokeWidth={INNER_RING_STROKE}
-          color={RECOVERY_COLOR}
+          color={colors.recovery}
           trackColor={colors.progressTrack}
         />
         <ProgressCircle
           value={activityScore}
           radius={40}
           strokeWidth={INNER_RING_STROKE}
-          color={ACTIVITY_COLOR}
+          color={colors.activity}
           trackColor={colors.progressTrack}
         />
       </Svg>
       <View style={[StyleSheet.absoluteFillObject, s.scoreRingCenter]}>
-        <Text style={[s.scoreValue, { color: score === null ? colors.textSubtle : centerColor }]}>
+        <Text style={[s.scoreValue, { color: centerColor }]}>
           {score === null ? '--' : `${clamp(score)}%`}
         </Text>
         <Text style={s.scoreLabel}>ONE L1FE SCORE</Text>
@@ -578,22 +578,25 @@ function MiniLineSeries({ data, color }: { data: HomeChartPoint[]; color: string
 function ContributorLegend({
   contributors,
   colors,
+  flex,
 }: {
   contributors: HomeDisplayData['contributors'];
   colors: ThemeColors;
+  flex?: boolean;
 }) {
   const s = createHomeStyles(colors);
   const [recoveryOpen, setRecoveryOpen] = React.useState(true);
   const [activityOpen, setActivityOpen] = React.useState(false);
   return (
-    <View style={s.legendCard}>
+    <View style={[s.legendCard, flex && s.legendCardFlex]}>
+      {/* Recovery — accordion */}
       <Pressable
         onPress={() => setRecoveryOpen((o) => !o)}
         style={s.accordionHeader}
         accessibilityRole="button"
         accessibilityState={{ expanded: recoveryOpen }}
       >
-        <View style={[s.contributorDot, { backgroundColor: RECOVERY_COLOR }]} />
+        <View style={[s.contributorDot, { backgroundColor: colors.recovery }]} />
         <Text style={[s.contributorLabel, { fontWeight: '800' }]}>{contributors.recovery.label}</Text>
         <Text style={s.contributorValue}>
           {contributors.recovery.value === null ? '--' : `${clamp(contributors.recovery.value)}%`}
@@ -608,13 +611,14 @@ function ContributorLegend({
 
       <View style={s.legendDivider} />
 
+      {/* Activity — accordion */}
       <Pressable
         onPress={() => setActivityOpen((o) => !o)}
         style={s.accordionHeader}
         accessibilityRole="button"
         accessibilityState={{ expanded: activityOpen }}
       >
-        <View style={[s.contributorDot, { backgroundColor: ACTIVITY_COLOR }]} />
+        <View style={[s.contributorDot, { backgroundColor: colors.activity }]} />
         <Text style={[s.contributorLabel, { fontWeight: '800' }]}>{contributors.activity.label}</Text>
         <Text style={s.contributorValue}>
           {contributors.activity.value === null ? '--' : `${clamp(contributors.activity.value)}%`}
@@ -629,15 +633,19 @@ function ContributorLegend({
 
       <View style={s.legendDivider} />
 
+      {/* Test Results — single static row, no chevron */}
       <ContributorRow item={contributors.bloodMarkers} colors={colors} />
 
-      {contributors.future.length > 0 && (
-        <View style={s.futureSection}>
-          {contributors.future.map((item) => (
-            <FutureContributor key={item.label} label={item.label} colors={colors} />
-          ))}
+      <View style={s.legendDivider} />
+
+      {/* Nutrition — disabled / coming soon */}
+      <View style={[s.contributorRow, { opacity: 0.5 }]}>
+        <View style={[s.contributorDot, { backgroundColor: colors.disabled }]} />
+        <Text style={[s.contributorLabel, { color: colors.textSubtle }]}>Nutrition</Text>
+        <View style={s.comingSoonPill}>
+          <Text style={s.comingSoonText}>Soon</Text>
         </View>
-      )}
+      </View>
     </View>
   );
 }
@@ -674,16 +682,6 @@ function ContributorRow({
   );
 }
 
-function FutureContributor({ label, colors }: { label: string; colors: ThemeColors }) {
-  const s = createHomeStyles(colors);
-  return (
-    <View style={s.contributorRow}>
-      <View style={[s.contributorDot, { backgroundColor: FUTURE_COLOR, opacity: 0.46 }]} />
-      <Text style={[s.contributorLabel, { color: colors.textSubtle }]}>{label}</Text>
-      <Text style={s.futureValue}>Coming soon</Text>
-    </View>
-  );
-}
 
 function TrendCard({
   title,
@@ -1126,9 +1124,9 @@ function createHomeStyles(colors: ThemeColors) {
     },
     scoreCard: {
       borderRadius: radius.xl,
-      backgroundColor: colors.surfaceElevated,
+      backgroundColor: colors.surface,
       borderWidth: StyleSheet.hairlineWidth,
-      borderColor: colors.border,
+      borderColor: colors.borderSubtle,
       padding: spacing.lg,
       alignItems: 'center',
       gap: spacing.md,
@@ -1174,6 +1172,11 @@ function createHomeStyles(colors: ThemeColors) {
       alignItems: 'center',
       gap: spacing.sm,
     },
+    scoreBodyRowWide: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: spacing.md,
+    },
     scoreRingWrap: {
       width: SCORE_RING_SIZE,
       height: SCORE_RING_SIZE,
@@ -1189,7 +1192,6 @@ function createHomeStyles(colors: ThemeColors) {
       lineHeight: 48,
       fontWeight: '900',
       letterSpacing: -1,
-      fontVariant: ['tabular-nums'],
     },
     scoreLabel: {
       color: colors.textSubtle,
@@ -1256,9 +1258,14 @@ function createHomeStyles(colors: ThemeColors) {
       borderRadius: radius.lg,
       borderWidth: StyleSheet.hairlineWidth,
       borderColor: colors.borderSubtle,
-      backgroundColor: colors.surface,
+      backgroundColor: colors.surfaceSoft,
       padding: spacing.sm,
       gap: 2,
+    },
+    legendCardFlex: {
+      flex: 1,
+      minWidth: 0,
+      alignSelf: 'auto',
     },
     legendDivider: {
       height: StyleSheet.hairlineWidth,
@@ -1312,14 +1319,12 @@ function createHomeStyles(colors: ThemeColors) {
       fontSize: typography.micro,
       fontWeight: '800',
       textAlign: 'right',
-      fontVariant: ['tabular-nums'],
     },
     contributorDelta: {
       width: 24,
       fontSize: typography.micro,
       fontWeight: '800',
       textAlign: 'right',
-      fontVariant: ['tabular-nums'],
     },
     deltaSpacer: {
       width: 24,

--- a/apps/mobile/prototypes/v2/src/screens/TrendsScreen.tsx
+++ b/apps/mobile/prototypes/v2/src/screens/TrendsScreen.tsx
@@ -313,7 +313,7 @@ function ScoreTrendSection({ data }: { data: HomeDisplayData }) {
           {data.score.overall !== null ? `${data.score.overall}` : '—'}
         </Text>
       </View>
-      <LineChart data={scoreSeries.data} color={colors.scoreStrong} />
+      <LineChart data={scoreSeries.data} color={colors.brandGreen} />
       <View style={scoreTrendStyles.legend}>
         {trend.series.map((s) => (
           <Text key={s.label} style={[scoreTrendStyles.legendItem, { color: colors.textSubtle }]}>
@@ -348,8 +348,8 @@ export function TrendsScreen({ data }: { data: HomeDisplayData }) {
   const rec = data.recoveryMetrics;
   const act = data.activityMetrics;
 
-  const accentRecover = colors.scoreStrong;
-  const accentActivity = (colors as Record<string, string>).accent ?? colors.scoreStrong;
+  const accentRecover = colors.recovery;
+  const accentActivity = colors.activity;
 
   return (
     <ScrollView

--- a/apps/mobile/prototypes/v2/src/theme/marathonTheme.ts
+++ b/apps/mobile/prototypes/v2/src/theme/marathonTheme.ts
@@ -1,5 +1,6 @@
 // One L1fe — V2 — Design tokens
 // Single source of truth for Android and Web in the v2 workspace.
+import { v2DarkTokens, v2LightTokens } from './v2Tokens';
 
 export const spacing = {
   xs:   4,
@@ -46,6 +47,7 @@ export type ThemeColors = {
   background:        string;
   surface:           string;
   surfaceElevated:   string;
+  surfaceSoft:       string;
   border:            string;
   borderSubtle:      string;
   text:              string;
@@ -74,72 +76,96 @@ export type ThemeColors = {
   demoBanner:        string;
   demoBannerBorder:  string;
   statusBar:         'dark' | 'light';
+  // v2 semantic tokens
+  brandGreen:        string;
+  brandGreenDark:    string;
+  brandGreenSoft:    string;
+  recovery:          string;
+  activity:          string;
+  testResults:       string;
+  disabled:          string;
 };
 
 export const lightColors: ThemeColors = {
-  background:       '#F9F7F4',
-  surface:          '#F3F0EB',
-  surfaceElevated:  '#FFFFFF',
-  border:           'rgba(60,40,20,0.10)',
-  borderSubtle:     'rgba(60,40,20,0.055)',
-  text:             '#1C1917',
-  textMuted:        '#5A5249',
-  textSubtle:       '#9A928A',
+  background:       v2LightTokens.background,
+  surface:          v2LightTokens.surface,
+  surfaceElevated:  v2LightTokens.surface,
+  surfaceSoft:      v2LightTokens.surfaceSoft,
+  border:           'rgba(17,24,32,0.09)',
+  borderSubtle:     v2LightTokens.borderSubtle,
+  text:             v2LightTokens.textPrimary,
+  textMuted:        '#485060',
+  textSubtle:       v2LightTokens.textSecondary,
   accent:           '#C4612C',
   accentBorder:     'rgba(196,97,44,0.25)',
   accentSoft:       'rgba(196,97,44,0.06)',
-  positive:         '#3A7A58',
+  positive:         '#1DAB68',
   warning:          '#A86E28',
   warningSoft:      'rgba(168,110,40,0.08)',
   danger:           '#993636',
-  scoreStrong:      '#4F9A66',
-  scoreStrongSoft:  'rgba(148,207,160,0.18)',
-  scoreSteady:      '#5F8F68',
-  scoreSteadySoft:  'rgba(178,213,184,0.18)',
-  scoreSoft:        '#78957D',
-  scoreSoftSoft:    'rgba(199,223,204,0.18)',
-  scoreLow:         '#8FA394',
-  scoreLowSoft:     'rgba(215,239,219,0.20)',
-  ringTrack:        '#EDE8E2',
-  ringProgress:     '#C4612C',
-  progressTrack:    '#EDE8E2',
-  profileSectionBg: '#FFFFFF',
-  profileRowBorder: 'rgba(60,40,20,0.06)',
+  scoreStrong:      v2LightTokens.brandGreen,
+  scoreStrongSoft:  v2LightTokens.brandGreenSoft,
+  scoreSteady:      '#2FAD6A',
+  scoreSteadySoft:  'rgba(47,173,106,0.12)',
+  scoreSoft:        '#5CC58D',
+  scoreSoftSoft:    'rgba(92,197,141,0.14)',
+  scoreLow:         '#8DCBA8',
+  scoreLowSoft:     'rgba(141,203,168,0.16)',
+  ringTrack:        v2LightTokens.borderSubtle,
+  ringProgress:     v2LightTokens.brandGreen,
+  progressTrack:    v2LightTokens.borderSubtle,
+  profileSectionBg: v2LightTokens.surface,
+  profileRowBorder: 'rgba(17,24,32,0.05)',
   demoBanner:       '#FEF7F2',
   demoBannerBorder: 'rgba(196,97,44,0.18)',
   statusBar:        'dark',
+  brandGreen:       v2LightTokens.brandGreen,
+  brandGreenDark:   v2LightTokens.brandGreenDark,
+  brandGreenSoft:   v2LightTokens.brandGreenSoft,
+  recovery:         v2LightTokens.recovery,
+  activity:         v2LightTokens.activity,
+  testResults:      v2LightTokens.testResults,
+  disabled:         v2LightTokens.disabled,
 };
 
 export const darkColors: ThemeColors = {
-  background:       '#0A0A0B',
-  surface:          '#111113',
-  surfaceElevated:  '#141416',
-  border:           'rgba(255,255,255,0.07)',
-  borderSubtle:     'rgba(255,255,255,0.035)',
-  text:             '#F2EFEA',
-  textMuted:        '#A8A29A',
-  textSubtle:       '#6E6862',
+  background:       v2DarkTokens.background,
+  surface:          v2DarkTokens.surface,
+  surfaceElevated:  v2DarkTokens.surfaceSoft,
+  surfaceSoft:      v2DarkTokens.surfaceSoft,
+  border:           'rgba(244,246,242,0.08)',
+  borderSubtle:     v2DarkTokens.borderSubtle,
+  text:             v2DarkTokens.textPrimary,
+  textMuted:        '#C0C8C2',
+  textSubtle:       v2DarkTokens.textSecondary,
   accent:           '#E07A45',
   accentBorder:     'rgba(224,122,69,0.32)',
   accentSoft:       'rgba(224,122,69,0.10)',
-  positive:         '#5BAE7C',
+  positive:         '#1DBC74',
   warning:          '#D69846',
   warningSoft:      'rgba(214,152,70,0.12)',
   danger:           '#C25A5A',
-  scoreStrong:      '#94CFA0',
-  scoreStrongSoft:  'rgba(148,207,160,0.16)',
-  scoreSteady:      '#B2D5B8',
-  scoreSteadySoft:  'rgba(178,213,184,0.14)',
-  scoreSoft:        '#C7DFCC',
-  scoreSoftSoft:    'rgba(199,223,204,0.12)',
-  scoreLow:         '#A8BAAC',
-  scoreLowSoft:     'rgba(215,239,219,0.10)',
-  ringTrack:        '#1F1F22',
-  ringProgress:     '#E07A45',
-  progressTrack:    '#1F1F22',
-  profileSectionBg: '#141416',
-  profileRowBorder: 'rgba(255,255,255,0.05)',
-  demoBanner:       '#161616',
+  scoreStrong:      v2DarkTokens.brandGreen,
+  scoreStrongSoft:  v2DarkTokens.brandGreenSoft,
+  scoreSteady:      '#2FAD6A',
+  scoreSteadySoft:  'rgba(47,173,106,0.14)',
+  scoreSoft:        '#5CC58D',
+  scoreSoftSoft:    'rgba(92,197,141,0.12)',
+  scoreLow:         '#8DCBA8',
+  scoreLowSoft:     'rgba(141,203,168,0.10)',
+  ringTrack:        v2DarkTokens.borderSubtle,
+  ringProgress:     v2DarkTokens.brandGreen,
+  progressTrack:    v2DarkTokens.borderSubtle,
+  profileSectionBg: v2DarkTokens.surfaceSoft,
+  profileRowBorder: 'rgba(244,246,242,0.05)',
+  demoBanner:       '#161B17',
   demoBannerBorder: 'rgba(224,122,69,0.22)',
   statusBar:        'light',
+  brandGreen:       v2DarkTokens.brandGreen,
+  brandGreenDark:   v2DarkTokens.brandGreenDark,
+  brandGreenSoft:   v2DarkTokens.brandGreenSoft,
+  recovery:         v2DarkTokens.recovery,
+  activity:         v2DarkTokens.activity,
+  testResults:      v2DarkTokens.testResults,
+  disabled:         v2DarkTokens.disabled,
 };

--- a/apps/mobile/prototypes/v2/src/theme/v2Tokens.ts
+++ b/apps/mobile/prototypes/v2/src/theme/v2Tokens.ts
@@ -1,0 +1,37 @@
+// One L1fe — v2 design tokens
+// Single source of truth for brand, semantic color, and layout constants.
+// Components import tokens only via ThemeColors (useTheme) — not directly from here.
+
+export const SCORE_CARD_SPLIT_WIDTH = 390;
+
+export const v2LightTokens = {
+  background:     '#FAF9F6',
+  surface:        '#FFFFFF',
+  surfaceSoft:    '#F3F1EC',
+  textPrimary:    '#111820',
+  textSecondary:  '#6F7782',
+  borderSubtle:   '#E7E9E6',
+  brandGreen:     '#1DBC74',
+  brandGreenDark: '#159B60',
+  brandGreenSoft: '#EAF8F1',
+  recovery:       '#4FC58B',
+  activity:       '#F59E3D',
+  testResults:    '#27B7C8',
+  disabled:       '#B8B8B2',
+} as const;
+
+export const v2DarkTokens = {
+  background:     '#101512',
+  surface:        '#171D19',
+  surfaceSoft:    '#202721',
+  textPrimary:    '#F4F6F2',
+  textSecondary:  '#A9B0AA',
+  borderSubtle:   '#2B332D',
+  brandGreen:     '#1DBC74',
+  brandGreenDark: '#159B60',
+  brandGreenSoft: '#173D2B',
+  recovery:       '#4FC58B',
+  activity:       '#F2A24A',
+  testResults:    '#34BFD0',
+  disabled:       '#6E756F',
+} as const;


### PR DESCRIPTION
## Summary

- **Brand lockup**: SVG logo-mark (open circle + integrated "1") + "One L1fe" wordmark, both using `brandGreen` (#1DBC74). No gradients or shadows.
- **v2Tokens.ts**: New canonical token file with light/dark semantic colors (`brandGreen`, `recovery`, `activity`, `testResults`, `disabled`, `surfaceSoft`, etc.) and `SCORE_CARD_SPLIT_WIDTH = 390`.
- **Responsive score card**: Ring visual left, contributors right when `width >= 390`; stacked on narrow screens (uses `useWindowDimensions`).
- **Contributors**: Recovery (accordion), Activity (accordion), Test Results (one row, no chevron), Nutrition (disabled / "Soon"). Removed old future-contributors ghost section.
- **Token alignment**: `marathonTheme.ts` extended with v2 semantic keys; components use `colors.brandGreen / recovery / activity / testResults` instead of hardcoded hex.
- **Clean-up**: Removed `fontVariant: ['tabular-nums']` (no Manrope asset loaded), updated `softMint` to use `colors.brandGreenSoft`, updated Trends accent colors to semantic tokens.

## Files changed

| File | Change |
|------|--------|
| `theme/v2Tokens.ts` | **NEW** — raw token source |
| `theme/marathonTheme.ts` | Extended `ThemeColors` type + updated light/dark values |
| `components/AppHeaderV2.tsx` | New header layout: logo-mark, compact controls, calm mode toggle |
| `screens/HomeScreen.tsx` | Responsive score card, updated contributors, semantic colors |
| `screens/TrendsScreen.tsx` | Semantic accent colors for recovery/activity |
| `data/homeDataAdapter.ts` | "Blood Markers" → "Test Results", removed Nutrition from future array |

## QA (Android Pixel 9 Pro emulator)

- [x] App opens on Home
- [x] Header: logo-mark readable, "One L1fe" wordmark, "1W" dropdown, theme toggle, profile icon
- [x] Range dropdown: opens below trigger, "1W" active with ✓, all 7 options shown
- [x] Score card row layout active at 411dp (>= 390 threshold)
- [x] Three rings: brand green outer, recovery green middle, activity amber inner
- [x] Contributors: Recovery expanded (Sleep/HRV/Resting HR), Activity collapsed/expandable, Test Results (teal dot, no chevron), Nutrition (disabled, "Soon" pill)
- [x] Dark mode toggle: visually clean dark theme
- [x] Trends tab: global header persists, semantic recovery/activity colors
- [x] No bottom-nav overlap, no clipped text
- [x] `typecheck`, `typecheck:mobile`, `test:domain` all pass
- [x] `npx expo run:android` → BUILD SUCCESSFUL

## Remaining risks

1. **Custom date picker unreachable from Trends tab** — no calendar widget when "Custom" is selected from Trends. Selecting Custom on Trends sets the range but shows no picker (picker lives in HomeScreen).
2. **TrendsScreen metric cards** — score trend still uses `colors.brandGreen`; individual Recovery/Activity metric card accent colors are consistent but not differentiated per sub-metric.
3. **Manrope font** — `fontVariant: ['tabular-nums']` removed as specced; if Manrope is later loaded, numeric formatting should be re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)