### PR TITLE
feat(mobile): v2 UX review pass

### DIFF
--- a/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
+++ b/apps/mobile/prototypes/v2/src/OneL1feV2Screen.tsx
@@ -17,6 +17,7 @@ import { AppHeaderV2 } from './components/AppHeaderV2';
 import { BottomNavV2, type BottomTabKey } from './components/BottomNavV2';
 import { BloodResultsScreenV2 } from './screens/BloodResultsScreenV2';
 import { HomeScreen } from './screens/HomeScreen';
+import { InsightsScreen } from './screens/InsightsScreen';
 import { ProfileScreenV2 } from './screens/ProfileScreenV2';
 import { TrendsScreen } from './screens/TrendsScreen';
 import { prototypeCopy } from './data/copy';
@@ -136,10 +137,7 @@ function V2Shell() {
           ) : activeView === 'trends' ? (
             <TrendsScreen data={trendsData} />
           ) : activeView === 'insights' ? (
-            <TopLevelPlaceholder
-              title="Insights"
-              subtitle="Insights will summarize patterns from your connected data."
-            />
+            <InsightsScreen />
           ) : (
             <HomeScreen
               onDemoInfoPress={() => setDemoInfoVisible(true)}

--- a/apps/mobile/prototypes/v2/src/screens/HomeScreen.tsx
+++ b/apps/mobile/prototypes/v2/src/screens/HomeScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import Svg, { Circle, Path } from 'react-native-svg';
-import { IdeasNotesCard } from '../components/IdeasNotesCard';
 import {
   InteractiveTrendChartV2,
   QuietBarChartV2,
@@ -122,6 +121,19 @@ function createCalendarDays() {
   const today = startOfDay(new Date());
   const first = addDays(today, -(CALENDAR_DAYS - 1));
   return Array.from({ length: CALENDAR_DAYS }, (_, index) => addDays(first, index));
+}
+
+function buildScoreInsight(
+  contributors: HomeDisplayData['contributors'],
+  isDemo: boolean,
+): string | null {
+  if (!isDemo) return null;
+  const r = contributors.recovery.delta;
+  const a = contributors.activity.delta;
+  const parts: string[] = [];
+  if (r !== null) parts.push(r > 0 ? `Recovery +${r}` : r < 0 ? `Recovery ${r}` : 'Recovery →');
+  if (a !== null) parts.push(a > 0 ? `Activity +${a}` : a < 0 ? `Activity ${a}` : 'Activity →');
+  return parts.length ? parts.join(' · ') + ' vs last period' : null;
 }
 
 function scoreTone(score: number | null, colors: ThemeColors) {
@@ -284,10 +296,6 @@ export function HomeScreen({
             colors={colors}
           />
 
-          <NextIntegrations colors={colors} />
-
-          <IdeasNotesCard />
-
           <SourceStatusCard
             hcStatus={hcStatus}
             onManageSources={onManageSources}
@@ -372,6 +380,7 @@ function ScoreCard({
   const { width } = useWindowDimensions();
   const isWide = width >= SCORE_CARD_SPLIT_WIDTH;
   const isCompactWide = isWide && width < 600;
+  const insight = buildScoreInsight(contributors, dataMode === 'demo');
   return (
     <View style={s.scoreCard}>
       <View style={s.scoreTopRow}>
@@ -406,6 +415,7 @@ function ScoreCard({
       <View style={[s.scoreBodyRow, isWide && s.scoreBodyRowWide, isCompactWide && s.scoreBodyRowCompactWide]}>
         <MultiRingScore
           score={score.overall}
+          insight={insight}
           colors={colors}
         />
 
@@ -420,7 +430,7 @@ function ScoreCard({
   );
 }
 
-function MultiRingScore({ score, colors }: { score: number | null; colors: ThemeColors }) {
+function MultiRingScore({ score, insight, colors }: { score: number | null; insight?: string | null; colors: ThemeColors }) {
   const s = createHomeStyles(colors);
   const centerColor = score === null ? colors.textSubtle : colors.brandGreen;
   return (
@@ -440,6 +450,7 @@ function MultiRingScore({ score, colors }: { score: number | null; colors: Theme
         </Text>
         <Text style={s.scoreLabel}>One L1fe Score</Text>
         <Text style={s.scoreStatusLine}>{score === null ? 'Waiting for data' : '● Good'}</Text>
+        {insight ? <Text style={s.scoreInsightLine}>{insight}</Text> : null}
       </View>
       <View style={s.scoreBasisRow}>
         <View style={s.scoreBasisIcon}>
@@ -547,8 +558,6 @@ function ScoreTrendMiniChart({
         <TrendLegendPill label="Score" color={scoreColor} on={visible.score} onPress={() => toggle('score')} colors={colors} />
         <TrendLegendPill label="Recovery" color={colors.recovery} on={visible.recovery} onPress={() => toggle('recovery')} colors={colors} />
         <TrendLegendPill label="Activity" color={colors.activity} on={visible.activity} onPress={() => toggle('activity')} colors={colors} />
-        <TrendLegendPill label="Test Results" color={colors.testResults} on={false} colors={colors} />
-        <TrendLegendPill label="Nutrition" color={colors.disabled} on={false} colors={colors} />
       </View>
     </View>
   );
@@ -995,43 +1004,6 @@ function HealthInputCard({
   );
 }
 
-const NEXT_INTEGRATIONS: { label: string; icon: HomeHealthInputIcon; description: string }[] = [
-  { label: 'Nutrition', icon: 'nutrition', description: 'Dietary intake and macro tracking' },
-  { label: 'Mental Health', icon: 'dna', description: 'Mood, stress, and cognitive signals' },
-  { label: 'DNA Insights', icon: 'dna', description: 'Genetic predispositions and traits' },
-  { label: 'Stool Analysis', icon: 'stool', description: 'Gut microbiome and digestive health' },
-  { label: 'Urine Analysis', icon: 'urine', description: 'Metabolic and kidney health markers' },
-];
-
-function NextIntegrations({ colors }: { colors: ThemeColors }) {
-  const s = createHomeStyles(colors);
-  return (
-    <View style={s.nextIntegrationsSection}>
-      <View style={s.nextIntegrationsHeader}>
-        <Text style={s.nextIntegrationsTitle}>Next Integrations</Text>
-        <Text style={s.nextIntegrationsSubtitle}>Premium data sources in development</Text>
-      </View>
-      {NEXT_INTEGRATIONS.map((item) => (
-        <View key={item.label} style={s.nextIntegrationCard}>
-          <View style={s.nextIntegrationIcon}>
-            <HealthInputGlyph name={item.icon} color={colors.disabled} />
-          </View>
-          <View style={{ flex: 1 }}>
-            <Text style={s.nextIntegrationLabel}>{item.label}</Text>
-            <Text style={s.nextIntegrationDescription}>{item.description}</Text>
-          </View>
-          <View style={s.nextIntegrationBar}>
-            <View style={s.nextIntegrationBarFill} />
-          </View>
-          <View style={s.comingSoonPill}>
-            <Text style={s.comingSoonText}>Coming soon</Text>
-          </View>
-        </View>
-      ))}
-    </View>
-  );
-}
-
 function HealthInputGlyph({ name, color }: { name: HomeHealthInputIcon; color: string }) {
   if (name === 'blood') {
     return (
@@ -1099,7 +1071,7 @@ function SourceStatusCard({
         </View>
         <View style={{ flex: 1 }}>
           <Text style={s.sourceTitle}>Sources</Text>
-          <Text style={s.sourceSubtitle}>Health Connect is display-only in this prototype.</Text>
+          <Text style={s.sourceSubtitle}>Data sources are read-only in this version.</Text>
         </View>
       </View>
       <View style={s.sourceFooter}>
@@ -1298,7 +1270,7 @@ function createHomeStyles(colors: ThemeColors) {
     },
     scoreRingWrap: {
       width: SCORE_RING_SIZE,
-      minHeight: SCORE_RING_SIZE + 76,
+      minHeight: SCORE_RING_SIZE + 96,
       alignItems: 'center',
       justifyContent: 'flex-start',
     },
@@ -1325,6 +1297,15 @@ function createHomeStyles(colors: ThemeColors) {
       lineHeight: 22,
       fontWeight: '700',
       marginTop: spacing.xs,
+    },
+    scoreInsightLine: {
+      color: colors.textSubtle,
+      fontSize: typography.caption,
+      lineHeight: lineHeights.caption,
+      fontWeight: '600',
+      textAlign: 'center',
+      marginTop: 2,
+      paddingHorizontal: spacing.sm,
     },
     scoreBasisRow: {
       width: '100%',
@@ -1776,67 +1757,6 @@ function createHomeStyles(colors: ThemeColors) {
       fontSize: typography.micro,
       lineHeight: lineHeights.caption,
       fontWeight: '800',
-    },
-    nextIntegrationsSection: {
-      gap: spacing.sm,
-    },
-    nextIntegrationsHeader: {
-      gap: 2,
-      paddingHorizontal: spacing.xs,
-    },
-    nextIntegrationsTitle: {
-      fontSize: typography.subtitle,
-      fontWeight: '800',
-      color: colors.textSubtle,
-    },
-    nextIntegrationsSubtitle: {
-      fontSize: typography.caption,
-      lineHeight: lineHeights.caption,
-      fontWeight: '600',
-      color: colors.textSubtle,
-    },
-    nextIntegrationCard: {
-      borderRadius: radius.lg,
-      backgroundColor: colors.surfaceSoft,
-      borderWidth: StyleSheet.hairlineWidth,
-      borderColor: colors.borderSubtle,
-      borderStyle: 'dashed',
-      padding: spacing.lg,
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: spacing.md,
-      opacity: 0.7,
-    },
-    nextIntegrationIcon: {
-      width: 36,
-      height: 36,
-      borderRadius: 18,
-      alignItems: 'center' as const,
-      justifyContent: 'center' as const,
-      backgroundColor: colors.surface,
-    },
-    nextIntegrationLabel: {
-      fontSize: typography.bodySmall,
-      fontWeight: '800',
-      color: colors.textSubtle,
-    },
-    nextIntegrationDescription: {
-      fontSize: typography.caption,
-      lineHeight: lineHeights.caption,
-      fontWeight: '500',
-      color: colors.disabled,
-    },
-    nextIntegrationBar: {
-      width: 44,
-      height: 4,
-      borderRadius: 2,
-      backgroundColor: colors.borderSubtle,
-      overflow: 'hidden' as const,
-    },
-    nextIntegrationBarFill: {
-      width: 0,
-      height: 4,
-      backgroundColor: colors.disabled,
     },
     sourceCard: {
       borderRadius: radius.lg,

--- a/apps/mobile/prototypes/v2/src/screens/InsightsScreen.tsx
+++ b/apps/mobile/prototypes/v2/src/screens/InsightsScreen.tsx
@@ -1,0 +1,846 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Keyboard,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { IdeasNotesCard } from '../components/IdeasNotesCard';
+import { useTheme } from '../theme/ThemeContext';
+import { layout, lineHeights, radius, spacing, typography } from '../theme/marathonTheme';
+import type { ThemeColors } from '../theme/marathonTheme';
+
+const EXPERIMENTS_KEY = '@one_l1fe_experiments_v1';
+
+type ExperimentCategory = 'Nutrition' | 'Recovery' | 'Activity' | 'Sleep' | 'Custom';
+const CATEGORIES: ExperimentCategory[] = ['Nutrition', 'Recovery', 'Activity', 'Sleep', 'Custom'];
+
+type Experiment = {
+  id: string;
+  title: string;
+  description: string;
+  category: ExperimentCategory;
+  hypothesis: string;
+  startDate: string;
+  endDate: string;
+  createdAt: number;
+};
+
+function isoToday(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function addDaysToIso(from: string, days: number): string {
+  const base = from.match(/^\d{4}-\d{2}-\d{2}$/) ? from : isoToday();
+  const d = new Date(base);
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function getStatus(exp: Experiment): 'planned' | 'active' | 'completed' {
+  const now = Date.now();
+  const start = new Date(exp.startDate).getTime();
+  const end = new Date(exp.endDate).getTime();
+  if (!isNaN(end) && now > end + 86400000) return 'completed';
+  if (!isNaN(start) && !isNaN(end) && now >= start && now <= end + 86400000) return 'active';
+  return 'planned';
+}
+
+async function loadExperiments(): Promise<Experiment[]> {
+  try {
+    const raw = await AsyncStorage.getItem(EXPERIMENTS_KEY);
+    return raw ? (JSON.parse(raw) as Experiment[]) : [];
+  } catch { return []; }
+}
+
+async function persistExperiments(items: Experiment[]): Promise<void> {
+  try {
+    await AsyncStorage.setItem(EXPERIMENTS_KEY, JSON.stringify(items));
+  } catch { /* noop */ }
+}
+
+const NEXT_INTEGRATIONS: { label: string; desc: string }[] = [
+  { label: 'Nutrition', desc: 'Dietary intake and macro tracking' },
+  { label: 'Mental Health', desc: 'Mood, stress, and cognitive signals' },
+  { label: 'DNA Insights', desc: 'Genetic predispositions and traits' },
+  { label: 'Stool Analysis', desc: 'Gut microbiome and digestive health' },
+  { label: 'Urine Analysis', desc: 'Metabolic and kidney health markers' },
+];
+
+export function InsightsScreen() {
+  const { colors } = useTheme();
+  const [experiments, setExperiments] = useState<Experiment[]>([]);
+  const [formOpen, setFormOpen] = useState(false);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    loadExperiments().then(setExperiments);
+  }, []);
+
+  useEffect(() => {
+    if (isFirstRender.current) { isFirstRender.current = false; return; }
+    persistExperiments(experiments);
+  }, [experiments]);
+
+  const handleAdd = useCallback((exp: Omit<Experiment, 'id' | 'createdAt'>) => {
+    setExperiments((prev) => [
+      { ...exp, id: Date.now().toString(), createdAt: Date.now() },
+      ...prev,
+    ]);
+    setFormOpen(false);
+  }, []);
+
+  function handleDelete(id: string) {
+    setExperiments((prev) => prev.filter((e) => e.id !== id));
+  }
+
+  return (
+    <>
+      <ScrollView
+        style={{ flex: 1, backgroundColor: colors.background }}
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+        contentInsetAdjustmentBehavior="automatic"
+      >
+        <View style={styles.container}>
+          <View style={[styles.hero, { backgroundColor: colors.surfaceElevated, borderColor: colors.border }]}>
+            <Text style={[styles.heroEyebrow, { color: colors.brandGreen }]}>Insights & Experiments</Text>
+            <Text style={[styles.heroTitle, { color: colors.text, fontFamily: 'BrandDisplay' }]}>Your health lab</Text>
+            <Text style={[styles.heroSubtitle, { color: colors.textMuted }]}>
+              Plan and track self-experiments. Log a change, set a timeframe, then watch how it moves your metrics.
+            </Text>
+          </View>
+
+          <View style={styles.section}>
+            <View style={styles.sectionHeaderRow}>
+              <View style={{ flex: 1 }}>
+                <Text style={[styles.sectionTitle, { color: colors.text }]}>Experiments</Text>
+                <Text style={[styles.sectionSubtitle, { color: colors.textSubtle }]}>
+                  Track a routine change and observe the impact.
+                </Text>
+              </View>
+              <Pressable
+                onPress={() => setFormOpen(true)}
+                style={({ pressed }) => [
+                  styles.newBtn,
+                  { backgroundColor: colors.brandGreenSoft, borderColor: colors.accentBorder },
+                  pressed && { opacity: 0.72 },
+                ]}
+                accessibilityLabel="Plan a new experiment"
+              >
+                <Text style={[styles.newBtnText, { color: colors.brandGreenDark }]}>+ New</Text>
+              </Pressable>
+            </View>
+
+            {experiments.length === 0 ? (
+              <Pressable
+                onPress={() => setFormOpen(true)}
+                style={({ pressed }) => [
+                  styles.emptyCard,
+                  { backgroundColor: colors.surface, borderColor: colors.borderSubtle },
+                  pressed && { opacity: 0.76 },
+                ]}
+                accessibilityLabel="Plan your first experiment"
+              >
+                <Text style={[styles.emptyTitle, { color: colors.text }]}>Plan your first experiment</Text>
+                <Text style={[styles.emptyExample, { color: colors.textMuted }]}>
+                  e.g. "30 days meat-free — does it improve my Recovery score?"
+                </Text>
+                <Text style={[styles.emptyLink, { color: colors.brandGreen }]}>+ Plan an experiment →</Text>
+              </Pressable>
+            ) : (
+              experiments.map((exp) => (
+                <ExperimentCard
+                  key={exp.id}
+                  experiment={exp}
+                  onDelete={handleDelete}
+                  colors={colors}
+                />
+              ))
+            )}
+          </View>
+
+          <View style={styles.section}>
+            <View style={styles.sectionHeaderRow}>
+              <View style={{ flex: 1 }}>
+                <Text style={[styles.sectionTitle, { color: colors.text }]}>Notes & Ideas</Text>
+                <Text style={[styles.sectionSubtitle, { color: colors.textSubtle }]}>
+                  Quick observations, questions, hypotheses.
+                </Text>
+              </View>
+            </View>
+            <IdeasNotesCard />
+          </View>
+
+          <View style={styles.section}>
+            <View style={styles.sectionHeaderRow}>
+              <View>
+                <Text style={[styles.sectionTitle, { color: colors.textSubtle }]}>Next integrations</Text>
+                <Text style={[styles.sectionSubtitle, { color: colors.disabled }]}>
+                  Premium data sources in development
+                </Text>
+              </View>
+            </View>
+            {NEXT_INTEGRATIONS.map((item) => (
+              <View
+                key={item.label}
+                style={[styles.nextRow, { backgroundColor: colors.surfaceSoft, borderColor: colors.borderSubtle }]}
+              >
+                <View style={{ flex: 1 }}>
+                  <Text style={[styles.nextLabel, { color: colors.textSubtle }]}>{item.label}</Text>
+                  <Text style={[styles.nextDesc, { color: colors.disabled }]}>{item.desc}</Text>
+                </View>
+                <View style={[styles.comingSoonPill, { borderColor: colors.borderSubtle, backgroundColor: colors.surface }]}>
+                  <Text style={[styles.comingSoonText, { color: colors.disabled }]}>Coming soon</Text>
+                </View>
+              </View>
+            ))}
+          </View>
+        </View>
+      </ScrollView>
+
+      <ExperimentFormModal
+        visible={formOpen}
+        onClose={() => setFormOpen(false)}
+        onSave={handleAdd}
+        colors={colors}
+      />
+    </>
+  );
+}
+
+function ExperimentCard({
+  experiment,
+  onDelete,
+  colors,
+}: {
+  experiment: Experiment;
+  onDelete: (id: string) => void;
+  colors: ThemeColors;
+}) {
+  const status = getStatus(experiment);
+  const statusColor =
+    status === 'active' ? colors.brandGreen :
+    status === 'completed' ? colors.textMuted :
+    colors.textSubtle;
+  const statusBg =
+    status === 'active' ? colors.brandGreenSoft :
+    status === 'completed' ? colors.surfaceSoft :
+    colors.surface;
+
+  return (
+    <View style={[styles.expCard, { backgroundColor: colors.surface, borderColor: colors.borderSubtle }]}>
+      <View style={styles.expCardTop}>
+        <View style={[styles.categoryChip, { backgroundColor: colors.accentSoft, borderColor: colors.accentBorder }]}>
+          <Text style={[styles.categoryText, { color: colors.brandGreenDark }]}>{experiment.category}</Text>
+        </View>
+        <View style={[styles.statusChip, { backgroundColor: statusBg, borderColor: `${statusColor}55` }]}>
+          <Text style={[styles.statusText, { color: statusColor }]}>{status}</Text>
+        </View>
+        <Pressable
+          onPress={() => onDelete(experiment.id)}
+          hitSlop={12}
+          style={styles.expDeleteBtn}
+          accessibilityLabel="Delete experiment"
+        >
+          <Text style={[styles.expDeleteText, { color: colors.textSubtle }]}>×</Text>
+        </Pressable>
+      </View>
+
+      <Text style={[styles.expTitle, { color: colors.text }]}>{experiment.title}</Text>
+
+      {experiment.description ? (
+        <Text style={[styles.expDesc, { color: colors.textMuted }]} numberOfLines={2}>
+          {experiment.description}
+        </Text>
+      ) : null}
+
+      {experiment.hypothesis ? (
+        <View style={[styles.hypothesisBox, { backgroundColor: colors.surfaceSoft, borderColor: colors.borderSubtle }]}>
+          <Text style={[styles.hypothesisLabel, { color: colors.textSubtle }]}>Hypothesis</Text>
+          <Text style={[styles.hypothesisText, { color: colors.textMuted }]} numberOfLines={3}>
+            {experiment.hypothesis}
+          </Text>
+        </View>
+      ) : null}
+
+      {(experiment.startDate || experiment.endDate) ? (
+        <Text style={[styles.expDates, { color: colors.textSubtle }]}>
+          {experiment.startDate || '?'} → {experiment.endDate || '?'}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+function ExperimentFormModal({
+  visible,
+  onClose,
+  onSave,
+  colors,
+}: {
+  visible: boolean;
+  onClose: () => void;
+  onSave: (exp: Omit<Experiment, 'id' | 'createdAt'>) => void;
+  colors: ThemeColors;
+}) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [category, setCategory] = useState<ExperimentCategory>('Custom');
+  const [hypothesis, setHypothesis] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  function reset() {
+    setTitle(''); setDescription(''); setCategory('Custom');
+    setHypothesis(''); setStartDate(''); setEndDate('');
+  }
+
+  function handleClose() {
+    reset();
+    Keyboard.dismiss();
+    onClose();
+  }
+
+  function handleSave() {
+    if (!title.trim()) return;
+    onSave({
+      title: title.trim(),
+      description: description.trim(),
+      category,
+      hypothesis: hypothesis.trim(),
+      startDate: startDate.trim(),
+      endDate: endDate.trim(),
+    });
+    reset();
+    Keyboard.dismiss();
+  }
+
+  const canSave = title.trim().length > 0;
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={handleClose}>
+      <TouchableWithoutFeedback onPress={handleClose}>
+        <View style={formStyles.backdrop}>
+          <TouchableWithoutFeedback onPress={() => { /* absorb */ }}>
+            <ScrollView
+              style={[formStyles.sheet, { backgroundColor: colors.surfaceElevated }]}
+              contentContainerStyle={formStyles.sheetContent}
+              keyboardShouldPersistTaps="handled"
+              showsVerticalScrollIndicator={false}
+            >
+              <View style={[formStyles.handle, { backgroundColor: colors.borderSubtle }]} />
+
+              <View style={formStyles.sheetHeader}>
+                <Text style={[formStyles.sheetTitle, { color: colors.text }]}>Plan an experiment</Text>
+                <Pressable
+                  onPress={handleClose}
+                  style={({ pressed }) => [
+                    formStyles.cancelBtn,
+                    { backgroundColor: colors.surface, borderColor: colors.borderSubtle },
+                    pressed && { opacity: 0.72 },
+                  ]}
+                >
+                  <Text style={[formStyles.cancelText, { color: colors.textMuted }]}>Cancel</Text>
+                </Pressable>
+              </View>
+
+              <FormField label="Title *" colors={colors}>
+                <TextInput
+                  value={title}
+                  onChangeText={setTitle}
+                  placeholder="e.g. 30 days meat-free"
+                  placeholderTextColor={colors.textSubtle}
+                  style={[formStyles.input, { color: colors.text, borderColor: colors.borderSubtle, backgroundColor: colors.surface }]}
+                  returnKeyType="next"
+                  autoFocus
+                />
+              </FormField>
+
+              <FormField label="Category" colors={colors}>
+                <View style={formStyles.chips}>
+                  {CATEGORIES.map((cat) => {
+                    const active = category === cat;
+                    return (
+                      <Pressable
+                        key={cat}
+                        onPress={() => setCategory(cat)}
+                        style={({ pressed }) => [
+                          formStyles.chip,
+                          active
+                            ? { backgroundColor: colors.brandGreenSoft, borderColor: colors.accentBorder }
+                            : { backgroundColor: colors.surface, borderColor: colors.borderSubtle },
+                          pressed && { opacity: 0.72 },
+                        ]}
+                      >
+                        <Text style={[formStyles.chipText, { color: active ? colors.brandGreenDark : colors.textSubtle }]}>
+                          {cat}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </FormField>
+
+              <FormField label="Description" colors={colors}>
+                <TextInput
+                  value={description}
+                  onChangeText={setDescription}
+                  placeholder="What are you changing and why?"
+                  placeholderTextColor={colors.textSubtle}
+                  style={[formStyles.input, formStyles.inputMulti, { color: colors.text, borderColor: colors.borderSubtle, backgroundColor: colors.surface }]}
+                  multiline
+                  textAlignVertical="top"
+                />
+              </FormField>
+
+              <View style={formStyles.fieldRow}>
+                <View style={{ flex: 1 }}>
+                  <FormField label="Start date" colors={colors}>
+                    <TextInput
+                      value={startDate}
+                      onChangeText={setStartDate}
+                      placeholder="YYYY-MM-DD"
+                      placeholderTextColor={colors.textSubtle}
+                      style={[formStyles.input, { color: colors.text, borderColor: colors.borderSubtle, backgroundColor: colors.surface }]}
+                    />
+                    <View style={formStyles.quickRow}>
+                      <Pressable
+                        onPress={() => setStartDate(isoToday())}
+                        style={[formStyles.quickBtn, { backgroundColor: colors.surface, borderColor: colors.borderSubtle }]}
+                      >
+                        <Text style={[formStyles.quickText, { color: colors.textSubtle }]}>Today</Text>
+                      </Pressable>
+                    </View>
+                  </FormField>
+                </View>
+                <View style={{ flex: 1 }}>
+                  <FormField label="End date" colors={colors}>
+                    <TextInput
+                      value={endDate}
+                      onChangeText={setEndDate}
+                      placeholder="YYYY-MM-DD"
+                      placeholderTextColor={colors.textSubtle}
+                      style={[formStyles.input, { color: colors.text, borderColor: colors.borderSubtle, backgroundColor: colors.surface }]}
+                    />
+                    <View style={formStyles.quickRow}>
+                      {([30, 90] as const).map((d) => (
+                        <Pressable
+                          key={d}
+                          onPress={() => setEndDate(addDaysToIso(startDate, d))}
+                          style={[formStyles.quickBtn, { backgroundColor: colors.surface, borderColor: colors.borderSubtle }]}
+                        >
+                          <Text style={[formStyles.quickText, { color: colors.textSubtle }]}>+{d}d</Text>
+                        </Pressable>
+                      ))}
+                    </View>
+                  </FormField>
+                </View>
+              </View>
+
+              <FormField
+                label="Hypothesis"
+                hint="What do you expect to observe in your metrics?"
+                colors={colors}
+              >
+                <TextInput
+                  value={hypothesis}
+                  onChangeText={setHypothesis}
+                  placeholder="I expect my Recovery score to improve because..."
+                  placeholderTextColor={colors.textSubtle}
+                  style={[formStyles.input, formStyles.inputMulti, { color: colors.text, borderColor: colors.borderSubtle, backgroundColor: colors.surface }]}
+                  multiline
+                  textAlignVertical="top"
+                />
+              </FormField>
+
+              <View style={[formStyles.metricsHint, { backgroundColor: colors.surfaceSoft, borderColor: colors.borderSubtle }]}>
+                <Text style={[formStyles.metricsHintText, { color: colors.textSubtle }]}>
+                  After saving, compare your experiment timeframe with your Trends data to observe metric changes.
+                </Text>
+              </View>
+
+              <Pressable
+                onPress={handleSave}
+                disabled={!canSave}
+                style={({ pressed }) => [
+                  formStyles.saveBtn,
+                  { backgroundColor: canSave ? colors.brandGreen : colors.disabled },
+                  pressed && canSave && { opacity: 0.8 },
+                ]}
+                accessibilityLabel="Save experiment"
+              >
+                <Text style={formStyles.saveBtnText}>Save experiment</Text>
+              </Pressable>
+            </ScrollView>
+          </TouchableWithoutFeedback>
+        </View>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+}
+
+function FormField({
+  label,
+  hint,
+  colors,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  colors: ThemeColors;
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={formStyles.field}>
+      <Text style={[formStyles.fieldLabel, { color: colors.textSubtle }]}>{label}</Text>
+      {hint ? <Text style={[formStyles.fieldHint, { color: colors.disabled }]}>{hint}</Text> : null}
+      {children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    alignItems: 'center',
+    paddingTop: spacing.md,
+    paddingBottom: 108,
+  },
+  container: {
+    width: '100%',
+    maxWidth: layout.maxWidth,
+    paddingHorizontal: layout.screenPaddingH,
+    gap: spacing.xl,
+  },
+  hero: {
+    borderRadius: radius.xl,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: spacing.xl,
+    gap: spacing.sm,
+  },
+  heroEyebrow: {
+    fontSize: typography.caption,
+    lineHeight: lineHeights.caption,
+    fontWeight: '900',
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+  },
+  heroTitle: {
+    fontSize: 30,
+    lineHeight: 34,
+  },
+  heroSubtitle: {
+    fontSize: typography.bodySmall,
+    lineHeight: lineHeights.bodySmall,
+    fontWeight: '600',
+  },
+  section: {
+    gap: spacing.md,
+  },
+  sectionHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.md,
+    paddingHorizontal: spacing.xs,
+  },
+  sectionTitle: {
+    fontSize: typography.subtitle,
+    fontWeight: '800',
+  },
+  sectionSubtitle: {
+    fontSize: typography.caption,
+    lineHeight: lineHeights.caption,
+    fontWeight: '600',
+    marginTop: 2,
+  },
+  newBtn: {
+    minHeight: 34,
+    borderRadius: radius.pill,
+    borderWidth: 1,
+    paddingHorizontal: spacing.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  newBtnText: {
+    fontSize: typography.caption,
+    fontWeight: '800',
+  },
+  emptyCard: {
+    borderRadius: radius.xl,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderStyle: 'dashed',
+    padding: spacing.xl,
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  emptyTitle: {
+    fontSize: typography.subtitle,
+    fontWeight: '800',
+    textAlign: 'center',
+  },
+  emptyExample: {
+    fontSize: typography.bodySmall,
+    lineHeight: lineHeights.bodySmall,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  emptyLink: {
+    fontSize: typography.bodySmall,
+    fontWeight: '800',
+    marginTop: spacing.xs,
+  },
+  expCard: {
+    borderRadius: radius.xl,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: spacing.lg,
+    gap: spacing.sm,
+    shadowColor: '#0B1C12',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.06,
+    shadowRadius: 10,
+    elevation: 2,
+  },
+  expCardTop: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  categoryChip: {
+    borderRadius: radius.pill,
+    borderWidth: 1,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 3,
+  },
+  categoryText: {
+    fontSize: typography.micro,
+    fontWeight: '800',
+    letterSpacing: 0.2,
+  },
+  statusChip: {
+    borderRadius: radius.pill,
+    borderWidth: 1,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 3,
+  },
+  statusText: {
+    fontSize: typography.micro,
+    fontWeight: '700',
+  },
+  expDeleteBtn: {
+    marginLeft: 'auto',
+    width: 26,
+    height: 26,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  expDeleteText: {
+    fontSize: 20,
+    lineHeight: 22,
+    fontWeight: '400',
+  },
+  expTitle: {
+    fontSize: typography.subtitle,
+    fontWeight: '800',
+    letterSpacing: -0.1,
+  },
+  expDesc: {
+    fontSize: typography.bodySmall,
+    lineHeight: lineHeights.bodySmall,
+    fontWeight: '600',
+  },
+  hypothesisBox: {
+    borderRadius: radius.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: spacing.sm,
+    gap: 3,
+  },
+  hypothesisLabel: {
+    fontSize: typography.micro,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  hypothesisText: {
+    fontSize: typography.caption,
+    lineHeight: lineHeights.caption,
+    fontWeight: '600',
+  },
+  expDates: {
+    fontSize: typography.caption,
+    fontWeight: '700',
+    letterSpacing: 0.1,
+  },
+  nextRow: {
+    borderRadius: radius.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderStyle: 'dashed',
+    padding: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    opacity: 0.72,
+  },
+  nextLabel: {
+    fontSize: typography.bodySmall,
+    fontWeight: '800',
+  },
+  nextDesc: {
+    fontSize: typography.caption,
+    lineHeight: lineHeights.caption,
+    fontWeight: '500',
+    marginTop: 1,
+  },
+  comingSoonPill: {
+    borderRadius: radius.pill,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 3,
+  },
+  comingSoonText: {
+    fontSize: typography.micro,
+    fontWeight: '800',
+  },
+  disabled: {
+    opacity: 0.7,
+  },
+});
+
+const formStyles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    maxHeight: '92%',
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+  },
+  sheetContent: {
+    paddingHorizontal: spacing.xl,
+    paddingBottom: spacing.xxl,
+    gap: spacing.lg,
+  },
+  handle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    alignSelf: 'center',
+    marginTop: spacing.sm,
+    marginBottom: spacing.xs,
+  },
+  sheetHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.xs,
+  },
+  sheetTitle: {
+    fontSize: typography.subtitle,
+    fontWeight: '800',
+  },
+  cancelBtn: {
+    minHeight: 34,
+    borderRadius: radius.pill,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: spacing.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cancelText: {
+    fontSize: typography.caption,
+    fontWeight: '700',
+  },
+  field: {
+    gap: spacing.xs,
+  },
+  fieldLabel: {
+    fontSize: typography.caption,
+    fontWeight: '800',
+    letterSpacing: 0.2,
+  },
+  fieldHint: {
+    fontSize: typography.micro,
+    lineHeight: lineHeights.caption,
+    fontWeight: '500',
+    marginTop: -2,
+  },
+  fieldRow: {
+    flexDirection: 'row',
+    gap: spacing.md,
+  },
+  input: {
+    fontSize: typography.bodySmall,
+    lineHeight: lineHeights.bodySmall,
+    borderWidth: 1,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    minHeight: 44,
+  },
+  inputMulti: {
+    minHeight: 80,
+  },
+  chips: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  chip: {
+    borderRadius: radius.pill,
+    borderWidth: 1,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    minHeight: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  chipText: {
+    fontSize: typography.caption,
+    fontWeight: '700',
+  },
+  quickRow: {
+    flexDirection: 'row',
+    gap: spacing.xs,
+    marginTop: spacing.xs,
+  },
+  quickBtn: {
+    borderRadius: radius.pill,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 3,
+  },
+  quickText: {
+    fontSize: typography.micro,
+    fontWeight: '700',
+  },
+  metricsHint: {
+    borderRadius: radius.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: spacing.md,
+  },
+  metricsHintText: {
+    fontSize: typography.caption,
+    lineHeight: lineHeights.caption,
+    fontWeight: '600',
+  },
+  saveBtn: {
+    minHeight: 52,
+    borderRadius: radius.pill,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: spacing.xs,
+  },
+  saveBtnText: {
+    color: '#FFFFFF',
+    fontSize: typography.body,
+    fontWeight: '800',
+    letterSpacing: 0.1,
+  },
+});

--- a/apps/mobile/prototypes/v2/src/screens/ProfileScreenV2.tsx
+++ b/apps/mobile/prototypes/v2/src/screens/ProfileScreenV2.tsx
@@ -114,13 +114,12 @@ export function ProfileScreenV2({ onClose, onViewBlood }: ProfileScreenV2Props) 
           <Text style={[styles.sectionTitle, { color: colors.textSubtle }]}>Data</Text>
           <ProfileRow
             title="Connected sources"
-            subtitle="Health Connect is display-only in this prototype."
+            subtitle="Data sources are read-only in this version."
             icon="sources"
-            actionLabel="Manage"
           />
           <ProfileRow
             title="Test results"
-            subtitle="Review local blood panels already available to v2."
+            subtitle="Review your imported blood panels."
             icon="tests"
             actionLabel="Open"
             onPress={onViewBlood}
@@ -131,12 +130,12 @@ export function ProfileScreenV2({ onClose, onViewBlood }: ProfileScreenV2Props) 
           <Text style={[styles.sectionTitle, { color: colors.textSubtle }]}>App</Text>
           <ProfileRow
             title="Demo and user data"
-            subtitle="Demo screens stay labelled; empty user states stay honest."
+            subtitle="Demo mode stays clearly labelled; your data is always separate."
             icon="mode"
           />
           <ProfileRow
             title="Privacy posture"
-            subtitle="No Supabase write, diagnosis, treatment, or clinical-risk-score claim in v2 UI."
+            subtitle="Your data stays on this device. No clinical assessments are made."
             icon="privacy"
           />
         </View>

--- a/apps/mobile/prototypes/v2/src/screens/TrendsScreen.tsx
+++ b/apps/mobile/prototypes/v2/src/screens/TrendsScreen.tsx
@@ -5,6 +5,39 @@ import type { HomeDisplayData, HomeTrendMetric } from '../data/homeTypes';
 import { useTheme } from '../theme/ThemeContext';
 import { layout, lineHeights, radius, spacing, typography } from '../theme/marathonTheme';
 
+function DeltaBadge({ delta, colors }: { delta: number | null; colors: import('../theme/marathonTheme').ThemeColors }) {
+  if (delta === null) return <Text style={[styles.compDeltaText, { color: colors.textSubtle }]}>No prior data</Text>;
+  const sign = delta > 0 ? '+' : '';
+  const color = delta > 0 ? colors.brandGreen : delta < 0 ? colors.scoreLow : colors.textSubtle;
+  return <Text style={[styles.compDeltaText, { color }]}>{sign}{delta} pts</Text>;
+}
+
+function PeriodComparisonCard({ data }: { data: HomeDisplayData }) {
+  const { colors } = useTheme();
+  const items = [
+    { label: 'Score', delta: data.score.delta, color: colors.brandGreen },
+    { label: 'Recovery', delta: data.contributors.recovery.delta, color: colors.recovery },
+    { label: 'Activity', delta: data.contributors.activity.delta, color: colors.activity },
+  ];
+  return (
+    <View style={[styles.compCard, { backgroundColor: colors.surfaceElevated, borderColor: colors.border }]}>
+      <View style={styles.compHeader}>
+        <Text style={[styles.compTitle, { color: colors.text }]}>Period comparison</Text>
+        <Text style={[styles.compCaption, { color: colors.textSubtle }]}>vs previous period</Text>
+      </View>
+      <View style={styles.compRow}>
+        {items.map((item) => (
+          <View key={item.label} style={[styles.compItem, { borderColor: colors.borderSubtle }]}>
+            <View style={[styles.compDot, { backgroundColor: item.color }]} />
+            <Text style={[styles.compLabel, { color: colors.textMuted }]}>{item.label}</Text>
+            <DeltaBadge delta={item.delta} colors={colors} />
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
 function MetricSurface({
   metric,
   color,
@@ -107,6 +140,8 @@ export function TrendsScreen({ data }: { data: HomeDisplayData }) {
 
         </View>
 
+        <PeriodComparisonCard data={data} />
+
         <Section title="Score" subtitle="Tap anywhere in the chart to inspect that point in time.">
           <View style={[styles.scoreCard, { backgroundColor: colors.surface, borderColor: colors.borderSubtle }]}>
             <InteractiveTrendChartV2
@@ -149,14 +184,6 @@ export function TrendsScreen({ data }: { data: HomeDisplayData }) {
                   </Pressable>
                 );
               })}
-              <View style={[styles.legendPill, { backgroundColor: colors.surfaceSoft, borderColor: colors.borderSubtle }]}>
-                <View style={[styles.legendDot, { backgroundColor: colors.testResults }]} />
-                <Text style={[styles.legendText, { color: colors.textSubtle }]}>Test Results</Text>
-              </View>
-              <View style={[styles.legendPill, { backgroundColor: colors.surfaceSoft, borderColor: colors.borderSubtle }]}>
-                <View style={[styles.legendDot, { backgroundColor: colors.disabled }]} />
-                <Text style={[styles.legendText, { color: colors.textSubtle }]}>Nutrition</Text>
-              </View>
             </View>
           </View>
         </Section>
@@ -346,5 +373,51 @@ const styles = StyleSheet.create({
     lineHeight: lineHeights.caption,
     textAlign: 'center',
     fontWeight: '600',
+  },
+  compCard: {
+    borderRadius: radius.xl,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: spacing.lg,
+    gap: spacing.md,
+  },
+  compHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  compTitle: {
+    fontSize: typography.subtitle,
+    fontWeight: '800',
+  },
+  compCaption: {
+    fontSize: typography.caption,
+    lineHeight: lineHeights.caption,
+    fontWeight: '600',
+  },
+  compRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  compItem: {
+    flex: 1,
+    borderRadius: radius.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: spacing.md,
+    gap: spacing.xs,
+    alignItems: 'flex-start',
+  },
+  compDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  compLabel: {
+    fontSize: typography.caption,
+    lineHeight: lineHeights.caption,
+    fontWeight: '700',
+  },
+  compDeltaText: {
+    fontSize: typography.bodySmall,
+    fontWeight: '800',
   },
 });


### PR DESCRIPTION
## Summary

- **InsightsScreen** (new): experiment planner with slide-up form (title, category, description, start/end dates + quick-action buttons, hypothesis), AsyncStorage persistence, status chips (planned/active/completed), plus Notes & Ideas and Next Integrations sections moved from Home
- **HomeScreen**: NextIntegrations and IdeasNotesCard removed (scroll shortened); score insight line added below ring with numeric deltas ("Recovery +3 · Activity +7 vs last period"); dead Test Results + Nutrition legend pills removed; Sources card developer copy fixed
- **TrendsScreen**: PeriodComparisonCard added between hero and Score section showing score/recovery/activity deltas vs previous period; same dead legend pills removed
- **ProfileScreenV2**: all developer-facing copy replaced with user-appropriate language ("No Supabase write…" → "Your data stays on this device…"); dead "Manage" button removed from Connected sources row
- **OneL1feV2Screen**: Insights tab now renders `InsightsScreen` instead of the placeholder

## Test plan

- [ ] `cd apps/mobile && npm run typecheck` passes (confirmed clean)
- [ ] Home scroll noticeably shorter — no Next Integrations cards, no Ideas section
- [ ] Demo mode shows insight line below ring: "Recovery +3 · Activity +7 vs last period"
- [ ] Score trend chart shows only 3 legend pills (Score / Recovery / Activity), all interactive
- [ ] Trends: Period Comparison card visible above Score section with 3 delta values
- [ ] Insights tab: experiment form modal opens, saves, lists with status chips; Notes & Ideas functional; Next Integrations visible at bottom
- [ ] Profile: no developer language anywhere; Connected sources row has no Manage button
- [ ] Android Pixel_9_Pro emulator QA: Home, Trends, Insights, Profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)